### PR TITLE
feat: simplificar creacion de solicitud al flujo del comercial

### DIFF
--- a/src/app/dashboard/solicitudes/[id]/page.tsx
+++ b/src/app/dashboard/solicitudes/[id]/page.tsx
@@ -7,9 +7,18 @@ import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { pushSingle } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
-  Building2,
   MapPin,
   User,
   Calendar,
@@ -65,6 +74,8 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
   const { isAdmin } = useRole();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [creatingVisita, setCreatingVisita] = useState(false);
+  const [tecnicoSel, setTecnicoSel] = useState("");
+  const [fechaVisitaSel, setFechaVisitaSel] = useState("");
   const [resultado, setResultado] = useState<{
     total: number;
     exitosas: number;
@@ -100,6 +111,12 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
     return { solicitud, cliente, ubicacion, tecnico, contacto, equipos, visitas };
   }, [isReady, solicitudId]);
 
+  const tecnicos = useLiveQuery(
+    () => (isReady ? db.usuarios.filter((t) => t.activo && t.cargo === "tecnico").toArray() : []),
+    [isReady],
+    []
+  );
+
   if (!isReady || data === undefined) {
     return (
       <div className="flex flex-col items-center justify-center py-20 gap-4">
@@ -134,11 +151,25 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
   const equiposConVisita = new Set(visitas.map((v) => v.equipo_id));
   const equiposSinVisita = equipos.filter((e) => !equiposConVisita.has(e.id!));
 
+  // Valores efectivos para programar: lo seleccionado, o lo ya guardado en la solicitud
+  const tecnicoValue =
+    tecnicoSel || (solicitud.tecnico_asignado_id ? String(solicitud.tecnico_asignado_id) : "");
+  const fechaVisitaValue = fechaVisitaSel || solicitud.fecha_estimada_visita || "";
+
   async function handleCrearVisitas() {
-    if (equiposSinVisita.length === 0) return;
+    if (equiposSinVisita.length === 0 || !tecnicoValue) return;
     setCreatingVisita(true);
     setResultado(null);
     try {
+      // Guardar técnico y fecha en la solicitud; la visita los hereda
+      const now = new Date().toISOString();
+      await db.solicitudes.update(solicitudId, {
+        tecnico_asignado_id: parseInt(tecnicoValue, 10),
+        fecha_estimada_visita: fechaVisitaValue || undefined,
+        sync_status: "pending",
+        last_modified: now,
+      });
+
       let exitosas = 0;
       let pruebasTotal = 0;
       const errores: string[] = [];
@@ -159,6 +190,8 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
         pruebasCreadas: pruebasTotal,
         errores,
       });
+
+      pushSingle("solicitudes", solicitudId);
     } catch (err) {
       console.error("[SolicitudDetail] Error:", err);
     } finally {
@@ -271,22 +304,24 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
             )}
           </div>
 
-          {/* Pago */}
-          <div className="flex items-center gap-2">
-            <DollarSign className="w-4 h-4 text-slate-400" />
-            <span className="text-sm font-medium text-slate-600">
-              {solicitud.forma_pago ?? "Sin definir"}
-            </span>
-            <span
-              className={`px-2 py-0.5 rounded-full text-[10px] font-black ${
-                solicitud.pago_recibido
-                  ? "bg-emerald-100 text-emerald-600"
-                  : "bg-red-100 text-red-500"
-              }`}
-            >
-              {solicitud.pago_recibido ? "Pagado" : "Pendiente"}
-            </span>
-          </div>
+          {/* Pago (solo para solicitudes con datos de pago registrados) */}
+          {(solicitud.forma_pago || solicitud.pago_recibido) && (
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-slate-400" />
+              <span className="text-sm font-medium text-slate-600">
+                {solicitud.forma_pago ?? "Sin definir"}
+              </span>
+              <span
+                className={`px-2 py-0.5 rounded-full text-[10px] font-black ${
+                  solicitud.pago_recibido
+                    ? "bg-emerald-100 text-emerald-600"
+                    : "bg-red-100 text-red-500"
+                }`}
+              >
+                {solicitud.pago_recibido ? "Pagado" : "Pendiente"}
+              </span>
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -333,22 +368,54 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
       {isAdmin && equiposSinVisita.length > 0 && (
         <Card className="border-2 border-dashed border-primary/30 shadow-none rounded-2xl bg-primary/5 overflow-hidden">
           <CardContent className="p-5 space-y-4">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <h3 className="text-base font-black text-slate-800 tracking-tight flex items-center gap-2">
-                  <Radio className="w-5 h-5 text-primary" />
-                  Programar Visitas
-                </h3>
-                <p className="text-sm text-slate-500 font-medium mt-1">
-                  {equiposSinVisita.length === 1
-                    ? `1 equipo pendiente: ${equiposSinVisita[0].gen_marca ?? ""} ${equiposSinVisita[0].gen_modelo ?? ""} ${equiposSinVisita[0].tipo_equipo ? `(${equiposSinVisita[0].tipo_equipo})` : ""}`.trim()
-                    : `${equiposSinVisita.length} equipos pendientes en esta ubicación.`}
-                </p>
-              </div>
+            <div>
+              <h3 className="text-base font-black text-slate-800 tracking-tight flex items-center gap-2">
+                <Radio className="w-5 h-5 text-primary" />
+                Programar Visitas
+              </h3>
+              <p className="text-sm text-slate-500 font-medium mt-1">
+                {equiposSinVisita.length === 1
+                  ? `1 equipo pendiente: ${equiposSinVisita[0].gen_marca ?? ""} ${equiposSinVisita[0].gen_modelo ?? ""} ${equiposSinVisita[0].tipo_equipo ? `(${equiposSinVisita[0].tipo_equipo})` : ""}`.trim()
+                  : `${equiposSinVisita.length} equipos pendientes en esta ubicación.`}
+              </p>
+            </div>
 
+            {/* Técnico y fecha de la visita */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                  Técnico Asignado *
+                </Label>
+                <Select value={tecnicoValue} onValueChange={(v) => setTecnicoSel(v ?? "")}>
+                  <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium bg-white">
+                    <SelectValue placeholder="Seleccionar técnico..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {tecnicos.map((t) => (
+                      <SelectItem key={t.id} value={String(t.id)}>
+                        {t.nombre}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                  Fecha de Visita
+                </Label>
+                <Input
+                  type="date"
+                  className="rounded-xl border-slate-200 focus:border-primary font-medium h-11 bg-white"
+                  value={fechaVisitaValue}
+                  onChange={(e) => setFechaVisitaSel(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end">
               <Button
                 className="rounded-xl font-black bg-primary hover:bg-primary/90 text-white h-11 px-6 flex-shrink-0"
-                disabled={creatingVisita}
+                disabled={creatingVisita || !tecnicoValue}
                 onClick={handleCrearVisitas}
               >
                 {creatingVisita ? (
@@ -359,7 +426,9 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                 ) : (
                   <>
                     <ClipboardCheck className="w-4 h-4 mr-2" />
-                    {equiposSinVisita.length === 1 ? "Crear Visita" : `Crear ${equiposSinVisita.length} Visitas`}
+                    {equiposSinVisita.length === 1
+                      ? "Crear Visita"
+                      : `Crear ${equiposSinVisita.length} Visitas`}
                   </>
                 )}
               </Button>
@@ -391,17 +460,23 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                   <div className="flex items-center gap-2">
                     <CheckCircle2 className="w-4 h-4" />
                     <span>
-                      {resultado.exitosas} {resultado.exitosas === 1 ? "visita creada" : "visitas creadas"} con {resultado.pruebasCreadas} pruebas en total.
+                      {resultado.exitosas}{" "}
+                      {resultado.exitosas === 1 ? "visita creada" : "visitas creadas"} con{" "}
+                      {resultado.pruebasCreadas} pruebas en total.
                     </span>
                   </div>
                 ) : (
                   <div className="space-y-1">
                     <div className="flex items-center gap-2">
                       <AlertCircle className="w-4 h-4" />
-                      <span>{resultado.exitosas}/{resultado.total} visitas creadas.</span>
+                      <span>
+                        {resultado.exitosas}/{resultado.total} visitas creadas.
+                      </span>
                     </div>
                     {resultado.errores.map((err, i) => (
-                      <p key={i} className="text-xs ml-6">{err}</p>
+                      <p key={i} className="text-xs ml-6">
+                        {err}
+                      </p>
                     ))}
                   </div>
                 )}

--- a/src/app/dashboard/solicitudes/page.tsx
+++ b/src/app/dashboard/solicitudes/page.tsx
@@ -72,7 +72,8 @@ const ESTADO_BADGE: Record<string, { bg: string; text: string; border: string }>
 
 export default function SolicitudesPage() {
   const { isReady } = useDb();
-  const { isAdmin } = useRole();
+  const { role, isAdmin } = useRole();
+  const canCreate = isAdmin || role?.cargo === "comercial";
   const [activeTab, setActiveTab] = useState<PipelineTab>("todas");
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -135,7 +136,7 @@ export default function SolicitudesPage() {
             Pipeline de servicios
           </p>
         </div>
-        {isAdmin && (
+        {canCreate && (
           <Button
             className="rounded-xl font-black bg-primary hover:bg-primary/90 text-white h-11 px-5"
             onClick={() => setDialogOpen(true)}

--- a/src/components/contacto-form-dialog.tsx
+++ b/src/components/contacto-form-dialog.tsx
@@ -33,7 +33,9 @@ interface ContactoFormDialogProps {
   onOpenChange: (open: boolean) => void;
   clienteId: number;
   contacto?: Contacto;
-  onSaved?: () => void;
+  onSaved?: (id: number) => void;
+  /** Valor inicial del checkbox "para programar" al crear */
+  defaultParaProgramar?: boolean;
 }
 
 const CARGO_OPTIONS = [
@@ -50,6 +52,7 @@ export function ContactoFormDialog({
   clienteId,
   contacto,
   onSaved,
+  defaultParaProgramar = false,
 }: ContactoFormDialogProps) {
   const isEdit = !!contacto;
 
@@ -58,7 +61,9 @@ export function ContactoFormDialog({
   const [cedula, setCedula] = useState(contacto?.cedula ?? "");
   const [telefono, setTelefono] = useState(contacto?.telefono ?? "");
   const [email, setEmail] = useState(contacto?.email ?? "");
-  const [paraProgramar, setParaProgramar] = useState(contacto?.para_programar ?? false);
+  const [paraProgramar, setParaProgramar] = useState(
+    contacto?.para_programar ?? defaultParaProgramar
+  );
   const [saving, setSaving] = useState(false);
 
   function resetForm() {
@@ -67,7 +72,7 @@ export function ContactoFormDialog({
     setCedula(contacto?.cedula ?? "");
     setTelefono(contacto?.telefono ?? "");
     setEmail(contacto?.email ?? "");
-    setParaProgramar(contacto?.para_programar ?? false);
+    setParaProgramar(contacto?.para_programar ?? defaultParaProgramar);
   }
 
   async function handleSave() {
@@ -98,7 +103,7 @@ export function ContactoFormDialog({
 
       resetForm();
       onOpenChange(false);
-      onSaved?.();
+      onSaved?.(savedId);
 
       pushSingle("contactos", savedId);
     } catch (err) {

--- a/src/components/sede-form-dialog.tsx
+++ b/src/components/sede-form-dialog.tsx
@@ -26,7 +26,7 @@ interface SedeFormDialogProps {
   onOpenChange: (open: boolean) => void;
   clienteId: number;
   sede?: Sede;
-  onSaved?: () => void;
+  onSaved?: (id: number) => void;
 }
 
 export function SedeFormDialog({
@@ -77,7 +77,7 @@ export function SedeFormDialog({
 
       resetForm();
       onOpenChange(false);
-      onSaved?.();
+      onSaved?.(savedId);
 
       pushSingle("sedes", savedId);
     } catch (err) {

--- a/src/components/solicitud-form-dialog.tsx
+++ b/src/components/solicitud-form-dialog.tsx
@@ -14,7 +14,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -23,15 +22,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Loader2, ChevronRight } from "lucide-react";
+import { Loader2, Plus } from "lucide-react";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { updateWithTracking } from "@/lib/workflow/change-tracker";
+import { ClienteFormDialog } from "@/components/cliente-form-dialog";
+import { SedeFormDialog } from "@/components/sede-form-dialog";
+import { UbicacionFormDialog } from "@/components/ubicacion-form-dialog";
+import { ContactoFormDialog } from "@/components/contacto-form-dialog";
 
 // ============================================================
 //  Dialog para crear una solicitud — flujo guiado paso a paso
 //  1. Cliente → 2. Sede → 3. Ubicación → 4. Contacto
-//  5. Técnico → 6. Detalles
+//  Cliente, sede, ubicación y contacto pueden crearse inline
+//  con los botones "+ Nuevo" si no existen aún.
+//  Técnico y fecha de visita se asignan al programar la visita.
 // ============================================================
 
 interface SolicitudFormDialogProps {
@@ -57,25 +62,27 @@ export function SolicitudFormDialog({
   const [sedeId, setSedeId] = useState("");
   const [ubicacionId, setUbicacionId] = useState("");
   const [contactoId, setContactoId] = useState("");
-  const [tecnicoId, setTecnicoId] = useState("");
-  const [tipoServicio, setTipoServicio] = useState("CONTROL_CALIDAD");
-  const [fechaSolicitud, setFechaSolicitud] = useState(new Date().toISOString().split("T")[0]);
-  const [fechaEstimada, setFechaEstimada] = useState("");
-  const [formaPago, setFormaPago] = useState("");
-  const [pagoRecibido, setPagoRecibido] = useState(false);
 
   const [saving, setSaving] = useState(false);
 
-  // Reset cascading selects
-  useEffect(() => {
+  // Dialogs para crear entidades auxiliares inline
+  const [clienteDialogOpen, setClienteDialogOpen] = useState(false);
+  const [sedeDialogOpen, setSedeDialogOpen] = useState(false);
+  const [ubicacionDialogOpen, setUbicacionDialogOpen] = useState(false);
+  const [contactoDialogOpen, setContactoDialogOpen] = useState(false);
+
+  // Reset cascading selects al cambiar el padre
+  function selectCliente(id: string) {
+    setClienteId(id);
     setSedeId("");
     setUbicacionId("");
     setContactoId("");
-  }, [clienteId]);
+  }
 
-  useEffect(() => {
+  function selectSede(id: string) {
+    setSedeId(id);
     setUbicacionId("");
-  }, [sedeId]);
+  }
 
   // Data queries
   const clientes = useLiveQuery(() => (isReady ? db.clientes.toArray() : []), [isReady], []);
@@ -111,38 +118,23 @@ export function SolicitudFormDialog({
     []
   );
 
-  const tecnicos = useLiveQuery(
-    () => (isReady ? db.usuarios.filter((t) => t.activo && t.cargo === "tecnico").toArray() : []),
-    [isReady],
-    []
-  );
-
   // Populate form from editSolicitud when dialog opens in edit mode
   useEffect(() => {
     if (!open || !editSolicitud) return;
-    setClienteId(editSolicitud.cliente_id ? String(editSolicitud.cliente_id) : "");
-    setContactoId(
-      editSolicitud.contacto_programar_id ? String(editSolicitud.contacto_programar_id) : ""
-    );
-    setTecnicoId(
-      editSolicitud.tecnico_asignado_id ? String(editSolicitud.tecnico_asignado_id) : ""
-    );
-    setTipoServicio(editSolicitud.tipo_servicio ?? "CONTROL_CALIDAD");
-    setFechaSolicitud(editSolicitud.fecha_solicitud ?? new Date().toISOString().split("T")[0]);
-    setFechaEstimada(editSolicitud.fecha_estimada_visita ?? "");
-    setFormaPago(editSolicitud.forma_pago ?? "");
-    setPagoRecibido(editSolicitud.pago_recibido ?? false);
+    void (async () => {
+      const ubicacion = editSolicitud.ubicacion_id
+        ? await db.ubicaciones_rx.get(editSolicitud.ubicacion_id)
+        : undefined;
 
-    // Load sede/ubicacion from the existing solicitud
-    if (editSolicitud.ubicacion_id) {
-      db.ubicaciones_rx.get(editSolicitud.ubicacion_id).then((ub) => {
-        if (ub?.sede_id) {
-          setSedeId(String(ub.sede_id));
-          setUbicacionId(String(editSolicitud.ubicacion_id));
-        }
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+      setClienteId(editSolicitud.cliente_id ? String(editSolicitud.cliente_id) : "");
+      setSedeId(ubicacion?.sede_id ? String(ubicacion.sede_id) : "");
+      setUbicacionId(
+        ubicacion?.sede_id && editSolicitud.ubicacion_id ? String(editSolicitud.ubicacion_id) : ""
+      );
+      setContactoId(
+        editSolicitud.contacto_programar_id ? String(editSolicitud.contacto_programar_id) : ""
+      );
+    })();
   }, [open, editSolicitud]);
 
   function resetForm() {
@@ -150,12 +142,6 @@ export function SolicitudFormDialog({
     setSedeId("");
     setUbicacionId("");
     setContactoId("");
-    setTecnicoId("");
-    setTipoServicio("CONTROL_CALIDAD");
-    setFechaSolicitud(new Date().toISOString().split("T")[0]);
-    setFechaEstimada("");
-    setFormaPago("");
-    setPagoRecibido(false);
   }
 
   async function handleSave() {
@@ -170,12 +156,6 @@ export function SolicitudFormDialog({
           cliente_id: parseInt(clienteId, 10),
           contacto_programar_id: contactoId ? parseInt(contactoId, 10) : undefined,
           ubicacion_id: ubicacionId ? parseInt(ubicacionId, 10) : undefined,
-          tecnico_asignado_id: tecnicoId ? parseInt(tecnicoId, 10) : undefined,
-          tipo_servicio: tipoServicio || undefined,
-          forma_pago: formaPago || undefined,
-          pago_recibido: pagoRecibido,
-          fecha_solicitud: fechaSolicitud || undefined,
-          fecha_estimada_visita: fechaEstimada || undefined,
           sync_status: "pending",
           last_modified: now,
         };
@@ -198,13 +178,9 @@ export function SolicitudFormDialog({
           cliente_id: parseInt(clienteId, 10),
           contacto_programar_id: contactoId ? parseInt(contactoId, 10) : undefined,
           ubicacion_id: ubicacionId ? parseInt(ubicacionId, 10) : undefined,
-          tecnico_asignado_id: tecnicoId ? parseInt(tecnicoId, 10) : undefined,
-          tipo_servicio: tipoServicio || undefined,
           pipeline_estado: "solicitudes",
-          forma_pago: formaPago || undefined,
-          pago_recibido: pagoRecibido,
-          fecha_solicitud: fechaSolicitud || undefined,
-          fecha_estimada_visita: fechaEstimada || undefined,
+          pago_recibido: false,
+          fecha_solicitud: now.split("T")[0],
           creado_en: now,
           sync_status: "pending",
           last_modified: now,
@@ -229,219 +205,205 @@ export function SolicitudFormDialog({
     onOpenChange(next);
   }
 
+  const labelClass = "text-xs font-black text-slate-600 uppercase tracking-wider";
+  const addButtonClass = "h-7 rounded-lg text-primary font-black text-xs hover:bg-primary/5";
+  const selectTriggerClass = "w-full rounded-xl border-slate-200 h-11 font-medium";
+
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="rounded-3xl border-none shadow-2xl p-0 overflow-hidden sm:max-w-lg">
-        <DialogHeader className="bg-gradient-to-br from-primary/5 to-primary/10 p-6 border-b border-primary/10">
-          <DialogTitle className="text-xl font-black text-slate-900 tracking-tight">
-            {isEditing ? "Editar Solicitud" : "Nueva Solicitud"}
-          </DialogTitle>
-          <DialogDescription className="text-slate-500 font-medium text-sm">
-            {isEditing
-              ? "Modifica los campos necesarios y guarda los cambios."
-              : "Selecciona cliente, ubicación y técnico para crear la solicitud."}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="rounded-3xl border-none shadow-2xl p-0 overflow-hidden sm:max-w-lg">
+          <DialogHeader className="bg-gradient-to-br from-primary/5 to-primary/10 p-6 border-b border-primary/10">
+            <DialogTitle className="text-xl font-black text-slate-900 tracking-tight">
+              {isEditing ? "Editar Solicitud" : "Nueva Solicitud"}
+            </DialogTitle>
+            <DialogDescription className="text-slate-500 font-medium text-sm">
+              {isEditing
+                ? "Modifica los campos necesarios y guarda los cambios."
+                : "Selecciona cliente, sede, ubicación y contacto, o créalos aquí mismo si no existen."}
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="p-6 space-y-4 max-h-[60vh] overflow-y-auto">
-          {/* 1. Cliente */}
-          <div className="space-y-2">
-            <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-              Cliente *
-            </Label>
-            <Select value={clienteId} onValueChange={(v) => setClienteId(v ?? "")}>
-              <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
-                <SelectValue placeholder="Seleccionar cliente..." />
-              </SelectTrigger>
-              <SelectContent>
-                {clientes.map((c) => (
-                  <SelectItem key={c.id} value={String(c.id)}>
-                    {c.nombre_cliente}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* 2. Sede (filtrada por cliente) */}
-          {clienteId && (
+          <div className="p-6 space-y-4 max-h-[60vh] overflow-y-auto">
+            {/* 1. Cliente */}
             <div className="space-y-2">
-              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                Sede
-              </Label>
-              <Select value={sedeId} onValueChange={(v) => setSedeId(v ?? "")}>
-                <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
-                  <SelectValue placeholder="Seleccionar sede..." />
+              <div className="flex items-center justify-between">
+                <Label className={labelClass}>Cliente *</Label>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={addButtonClass}
+                  onClick={() => setClienteDialogOpen(true)}
+                >
+                  <Plus className="w-3.5 h-3.5 mr-1" />
+                  Nuevo
+                </Button>
+              </div>
+              <Select value={clienteId} onValueChange={(v) => selectCliente(v ?? "")}>
+                <SelectTrigger className={selectTriggerClass}>
+                  <SelectValue placeholder="Seleccionar cliente..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {sedes.map((s) => (
-                    <SelectItem key={s.id} value={String(s.id)}>
-                      {s.nombre_sede}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          {/* 3. Ubicación (filtrada por sede) */}
-          {sedeId && (
-            <div className="space-y-2">
-              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                Ubicación RX
-              </Label>
-              <Select value={ubicacionId} onValueChange={(v) => setUbicacionId(v ?? "")}>
-                <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
-                  <SelectValue placeholder="Seleccionar ubicación..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {ubicaciones.map((u) => (
-                    <SelectItem key={u.id} value={String(u.id)}>
-                      {u.nombre_servicio}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          {/* 4. Contacto para programar */}
-          {clienteId && (
-            <div className="space-y-2">
-              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                Contacto para Programar
-              </Label>
-              <Select value={contactoId} onValueChange={(v) => setContactoId(v ?? "")}>
-                <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
-                  <SelectValue placeholder="Seleccionar contacto..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {contactos.map((c) => (
+                  {clientes.map((c) => (
                     <SelectItem key={c.id} value={String(c.id)}>
-                      {c.nombre}
-                      {c.telefono ? ` — ${c.telefono}` : ""}
+                      {c.nombre_cliente}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
-          )}
 
-          {/* 5. Técnico */}
-          <div className="space-y-2">
-            <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-              Técnico Asignado
-            </Label>
-            <Select value={tecnicoId} onValueChange={(v) => setTecnicoId(v ?? "")}>
-              <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
-                <SelectValue placeholder="Seleccionar técnico..." />
-              </SelectTrigger>
-              <SelectContent>
-                {tecnicos.map((t) => (
-                  <SelectItem key={t.id} value={String(t.id)}>
-                    {t.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* 6. Detalles */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-2">
-              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                Tipo de Servicio
-              </Label>
-              <Select
-                value={tipoServicio}
-                onValueChange={(v) => setTipoServicio(v ?? "CONTROL_CALIDAD")}
-              >
-                <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="CONTROL_CALIDAD">Control de Calidad</SelectItem>
-                  <SelectItem value="LEVANTAMIENTO">Levantamiento</SelectItem>
-                  <SelectItem value="ASESORIA">Asesoría</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                Forma de Pago
-              </Label>
-              <Input
-                className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
-                placeholder="Ej: Transferencia"
-                value={formaPago}
-                onChange={(e) => setFormaPago(e.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-2">
-              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                Fecha Solicitud
-              </Label>
-              <Input
-                type="date"
-                className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
-                value={fechaSolicitud}
-                onChange={(e) => setFechaSolicitud(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                Fecha Estimada Visita
-              </Label>
-              <Input
-                type="date"
-                className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
-                value={fechaEstimada}
-                onChange={(e) => setFechaEstimada(e.target.value)}
-              />
-            </div>
-          </div>
-
-          {/* Pago recibido */}
-          <label className="flex items-center gap-3 p-3 bg-slate-50 rounded-xl border border-slate-100 cursor-pointer hover:bg-slate-100 transition-colors">
-            <input
-              type="checkbox"
-              checked={pagoRecibido}
-              onChange={(e) => setPagoRecibido(e.target.checked)}
-              className="w-4 h-4 rounded border-slate-300 text-primary focus:ring-primary"
-            />
-            <span className="text-sm font-bold text-slate-700">Pago recibido</span>
-          </label>
-        </div>
-
-        <DialogFooter className="p-6 pt-0 flex justify-end gap-3 border-none bg-transparent">
-          <Button
-            variant="ghost"
-            className="rounded-xl font-black"
-            onClick={() => onOpenChange(false)}
-          >
-            Cancelar
-          </Button>
-          <Button
-            className="rounded-xl font-black bg-primary hover:bg-primary/90 text-white"
-            disabled={saving || !clienteId}
-            onClick={handleSave}
-          >
-            {saving ? (
-              <>
-                <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                Creando...
-              </>
-            ) : isEditing ? (
-              "Guardar Cambios"
-            ) : (
-              "Crear Solicitud"
+            {/* 2. Sede (filtrada por cliente) */}
+            {clienteId && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label className={labelClass}>Sede</Label>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={addButtonClass}
+                    onClick={() => setSedeDialogOpen(true)}
+                  >
+                    <Plus className="w-3.5 h-3.5 mr-1" />
+                    Nueva
+                  </Button>
+                </div>
+                <Select value={sedeId} onValueChange={(v) => selectSede(v ?? "")}>
+                  <SelectTrigger className={selectTriggerClass}>
+                    <SelectValue placeholder="Seleccionar sede..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sedes.map((s) => (
+                      <SelectItem key={s.id} value={String(s.id)}>
+                        {s.nombre_sede}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+
+            {/* 3. Ubicación (filtrada por sede) */}
+            {sedeId && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label className={labelClass}>Ubicación RX</Label>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={addButtonClass}
+                    onClick={() => setUbicacionDialogOpen(true)}
+                  >
+                    <Plus className="w-3.5 h-3.5 mr-1" />
+                    Nueva
+                  </Button>
+                </div>
+                <Select value={ubicacionId} onValueChange={(v) => setUbicacionId(v ?? "")}>
+                  <SelectTrigger className={selectTriggerClass}>
+                    <SelectValue placeholder="Seleccionar ubicación..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ubicaciones.map((u) => (
+                      <SelectItem key={u.id} value={String(u.id)}>
+                        {u.nombre_servicio}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {/* 4. Contacto para programar */}
+            {clienteId && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label className={labelClass}>Contacto para Programar</Label>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={addButtonClass}
+                    onClick={() => setContactoDialogOpen(true)}
+                  >
+                    <Plus className="w-3.5 h-3.5 mr-1" />
+                    Nuevo
+                  </Button>
+                </div>
+                <Select value={contactoId} onValueChange={(v) => setContactoId(v ?? "")}>
+                  <SelectTrigger className={selectTriggerClass}>
+                    <SelectValue placeholder="Seleccionar contacto..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {contactos.map((c) => (
+                      <SelectItem key={c.id} value={String(c.id)}>
+                        {c.nombre}
+                        {c.telefono ? ` — ${c.telefono}` : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+
+          <DialogFooter className="p-6 pt-0 flex justify-end gap-3 border-none bg-transparent">
+            <Button
+              variant="ghost"
+              className="rounded-xl font-black"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancelar
+            </Button>
+            <Button
+              className="rounded-xl font-black bg-primary hover:bg-primary/90 text-white"
+              disabled={saving || !clienteId}
+              onClick={handleSave}
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  Creando...
+                </>
+              ) : isEditing ? (
+                "Guardar Cambios"
+              ) : (
+                "Crear Solicitud"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Dialogs de creación inline (se apilan sobre el dialog principal) */}
+      <ClienteFormDialog
+        open={clienteDialogOpen}
+        onOpenChange={setClienteDialogOpen}
+        onSaved={(id) => selectCliente(String(id))}
+      />
+      {clienteId && (
+        <SedeFormDialog
+          open={sedeDialogOpen}
+          onOpenChange={setSedeDialogOpen}
+          clienteId={parseInt(clienteId, 10)}
+          onSaved={(id) => selectSede(String(id))}
+        />
+      )}
+      {sedeId && (
+        <UbicacionFormDialog
+          open={ubicacionDialogOpen}
+          onOpenChange={setUbicacionDialogOpen}
+          sedeId={parseInt(sedeId, 10)}
+          onSaved={(id) => setUbicacionId(String(id))}
+        />
+      )}
+      {clienteId && (
+        <ContactoFormDialog
+          open={contactoDialogOpen}
+          onOpenChange={setContactoDialogOpen}
+          clienteId={parseInt(clienteId, 10)}
+          defaultParaProgramar
+          onSaved={(id) => setContactoId(String(id))}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/ubicacion-form-dialog.tsx
+++ b/src/components/ubicacion-form-dialog.tsx
@@ -26,7 +26,7 @@ interface UbicacionFormDialogProps {
   onOpenChange: (open: boolean) => void;
   sedeId: number;
   ubicacion?: UbicacionRx;
-  onSaved?: () => void;
+  onSaved?: (id: number) => void;
 }
 
 export function UbicacionFormDialog({
@@ -80,7 +80,7 @@ export function UbicacionFormDialog({
 
       resetForm();
       onOpenChange(false);
-      onSaved?.();
+      onSaved?.(savedId);
 
       pushSingle("ubicaciones_rx", savedId);
     } catch (err) {


### PR DESCRIPTION
- Modal de solicitud reducido a cliente/sede/ubicacion/contacto, con botones de creacion inline para las entidades auxiliares
- Tipo de servicio, forma de pago y pago recibido eliminados del form; fecha_solicitud se asigna automaticamente al crear
- Tecnico asignado y fecha de visita se piden al programar visitas en el detalle de la solicitud (tecnico obligatorio)
- Boton de nueva solicitud habilitado para comercial ademas de coordinador
- onSaved de los dialogs de sede/ubicacion/contacto devuelve el id creado
- Fix lint: resets en cascada fuera de useEffect en solicitud-form-dialog