### PR TITLE
feat: permisos granulares, edicion inline y vistas en tabla

### DIFF
--- a/src/app/dashboard/clientes/[id]/page.tsx
+++ b/src/app/dashboard/clientes/[id]/page.tsx
@@ -10,7 +10,6 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
   ArrowLeft,
-  Building2,
   Users,
   MapPin,
   Plus,
@@ -67,7 +66,11 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
   const { id } = use(params);
   const clienteId = parseInt(id, 10);
   const { isReady } = useDb();
-  const { isAdmin } = useRole();
+  const { hasPermission } = useRole();
+  const canCreateCliente = hasPermission("clientes", "crear");
+  const canEditCliente = hasPermission("clientes", "editar");
+  const canCreateEquipo = hasPermission("equipos", "crear");
+  const canEditEquipo = hasPermission("equipos", "editar");
 
   // Dialog states
   const [editClienteOpen, setEditClienteOpen] = useState(false);
@@ -80,6 +83,7 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
   const [editUbicacion, setEditUbicacion] = useState<UbicacionRx | undefined>();
   const [equipoDialogOpen, setEquipoDialogOpen] = useState(false);
   const [equipoUbicacionId, setEquipoUbicacionId] = useState<number>(0);
+  const [editEquipo, setEditEquipo] = useState<Equipo | undefined>();
 
   // Expandable sedes
   const [expandedSedes, setExpandedSedes] = useState<Set<number>>(new Set());
@@ -185,7 +189,7 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
             {cliente.digito_verificacion ? `-${cliente.digito_verificacion}` : ""}
           </p>
         </div>
-        {isAdmin && (
+        {canEditCliente && (
           <Button
             variant="outline"
             className="rounded-xl font-black border-slate-200 hover:bg-primary/5"
@@ -277,7 +281,7 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
 
         {/* ─── Tab: Contactos ─── */}
         <TabsContent value="contactos" className="pt-4 space-y-3">
-          {isAdmin && (
+          {canCreateCliente && (
             <Button
               className="rounded-xl font-black bg-primary hover:bg-primary/90 text-white h-10"
               onClick={() => {
@@ -334,7 +338,7 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
                         )}
                       </div>
                     </div>
-                    {isAdmin && (
+                    {canEditCliente && (
                       <Button
                         variant="ghost"
                         size="sm"
@@ -356,7 +360,7 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
 
         {/* ─── Tab: Sedes ─── */}
         <TabsContent value="sedes" className="pt-4 space-y-3">
-          {isAdmin && (
+          {canCreateCliente && (
             <Button
               className="rounded-xl font-black bg-primary hover:bg-primary/90 text-white h-10"
               onClick={() => {
@@ -386,54 +390,80 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
                 >
                   <CardContent className="p-0">
                     {/* Sede header */}
-                    <button
-                      onClick={() => toggleSede(sede.id!)}
-                      className="w-full flex items-center justify-between p-4 sm:p-5 hover:bg-slate-50 transition-colors text-left"
-                    >
-                      <div className="flex items-center gap-3 min-w-0">
-                        <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
-                          <MapPin className="w-4 h-4 text-primary" />
+                    <div className="flex items-center">
+                      <button
+                        onClick={() => toggleSede(sede.id!)}
+                        className="flex-1 min-w-0 flex items-center justify-between p-4 sm:p-5 hover:bg-slate-50 transition-colors text-left"
+                      >
+                        <div className="flex items-center gap-3 min-w-0">
+                          <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
+                            <MapPin className="w-4 h-4 text-primary" />
+                          </div>
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <p className="font-black text-slate-900 text-sm truncate">
+                                {sede.nombre_sede}
+                              </p>
+                              <span className="px-1.5 py-0.5 rounded-full text-[8px] font-black uppercase tracking-widest bg-primary/10 text-primary border border-primary/20 flex-shrink-0">
+                                Sede
+                              </span>
+                            </div>
+                            <p className="text-[11px] text-slate-400 font-medium">
+                              {[sede.ciudad, sede.departamento].filter(Boolean).join(", ") ||
+                                sede.direccion_sede}
+                            </p>
+                          </div>
                         </div>
-                        <div className="min-w-0">
-                          <p className="font-black text-slate-900 text-sm truncate">
-                            {sede.nombre_sede}
-                          </p>
-                          <p className="text-[11px] text-slate-400 font-medium">
-                            {[sede.ciudad, sede.departamento].filter(Boolean).join(", ") ||
-                              sede.direccion_sede}
-                          </p>
+                        <div className="flex items-center gap-2 flex-shrink-0">
+                          <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-slate-100 text-slate-500">
+                            {ubicaciones.length} ubic.
+                          </span>
+                          {isExpanded ? (
+                            <ChevronUp className="w-4 h-4 text-slate-400" />
+                          ) : (
+                            <ChevronDown className="w-4 h-4 text-slate-400" />
+                          )}
                         </div>
-                      </div>
-                      <div className="flex items-center gap-2 flex-shrink-0">
-                        <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-slate-100 text-slate-500">
-                          {ubicaciones.length} ubic.
-                        </span>
-                        {isExpanded ? (
-                          <ChevronUp className="w-4 h-4 text-slate-400" />
-                        ) : (
-                          <ChevronDown className="w-4 h-4 text-slate-400" />
-                        )}
-                      </div>
-                    </button>
+                      </button>
+                      {canEditCliente && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="rounded-lg text-slate-400 hover:text-primary mr-3 flex-shrink-0"
+                          aria-label={`Editar sede ${sede.nombre_sede}`}
+                          onClick={() => {
+                            setEditSede(sede);
+                            setSedeDialogOpen(true);
+                          }}
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                        </Button>
+                      )}
+                    </div>
 
                     {/* Ubicaciones */}
                     {isExpanded && (
                       <div className="border-t border-slate-100 bg-slate-50/50 px-4 py-3 space-y-2">
-                        {isAdmin && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="rounded-lg font-bold border-dashed border-slate-300 text-slate-500 hover:text-primary hover:border-primary mb-2"
-                            onClick={() => {
-                              setUbicacionSedeId(sede.id!);
-                              setEditUbicacion(undefined);
-                              setUbicacionDialogOpen(true);
-                            }}
-                          >
-                            <Plus className="w-3.5 h-3.5 mr-1" />
-                            Agregar Ubicación
-                          </Button>
-                        )}
+                        <div className="flex items-center justify-between gap-2 mb-1">
+                          <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                            Ubicaciones RX ({ubicaciones.length})
+                          </p>
+                          {canCreateCliente && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="rounded-lg font-bold border-dashed border-slate-300 text-slate-500 hover:text-primary hover:border-primary"
+                              onClick={() => {
+                                setUbicacionSedeId(sede.id!);
+                                setEditUbicacion(undefined);
+                                setUbicacionDialogOpen(true);
+                              }}
+                            >
+                              <Plus className="w-3.5 h-3.5 mr-1" />
+                              Agregar Ubicación
+                            </Button>
+                          )}
+                        </div>
 
                         {ubicaciones.length === 0 ? (
                           <p className="text-xs text-slate-400 font-medium py-4 text-center">
@@ -448,47 +478,75 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
                                 className="bg-white rounded-xl border border-slate-200 overflow-hidden"
                               >
                                 {/* Ubicación header */}
-                                <button
-                                  onClick={() => toggleUbi(ubicacion.id!)}
-                                  className="w-full flex items-center justify-between p-3 hover:bg-slate-50 transition-colors text-left"
-                                >
-                                  <div className="min-w-0">
-                                    <p className="font-bold text-slate-800 text-sm truncate">
-                                      {ubicacion.nombre_servicio}
-                                    </p>
-                                    <p className="text-[10px] text-slate-400 font-medium">
-                                      {ubicacion.codigo_habilitacion ?? "Sin código"}
-                                    </p>
-                                  </div>
-                                  <div className="flex items-center gap-2 flex-shrink-0">
-                                    <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary">
-                                      {equipos.length} eq.
-                                    </span>
-                                    {ubiExpanded ? (
-                                      <ChevronUp className="w-3.5 h-3.5 text-slate-400" />
-                                    ) : (
-                                      <ChevronDown className="w-3.5 h-3.5 text-slate-400" />
-                                    )}
-                                  </div>
-                                </button>
+                                <div className="flex items-center">
+                                  <button
+                                    onClick={() => toggleUbi(ubicacion.id!)}
+                                    className="flex-1 min-w-0 flex items-center justify-between p-3 hover:bg-slate-50 transition-colors text-left"
+                                  >
+                                    <div className="min-w-0">
+                                      <div className="flex items-center gap-2 min-w-0">
+                                        <p className="font-bold text-slate-800 text-sm truncate">
+                                          {ubicacion.nombre_servicio}
+                                        </p>
+                                        <span className="px-1.5 py-0.5 rounded-full text-[8px] font-black uppercase tracking-widest bg-indigo-100 text-indigo-600 border border-indigo-200 flex-shrink-0">
+                                          Ubicación RX
+                                        </span>
+                                      </div>
+                                      <p className="text-[10px] text-slate-400 font-medium">
+                                        {ubicacion.codigo_habilitacion ?? "Sin código"}
+                                      </p>
+                                    </div>
+                                    <div className="flex items-center gap-2 flex-shrink-0">
+                                      <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary">
+                                        {equipos.length} eq.
+                                      </span>
+                                      {ubiExpanded ? (
+                                        <ChevronUp className="w-3.5 h-3.5 text-slate-400" />
+                                      ) : (
+                                        <ChevronDown className="w-3.5 h-3.5 text-slate-400" />
+                                      )}
+                                    </div>
+                                  </button>
+                                  {canEditCliente && (
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="rounded-lg text-slate-400 hover:text-primary mr-2 flex-shrink-0"
+                                      aria-label={`Editar ubicación ${ubicacion.nombre_servicio}`}
+                                      onClick={() => {
+                                        setUbicacionSedeId(sede.id!);
+                                        setEditUbicacion(ubicacion);
+                                        setUbicacionDialogOpen(true);
+                                      }}
+                                    >
+                                      <Pencil className="w-3.5 h-3.5" />
+                                    </Button>
+                                  )}
+                                </div>
 
                                 {/* Equipos */}
                                 {ubiExpanded && (
                                   <div className="border-t border-slate-100 px-3 py-2 space-y-1.5 bg-slate-50/30">
-                                    {isAdmin && (
-                                      <Button
-                                        variant="outline"
-                                        size="sm"
-                                        className="rounded-lg font-bold border-dashed border-slate-300 text-slate-500 hover:text-primary hover:border-primary text-xs"
-                                        onClick={() => {
-                                          setEquipoUbicacionId(ubicacion.id!);
-                                          setEquipoDialogOpen(true);
-                                        }}
-                                      >
-                                        <Plus className="w-3 h-3 mr-1" />
-                                        Agregar Equipo
-                                      </Button>
-                                    )}
+                                    <div className="flex items-center justify-between gap-2 mb-1">
+                                      <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                                        Equipos ({equipos.length})
+                                      </p>
+                                      {canCreateEquipo && (
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          className="rounded-lg font-bold border-dashed border-slate-300 text-slate-500 hover:text-primary hover:border-primary text-xs"
+                                          onClick={() => {
+                                            setEquipoUbicacionId(ubicacion.id!);
+                                            setEditEquipo(undefined);
+                                            setEquipoDialogOpen(true);
+                                          }}
+                                        >
+                                          <Plus className="w-3 h-3 mr-1" />
+                                          Agregar Equipo
+                                        </Button>
+                                      )}
+                                    </div>
 
                                     {equipos.length === 0 ? (
                                       <p className="text-xs text-slate-400 font-medium py-3 text-center">
@@ -501,10 +559,17 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
                                           className="flex items-center gap-3 p-2.5 bg-white rounded-lg border border-slate-100"
                                         >
                                           <Radio className="w-4 h-4 text-primary flex-shrink-0" />
-                                          <div className="min-w-0">
-                                            <p className="text-sm font-bold text-slate-800 truncate">
-                                              {equipo.gen_marca} {equipo.gen_modelo}
-                                            </p>
+                                          <div className="min-w-0 flex-1">
+                                            <div className="flex items-center gap-2 min-w-0">
+                                              <p className="text-sm font-bold text-slate-800 truncate">
+                                                {[equipo.gen_marca, equipo.gen_modelo]
+                                                  .filter(Boolean)
+                                                  .join(" ") || "Equipo sin marca"}
+                                              </p>
+                                              <span className="px-1.5 py-0.5 rounded-full text-[8px] font-black uppercase tracking-widest bg-emerald-100 text-emerald-600 border border-emerald-200 flex-shrink-0">
+                                                Equipo
+                                              </span>
+                                            </div>
                                             <p className="text-[10px] text-slate-400 font-medium">
                                               {equipo.tipo_equipo
                                                 ? (TIPO_EQUIPO_LABELS[equipo.tipo_equipo] ??
@@ -515,6 +580,21 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
                                                 : ""}
                                             </p>
                                           </div>
+                                          {canEditEquipo && (
+                                            <Button
+                                              variant="ghost"
+                                              size="sm"
+                                              className="rounded-lg text-slate-400 hover:text-primary flex-shrink-0"
+                                              aria-label={`Editar equipo ${equipo.gen_marca ?? ""} ${equipo.gen_modelo ?? ""}`}
+                                              onClick={() => {
+                                                setEquipoUbicacionId(ubicacion.id!);
+                                                setEditEquipo(equipo);
+                                                setEquipoDialogOpen(true);
+                                              }}
+                                            >
+                                              <Pencil className="w-3.5 h-3.5" />
+                                            </Button>
+                                          )}
                                         </div>
                                       ))
                                     )}
@@ -540,28 +620,35 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
         onOpenChange={setEditClienteOpen}
         cliente={cliente}
       />
+      {/* key fuerza el remount al cambiar la entidad, para que el form
+          se reinicialice con los datos correctos (crear vs editar) */}
       <ContactoFormDialog
+        key={editContacto?.id ?? "nuevo-contacto"}
         open={contactoDialogOpen}
         onOpenChange={setContactoDialogOpen}
         clienteId={clienteId}
         contacto={editContacto}
       />
       <SedeFormDialog
+        key={editSede?.id ?? "nueva-sede"}
         open={sedeDialogOpen}
         onOpenChange={setSedeDialogOpen}
         clienteId={clienteId}
         sede={editSede}
       />
       <UbicacionFormDialog
+        key={editUbicacion?.id ?? "nueva-ubicacion"}
         open={ubicacionDialogOpen}
         onOpenChange={setUbicacionDialogOpen}
         sedeId={ubicacionSedeId}
         ubicacion={editUbicacion}
       />
       <EquipoFormDialog
+        key={editEquipo?.id ?? "nuevo-equipo"}
         open={equipoDialogOpen}
         onOpenChange={setEquipoDialogOpen}
         ubicacionId={equipoUbicacionId}
+        equipo={editEquipo}
       />
     </div>
   );

--- a/src/app/dashboard/clientes/page.tsx
+++ b/src/app/dashboard/clientes/page.tsx
@@ -10,15 +10,26 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Building2, Search, Plus, MapPin, ArrowRight, Loader2, Radio } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { ClienteFormDialog } from "@/components/cliente-form-dialog";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
 
 // ============================================================
 //  Lista de clientes con búsqueda
 // ============================================================
 
 export default function ClientesPage() {
+  const router = useRouter();
   const { isReady } = useDb();
-  const { isAdmin } = useRole();
+  const { hasPermission } = useRole();
+  const canCreate = hasPermission("clientes", "crear");
   const [search, setSearch] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -82,7 +93,7 @@ export default function ClientesPage() {
             {data.length !== 1 ? "s" : ""}
           </p>
         </div>
-        {isAdmin && (
+        {canCreate && (
           <Button
             className="rounded-xl font-black bg-primary hover:bg-primary/90 text-white h-11 px-5"
             onClick={() => setDialogOpen(true)}
@@ -121,45 +132,106 @@ export default function ClientesPage() {
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
-          {filtered.map(({ cliente, sedes, equipos }) => (
-            <Link key={cliente.id} href={`/dashboard/clientes/${cliente.id}`}>
-              <Card className="border-none shadow-sm hover:shadow-lg transition-all duration-300 rounded-2xl md:rounded-3xl bg-white group cursor-pointer overflow-hidden mb-3">
-                <CardContent className="p-4 sm:p-5 md:p-6">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex items-start gap-3 min-w-0 flex-1">
-                      <div className="bg-primary/10 p-2.5 rounded-xl flex-shrink-0 mt-0.5">
-                        <Building2 className="text-primary w-5 h-5" />
-                      </div>
-                      <div className="min-w-0 space-y-1.5">
-                        <p className="font-black text-slate-900 text-sm sm:text-base truncate">
-                          {cliente.nombre_cliente}
-                        </p>
-                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] sm:text-xs text-slate-500 font-medium">
-                          <span>NIT: {cliente.nit}</span>
-                          {cliente.naturaleza && (
-                            <span className="capitalize">{cliente.naturaleza}</span>
-                          )}
+        <>
+          {/* Tabla (escritorio) */}
+          <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden hidden md:block">
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Cliente</TableHead>
+                    <TableHead>NIT</TableHead>
+                    <TableHead>Naturaleza</TableHead>
+                    <TableHead className="text-center">Sedes</TableHead>
+                    <TableHead className="text-center">Equipos</TableHead>
+                    <TableHead className="w-10" aria-label="Abrir" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map(({ cliente, sedes, equipos }) => (
+                    <TableRow
+                      key={cliente.id}
+                      className="cursor-pointer group"
+                      onClick={() => router.push(`/dashboard/clientes/${cliente.id}`)}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-3 min-w-0">
+                          <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
+                            <Building2 className="text-primary w-4 h-4" />
+                          </div>
+                          <p className="font-black text-slate-900 truncate">
+                            {cliente.nombre_cliente}
+                          </p>
                         </div>
-                        <div className="flex flex-wrap items-center gap-2 pt-0.5">
-                          <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-slate-100 text-slate-500 border border-slate-200 flex items-center gap-1">
-                            <MapPin className="w-3 h-3" />
-                            {sedes} sede{sedes !== 1 ? "s" : ""}
-                          </span>
-                          <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary border border-primary/20 flex items-center gap-1">
-                            <Radio className="w-3 h-3" />
-                            {equipos} equipo{equipos !== 1 ? "s" : ""}
-                          </span>
+                      </TableCell>
+                      <TableCell className="font-medium text-slate-600 whitespace-nowrap">
+                        {cliente.nit}
+                        {cliente.digito_verificacion ? `-${cliente.digito_verificacion}` : ""}
+                      </TableCell>
+                      <TableCell className="font-medium text-slate-600 capitalize">
+                        {cliente.naturaleza ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-slate-100 text-slate-500 border border-slate-200">
+                          {sedes}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary border border-primary/20">
+                          {equipos}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        <ArrowRight className="w-4 h-4 text-slate-300 group-hover:text-primary transition-colors" />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          {/* Tarjetas (móvil) */}
+          <div className="space-y-3 md:hidden">
+            {filtered.map(({ cliente, sedes, equipos }) => (
+              <Link key={cliente.id} href={`/dashboard/clientes/${cliente.id}`}>
+                <Card className="border-none shadow-sm hover:shadow-lg transition-all duration-300 rounded-2xl md:rounded-3xl bg-white group cursor-pointer overflow-hidden mb-3">
+                  <CardContent className="p-4 sm:p-5 md:p-6">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-start gap-3 min-w-0 flex-1">
+                        <div className="bg-primary/10 p-2.5 rounded-xl flex-shrink-0 mt-0.5">
+                          <Building2 className="text-primary w-5 h-5" />
+                        </div>
+                        <div className="min-w-0 space-y-1.5">
+                          <p className="font-black text-slate-900 text-sm sm:text-base truncate">
+                            {cliente.nombre_cliente}
+                          </p>
+                          <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] sm:text-xs text-slate-500 font-medium">
+                            <span>NIT: {cliente.nit}</span>
+                            {cliente.naturaleza && (
+                              <span className="capitalize">{cliente.naturaleza}</span>
+                            )}
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 pt-0.5">
+                            <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-slate-100 text-slate-500 border border-slate-200 flex items-center gap-1">
+                              <MapPin className="w-3 h-3" />
+                              {sedes} sede{sedes !== 1 ? "s" : ""}
+                            </span>
+                            <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary border border-primary/20 flex items-center gap-1">
+                              <Radio className="w-3 h-3" />
+                              {equipos} equipo{equipos !== 1 ? "s" : ""}
+                            </span>
+                          </div>
                         </div>
                       </div>
+                      <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-2 group-hover:text-primary transition-colors" />
                     </div>
-                    <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-2 group-hover:text-primary transition-colors" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
-        </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </>
       )}
 
       {/* Dialog crear cliente */}

--- a/src/app/dashboard/configuracion/page.tsx
+++ b/src/app/dashboard/configuracion/page.tsx
@@ -18,9 +18,19 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Settings, Users, Shield, Plus, Loader2, UserCheck, UserX, Pencil } from "lucide-react";
-import type { RolUsuario, ModuloApp } from "@/lib/db/types";
-import { ROLES_DISPONIBLES, ROL_LABELS, MODULOS_APP, MODULO_LABELS } from "@/lib/db/types";
+import { Users, Shield, Plus, Loader2, UserCheck, UserX, Pencil, Eye, Trash2 } from "lucide-react";
+import type { RolUsuario, ModuloApp, AccionPermiso, RolPermiso } from "@/lib/db/types";
+import {
+  ROLES_DISPONIBLES,
+  ROL_LABELS,
+  MODULOS_APP,
+  MODULO_LABELS,
+  ACCIONES_PERMISO,
+  ACCION_LABELS,
+  accionesEfectivas,
+} from "@/lib/db/types";
+import { createClient } from "@/lib/supabase/client";
+import { logger } from "@/lib/logger";
 
 export default function ConfiguracionPage() {
   const { isReady } = useDb();
@@ -377,47 +387,122 @@ function UsuarioFormDialog({ onClose, editId }: { onClose: () => void; editId: n
 //  Tab: Roles y Permisos
 // ============================================================
 
+const ACCION_ICONS: Record<AccionPermiso, typeof Eye> = {
+  ver: Eye,
+  crear: Plus,
+  editar: Pencil,
+  eliminar: Trash2,
+};
+
+/**
+ * Persiste el permiso en Supabase (best-effort). `rol_permisos` es una
+ * tabla master que el sync solo descarga, así que sin esto los cambios
+ * locales se revertirían en el siguiente pull.
+ */
+async function persistirPermisoRemoto(record: Omit<RolPermiso, "id">) {
+  if (typeof navigator !== "undefined" && !navigator.onLine) {
+    logger.warn("Permisos", "Sin conexión — el permiso se aplicó solo localmente", record);
+    return;
+  }
+  try {
+    // Los tipos manuales de Database no soportan la inferencia de supabase-js
+    // (mismo patrón que sync-engine.ts)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const supabase = createClient() as any;
+    const { data, error } = await supabase
+      .from("rol_permisos")
+      .select("id")
+      .eq("rol", record.rol)
+      .eq("modulo", record.modulo)
+      .maybeSingle();
+    if (error) throw error;
+
+    if (data?.id) {
+      const { error: updateError } = await supabase
+        .from("rol_permisos")
+        .update(record)
+        .eq("id", data.id);
+      if (updateError) throw updateError;
+    } else {
+      const { error: insertError } = await supabase.from("rol_permisos").insert(record);
+      if (insertError) throw insertError;
+    }
+  } catch (err) {
+    logger.warn(
+      "Permisos",
+      "No se pudo guardar el permiso en Supabase (se aplicó localmente)",
+      err
+    );
+  }
+}
+
 function RolesTab() {
   const permisos = useLiveQuery(() => db.rol_permisos.toArray());
   const [saving, setSaving] = useState<string | null>(null);
 
   if (!permisos) return null;
 
-  function isActive(rol: RolUsuario, modulo: ModuloApp): boolean {
-    return permisos?.some((p) => p.rol === rol && p.modulo === modulo && p.activo) ?? false;
+  function getPermiso(rol: RolUsuario, modulo: ModuloApp): RolPermiso | undefined {
+    return permisos?.find((p) => p.rol === rol && p.modulo === modulo);
   }
 
-  async function togglePermiso(rol: RolUsuario, modulo: ModuloApp) {
-    const key = `${rol}-${modulo}`;
+  /** Estado efectivo de las 4 acciones (registro + fallback a defaults) */
+  function acciones(rol: RolUsuario, modulo: ModuloApp) {
+    return accionesEfectivas(getPermiso(rol, modulo), rol, modulo);
+  }
+
+  async function togglePermiso(rol: RolUsuario, modulo: ModuloApp, accion: AccionPermiso) {
+    const key = `${rol}-${modulo}-${accion}`;
     setSaving(key);
     try {
-      const existing = permisos?.find((p) => p.rol === rol && p.modulo === modulo);
+      const existing = getPermiso(rol, modulo);
+      const next = acciones(rol, modulo);
+      next[accion] = !next[accion];
+
+      const record: Omit<RolPermiso, "id"> = {
+        rol,
+        modulo,
+        activo: next.ver,
+        crear: next.crear,
+        editar: next.editar,
+        eliminar: next.eliminar,
+        modificado_en: new Date().toISOString(),
+      };
+
       if (existing) {
-        await db.rol_permisos.update(existing.id!, {
-          activo: !existing.activo,
-          modificado_en: new Date().toISOString(),
-        });
+        await db.rol_permisos.update(existing.id!, record);
       } else {
-        await db.rol_permisos.add({
-          rol,
-          modulo,
-          activo: true,
-          modificado_en: new Date().toISOString(),
-        });
+        await db.rol_permisos.add(record as RolPermiso);
       }
+
+      // No bloquear la UI con la escritura remota
+      persistirPermisoRemoto(record);
     } finally {
       setSaving(null);
     }
   }
 
-  const isLocked = (rol: RolUsuario, modulo: ModuloApp) =>
-    rol === "coordinador" && modulo === "configuracion";
+  const isLocked = (rol: RolUsuario, modulo: ModuloApp, accion: AccionPermiso) =>
+    rol === "coordinador" && modulo === "configuracion" && accion === "ver";
 
   return (
     <div className="space-y-4 mt-4">
       <p className="text-sm text-slate-500 font-medium">
-        Configura qué módulos puede ver cada rol. Los cambios se aplican inmediatamente.
+        Configura qué puede hacer cada rol en cada módulo. Los cambios se aplican inmediatamente.
       </p>
+
+      {/* Leyenda */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-500 font-bold">
+        {ACCIONES_PERMISO.map((accion) => {
+          const Icon = ACCION_ICONS[accion];
+          return (
+            <span key={accion} className="flex items-center gap-1">
+              <Icon className="w-3.5 h-3.5 text-primary" />
+              {ACCION_LABELS[accion]}
+            </span>
+          );
+        })}
+      </div>
 
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-0">
@@ -446,44 +531,47 @@ function RolesTab() {
                   >
                     <td className="p-3 sm:p-4 font-bold text-slate-700">{MODULO_LABELS[modulo]}</td>
                     {ROLES_DISPONIBLES.map((rol) => {
-                      const locked = isLocked(rol, modulo);
-                      const active = locked || isActive(rol, modulo);
-                      const key = `${rol}-${modulo}`;
+                      const estado = acciones(rol, modulo);
 
                       return (
-                        <td key={rol} className="text-center p-3 sm:p-4">
-                          <button
-                            role="switch"
-                            aria-checked={active}
-                            aria-label={`${MODULO_LABELS[modulo]} para ${ROL_LABELS[rol]}`}
-                            onClick={() => !locked && togglePermiso(rol, modulo)}
-                            disabled={locked || saving === key}
-                            className={`w-7 h-7 rounded-lg transition-all ${
-                              active
-                                ? "bg-primary text-white shadow-sm"
-                                : "bg-slate-100 text-slate-300 hover:bg-slate-200"
-                            } ${
-                              locked ? "cursor-not-allowed opacity-70" : "cursor-pointer"
-                            } flex items-center justify-center mx-auto`}
-                          >
-                            {saving === key ? (
-                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                            ) : active ? (
-                              <svg
-                                className="w-3.5 h-3.5"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={3}
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M5 13l4 4L19 7"
-                                />
-                              </svg>
-                            ) : null}
-                          </button>
+                        <td key={rol} className="text-center p-2 sm:p-3">
+                          <div className="flex items-center justify-center gap-1">
+                            {ACCIONES_PERMISO.map((accion) => {
+                              const locked = isLocked(rol, modulo, accion);
+                              const active = locked || estado[accion];
+                              // Sin "ver", las demás acciones no aplican
+                              const inert = accion !== "ver" && !estado.ver;
+                              const key = `${rol}-${modulo}-${accion}`;
+                              const Icon = ACCION_ICONS[accion];
+
+                              return (
+                                <button
+                                  key={accion}
+                                  role="switch"
+                                  aria-checked={active}
+                                  title={`${ACCION_LABELS[accion]} — ${MODULO_LABELS[modulo]} (${ROL_LABELS[rol]})`}
+                                  aria-label={`${ACCION_LABELS[accion]} ${MODULO_LABELS[modulo]} para ${ROL_LABELS[rol]}`}
+                                  onClick={() =>
+                                    !locked && !inert && togglePermiso(rol, modulo, accion)
+                                  }
+                                  disabled={locked || inert || saving === key}
+                                  className={`w-6 h-6 rounded-md transition-all flex items-center justify-center ${
+                                    inert
+                                      ? "bg-slate-50 text-slate-200 cursor-not-allowed"
+                                      : active
+                                        ? "bg-primary text-white shadow-sm"
+                                        : "bg-slate-100 text-slate-300 hover:bg-slate-200"
+                                  } ${locked ? "cursor-not-allowed opacity-70" : ""}`}
+                                >
+                                  {saving === key ? (
+                                    <Loader2 className="w-3 h-3 animate-spin" />
+                                  ) : (
+                                    <Icon className="w-3 h-3" />
+                                  )}
+                                </button>
+                              );
+                            })}
+                          </div>
                         </td>
                       );
                     })}
@@ -496,7 +584,8 @@ function RolesTab() {
       </Card>
 
       <p className="text-[11px] text-slate-400 font-medium">
-        El rol Coordinador siempre tiene acceso a Configuración y no puede ser desactivado.
+        El rol Coordinador siempre puede ver Configuración. Si un rol no puede ver un módulo, las
+        demás acciones quedan deshabilitadas.
       </p>
     </div>
   );

--- a/src/app/dashboard/equipos/page.tsx
+++ b/src/app/dashboard/equipos/page.tsx
@@ -4,8 +4,10 @@ import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
+import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import {
   Radio,
   Search,
@@ -15,9 +17,12 @@ import {
   Calendar,
   ArrowRight,
   Loader2,
+  Pencil,
 } from "lucide-react";
 import Link from "next/link";
 import { TIPOS_EQUIPO } from "@/lib/db/types";
+import type { Equipo } from "@/lib/db/types";
+import { EquipoFormDialog } from "@/components/equipo-form-dialog";
 
 // ============================================================
 //  Inventario general de equipos — vista consolidada
@@ -28,8 +33,12 @@ type FilterType = "todos" | string;
 
 export default function EquiposPage() {
   const { isReady } = useDb();
+  const { hasPermission } = useRole();
+  const canEditEquipo = hasPermission("equipos", "editar");
   const [search, setSearch] = useState("");
   const [tipoFilter, setTipoFilter] = useState<FilterType>("todos");
+  const [editEquipo, setEditEquipo] = useState<Equipo | undefined>();
+  const [equipoDialogOpen, setEquipoDialogOpen] = useState(false);
 
   const data = useLiveQuery(async () => {
     if (!isReady) return undefined;
@@ -238,13 +247,42 @@ export default function EquiposPage() {
                       </div>
                     </div>
 
-                    <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-2 group-hover:text-primary transition-colors" />
+                    <div className="flex flex-col items-end gap-2 flex-shrink-0">
+                      {canEditEquipo && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="rounded-lg text-slate-400 hover:text-primary"
+                          aria-label={`Editar equipo ${equipo.gen_marca ?? ""} ${equipo.gen_modelo ?? ""}`}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setEditEquipo(equipo);
+                            setEquipoDialogOpen(true);
+                          }}
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </Button>
+                      )}
+                      <ArrowRight className="w-5 h-5 text-slate-300 group-hover:text-primary transition-colors" />
+                    </div>
                   </div>
                 </CardContent>
               </Card>
             </Link>
           ))}
         </div>
+      )}
+
+      {/* Dialog de edición — key fuerza remount para reinicializar el form */}
+      {editEquipo && (
+        <EquipoFormDialog
+          key={editEquipo.id}
+          open={equipoDialogOpen}
+          onOpenChange={setEquipoDialogOpen}
+          ubicacionId={editEquipo.ubicacion_id}
+          equipo={editEquipo}
+        />
       )}
     </div>
   );

--- a/src/app/dashboard/solicitudes/[id]/page.tsx
+++ b/src/app/dashboard/solicitudes/[id]/page.tsx
@@ -71,7 +71,9 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
   const { id } = use(params);
   const solicitudId = parseInt(id, 10);
   const { isReady } = useDb();
-  const { isAdmin } = useRole();
+  const { hasPermission } = useRole();
+  const canEditSolicitud = hasPermission("solicitudes", "editar");
+  const canCrearVisitas = hasPermission("visitas", "crear");
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [creatingVisita, setCreatingVisita] = useState(false);
   const [tecnicoSel, setTecnicoSel] = useState("");
@@ -225,7 +227,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
               >
                 {estado.replace("_", " ")}
               </span>
-              {isAdmin && (
+              {canEditSolicitud && (
                 <Button
                   variant="outline"
                   className="rounded-xl font-black border-slate-200 hover:bg-primary/5 h-9 px-3 text-xs"
@@ -365,7 +367,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
       )}
 
       {/* Crear visitas para todos los equipos pendientes */}
-      {isAdmin && equiposSinVisita.length > 0 && (
+      {canCrearVisitas && equiposSinVisita.length > 0 && (
         <Card className="border-2 border-dashed border-primary/30 shadow-none rounded-2xl bg-primary/5 overflow-hidden">
           <CardContent className="p-5 space-y-4">
             <div>

--- a/src/app/dashboard/solicitudes/page.tsx
+++ b/src/app/dashboard/solicitudes/page.tsx
@@ -19,7 +19,16 @@ import {
   DollarSign,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { SolicitudFormDialog } from "@/components/solicitud-form-dialog";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
 
 // ============================================================
 //  Pipeline de solicitudes con tabs de estado
@@ -71,9 +80,10 @@ const ESTADO_BADGE: Record<string, { bg: string; text: string; border: string }>
 };
 
 export default function SolicitudesPage() {
+  const router = useRouter();
   const { isReady } = useDb();
-  const { role, isAdmin } = useRole();
-  const canCreate = isAdmin || role?.cargo === "comercial";
+  const { hasPermission } = useRole();
+  const canCreate = hasPermission("solicitudes", "crear");
   const [activeTab, setActiveTab] = useState<PipelineTab>("todas");
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -191,76 +201,158 @@ export default function SolicitudesPage() {
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
-          {filtered.map(({ solicitud, cliente, ubicacion, tecnico }) => {
-            const estado = solicitud.pipeline_estado ?? "solicitudes";
-            const badge = ESTADO_BADGE[estado] ?? ESTADO_BADGE.solicitudes;
+        <>
+          {/* Tabla (escritorio) */}
+          <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden hidden md:block">
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Cliente</TableHead>
+                    <TableHead>Ubicación</TableHead>
+                    <TableHead>Técnico</TableHead>
+                    <TableHead>Fecha Estimada</TableHead>
+                    <TableHead>Tipo</TableHead>
+                    <TableHead>Estado</TableHead>
+                    <TableHead className="w-10" aria-label="Abrir" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map(({ solicitud, cliente, ubicacion, tecnico }) => {
+                    const estado = solicitud.pipeline_estado ?? "solicitudes";
+                    const badge = ESTADO_BADGE[estado] ?? ESTADO_BADGE.solicitudes;
 
-            return (
-              <Link key={solicitud.id} href={`/dashboard/solicitudes/${solicitud.id}`}>
-                <Card className="border-none shadow-sm hover:shadow-lg transition-all duration-300 rounded-2xl md:rounded-3xl bg-white group cursor-pointer overflow-hidden mb-3">
-                  <CardContent className="p-4 sm:p-5 md:p-6">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="flex-1 min-w-0 space-y-2">
-                        {/* Cliente */}
-                        <div className="flex items-center gap-2">
-                          <Building2 className="w-4 h-4 text-primary flex-shrink-0" />
-                          <p className="font-black text-slate-900 text-sm sm:text-base truncate">
-                            {cliente?.nombre_cliente ?? "—"}
-                          </p>
-                        </div>
-
-                        {/* Metadata */}
-                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] sm:text-xs text-slate-500 font-medium">
-                          {ubicacion && (
-                            <span className="flex items-center gap-1">
-                              <MapPin className="w-3 h-3" />
-                              {ubicacion.nombre_servicio}
-                            </span>
-                          )}
-                          {tecnico && (
-                            <span className="flex items-center gap-1">
-                              <User className="w-3 h-3" />
-                              {tecnico.nombre.split(" ").slice(0, 2).join(" ")}
-                            </span>
-                          )}
-                          {solicitud.fecha_estimada_visita && (
-                            <span className="flex items-center gap-1">
-                              <Calendar className="w-3 h-3" />
-                              {solicitud.fecha_estimada_visita}
-                            </span>
-                          )}
-                        </div>
-
-                        {/* Badges */}
-                        <div className="flex flex-wrap items-center gap-2 pt-0.5">
-                          <span
-                            className={`px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest ${badge.bg} ${badge.text} border ${badge.border}`}
-                          >
-                            {estado.replace("_", " ")}
-                          </span>
-                          {solicitud.tipo_servicio && (
-                            <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-slate-100 text-slate-500 border border-slate-200">
+                    return (
+                      <TableRow
+                        key={solicitud.id}
+                        className="cursor-pointer group"
+                        onClick={() => router.push(`/dashboard/solicitudes/${solicitud.id}`)}
+                      >
+                        <TableCell>
+                          <div className="flex items-center gap-3 min-w-0">
+                            <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
+                              <Building2 className="text-primary w-4 h-4" />
+                            </div>
+                            <p className="font-black text-slate-900 truncate">
+                              {cliente?.nombre_cliente ?? "—"}
+                            </p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="font-medium text-slate-600">
+                          {ubicacion?.nombre_servicio ?? "—"}
+                        </TableCell>
+                        <TableCell className="font-medium text-slate-600 whitespace-nowrap">
+                          {tecnico ? tecnico.nombre.split(" ").slice(0, 2).join(" ") : "—"}
+                        </TableCell>
+                        <TableCell className="font-medium text-slate-600 whitespace-nowrap">
+                          {solicitud.fecha_estimada_visita ?? "—"}
+                        </TableCell>
+                        <TableCell>
+                          {solicitud.tipo_servicio ? (
+                            <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-slate-100 text-slate-500 border border-slate-200 whitespace-nowrap">
                               {solicitud.tipo_servicio.replace("_", " ")}
                             </span>
+                          ) : (
+                            <span className="text-slate-400">—</span>
                           )}
-                          {solicitud.pago_recibido && (
-                            <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-emerald-100 text-emerald-600 border border-emerald-200 flex items-center gap-0.5">
-                              <DollarSign className="w-3 h-3" />
-                              Pagado
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1.5">
+                            <span
+                              className={`px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest whitespace-nowrap ${badge.bg} ${badge.text} border ${badge.border}`}
+                            >
+                              {estado.replace("_", " ")}
                             </span>
-                          )}
-                        </div>
-                      </div>
+                            {solicitud.pago_recibido && (
+                              <span className="px-1.5 py-1 rounded-full text-[10px] font-black bg-emerald-100 text-emerald-600 border border-emerald-200">
+                                <DollarSign className="w-3 h-3" />
+                              </span>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <ArrowRight className="w-4 h-4 text-slate-300 group-hover:text-primary transition-colors" />
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
 
-                      <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-2 group-hover:text-primary transition-colors" />
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-            );
-          })}
-        </div>
+          {/* Tarjetas (móvil) */}
+          <div className="space-y-3 md:hidden">
+            {filtered.map(({ solicitud, cliente, ubicacion, tecnico }) => {
+              const estado = solicitud.pipeline_estado ?? "solicitudes";
+              const badge = ESTADO_BADGE[estado] ?? ESTADO_BADGE.solicitudes;
+
+              return (
+                <Link key={solicitud.id} href={`/dashboard/solicitudes/${solicitud.id}`}>
+                  <Card className="border-none shadow-sm hover:shadow-lg transition-all duration-300 rounded-2xl md:rounded-3xl bg-white group cursor-pointer overflow-hidden mb-3">
+                    <CardContent className="p-4 sm:p-5 md:p-6">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex-1 min-w-0 space-y-2">
+                          {/* Cliente */}
+                          <div className="flex items-center gap-2">
+                            <Building2 className="w-4 h-4 text-primary flex-shrink-0" />
+                            <p className="font-black text-slate-900 text-sm sm:text-base truncate">
+                              {cliente?.nombre_cliente ?? "—"}
+                            </p>
+                          </div>
+
+                          {/* Metadata */}
+                          <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] sm:text-xs text-slate-500 font-medium">
+                            {ubicacion && (
+                              <span className="flex items-center gap-1">
+                                <MapPin className="w-3 h-3" />
+                                {ubicacion.nombre_servicio}
+                              </span>
+                            )}
+                            {tecnico && (
+                              <span className="flex items-center gap-1">
+                                <User className="w-3 h-3" />
+                                {tecnico.nombre.split(" ").slice(0, 2).join(" ")}
+                              </span>
+                            )}
+                            {solicitud.fecha_estimada_visita && (
+                              <span className="flex items-center gap-1">
+                                <Calendar className="w-3 h-3" />
+                                {solicitud.fecha_estimada_visita}
+                              </span>
+                            )}
+                          </div>
+
+                          {/* Badges */}
+                          <div className="flex flex-wrap items-center gap-2 pt-0.5">
+                            <span
+                              className={`px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest ${badge.bg} ${badge.text} border ${badge.border}`}
+                            >
+                              {estado.replace("_", " ")}
+                            </span>
+                            {solicitud.tipo_servicio && (
+                              <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-slate-100 text-slate-500 border border-slate-200">
+                                {solicitud.tipo_servicio.replace("_", " ")}
+                              </span>
+                            )}
+                            {solicitud.pago_recibido && (
+                              <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-emerald-100 text-emerald-600 border border-emerald-200 flex items-center gap-0.5">
+                                <DollarSign className="w-3 h-3" />
+                                Pagado
+                              </span>
+                            )}
+                          </div>
+                        </div>
+
+                        <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-2 group-hover:text-primary transition-colors" />
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              );
+            })}
+          </div>
+        </>
       )}
 
       {/* Dialog */}

--- a/src/app/dashboard/visitas/page.tsx
+++ b/src/app/dashboard/visitas/page.tsx
@@ -6,8 +6,7 @@ import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { ESTADO_CONFIG, ESTADO_ORDER } from "@/lib/workflow/visit-state-machine";
+import { ESTADO_CONFIG } from "@/lib/workflow/visit-state-machine";
 import { getVisitCompletenessBulk } from "@/lib/workflow/module-completeness";
 import {
   ClipboardCheck,
@@ -19,7 +18,16 @@ import {
   Loader2,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import type { EstadoVisita } from "@/lib/db/types";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
 
 type FilterTab = "todas" | "pendientes" | "en_progreso" | "completadas";
 
@@ -35,6 +43,7 @@ const FILTER_TABS: { id: FilterTab; label: string; states: EstadoVisita[] }[] = 
 ];
 
 export default function VisitasPage() {
+  const router = useRouter();
   const { isReady } = useDb();
   const { role } = useRole();
   const [activeFilter, setActiveFilter] = useState<FilterTab>("todas");
@@ -205,71 +214,157 @@ export default function VisitasPage() {
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
-          {filteredVisitas.map(({ visita, equipo, ubicacion, sede, cliente, completeness }) => {
-            const estado = ESTADO_CONFIG[visita.estado_visita];
-            return (
-              <Link key={visita.id} href={`/dashboard/visitas/${visita.id}`}>
-                <Card className="border-none shadow-sm hover:shadow-lg transition-all duration-300 rounded-2xl md:rounded-3xl bg-white group cursor-pointer overflow-hidden mb-3">
-                  <CardContent className="p-4 sm:p-5 md:p-6">
-                    <div className="flex items-start justify-between gap-3">
-                      {/* Info principal */}
-                      <div className="flex-1 min-w-0 space-y-2">
-                        {/* Cliente */}
-                        <div className="flex items-start gap-2">
-                          <Building2 className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
-                          <p className="font-black text-slate-900 text-sm sm:text-base leading-tight">
-                            {cliente?.nombre_cliente ?? "Sin cliente"}
-                          </p>
-                        </div>
+        <>
+          {/* Tabla (escritorio) */}
+          <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden hidden md:block">
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Cliente</TableHead>
+                    <TableHead>Ubicación</TableHead>
+                    <TableHead>Equipo</TableHead>
+                    <TableHead>Fecha</TableHead>
+                    <TableHead className="text-center">Progreso</TableHead>
+                    <TableHead>Estado</TableHead>
+                    <TableHead className="w-10" aria-label="Abrir" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredVisitas.map(
+                    ({ visita, equipo, ubicacion, sede, cliente, completeness }) => {
+                      const estado = ESTADO_CONFIG[visita.estado_visita];
+                      const muestraProgreso =
+                        visita.estado_visita !== "asignada" && visita.estado_visita !== "aprobada";
 
-                        {/* Ubicación y equipo */}
-                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] sm:text-xs text-slate-500 font-medium">
-                          <span className="flex items-center gap-1">
-                            <MapPin className="w-3 h-3" />
+                      return (
+                        <TableRow
+                          key={visita.id}
+                          className="cursor-pointer group"
+                          onClick={() => router.push(`/dashboard/visitas/${visita.id}`)}
+                        >
+                          <TableCell>
+                            <div className="flex items-center gap-3 min-w-0">
+                              <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
+                                <ClipboardCheck className="text-primary w-4 h-4" />
+                              </div>
+                              <p className="font-black text-slate-900 truncate">
+                                {cliente?.nombre_cliente ?? "Sin cliente"}
+                              </p>
+                            </div>
+                          </TableCell>
+                          <TableCell className="font-medium text-slate-600">
                             {sede?.ciudad ?? "—"}, {ubicacion?.nombre_servicio ?? "—"}
-                          </span>
-                          <span className="flex items-center gap-1">
-                            <Radio className="w-3 h-3" />
-                            {equipo?.gen_marca} {equipo?.gen_modelo}
-                          </span>
-                          <span className="flex items-center gap-1">
-                            <Calendar className="w-3 h-3" />
+                          </TableCell>
+                          <TableCell>
+                            <p className="font-medium text-slate-600 whitespace-nowrap">
+                              {[equipo?.gen_marca, equipo?.gen_modelo].filter(Boolean).join(" ") ||
+                                "—"}
+                            </p>
+                            {equipo?.tipo_equipo && (
+                              <p className="text-[10px] text-slate-400 font-medium uppercase">
+                                {equipo.tipo_equipo.replace(/_/g, " ")}
+                              </p>
+                            )}
+                          </TableCell>
+                          <TableCell className="font-medium text-slate-600 whitespace-nowrap">
                             {visita.fecha_visita ?? "Sin fecha"}
-                          </span>
-                        </div>
-
-                        {/* Badges + Progress */}
-                        <div className="flex flex-wrap items-center gap-2 pt-1">
-                          <span
-                            className={`px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest ${estado.bgColor} ${estado.color} border ${estado.borderColor}`}
-                          >
-                            {estado.label}
-                          </span>
-                          {equipo?.tipo_equipo && (
-                            <span className="px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest bg-slate-100 text-slate-500 border border-slate-200">
-                              {equipo.tipo_equipo.replace(/_/g, " ")}
-                            </span>
-                          )}
-                          {/* Progress pill */}
-                          {visita.estado_visita !== "asignada" &&
-                            visita.estado_visita !== "aprobada" && (
-                              <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary border border-primary/20">
+                          </TableCell>
+                          <TableCell className="text-center">
+                            {muestraProgreso ? (
+                              <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary border border-primary/20 whitespace-nowrap">
                                 {completeness.completed}/{completeness.total}
                               </span>
+                            ) : (
+                              <span className="text-slate-400">—</span>
                             )}
-                        </div>
-                      </div>
+                          </TableCell>
+                          <TableCell>
+                            <span
+                              className={`px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest whitespace-nowrap ${estado.bgColor} ${estado.color} border ${estado.borderColor}`}
+                            >
+                              {estado.label}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <ArrowRight className="w-4 h-4 text-slate-300 group-hover:text-primary transition-colors" />
+                          </TableCell>
+                        </TableRow>
+                      );
+                    }
+                  )}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
 
-                      {/* Flecha */}
-                      <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-1 group-hover:text-primary transition-colors" />
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-            );
-          })}
-        </div>
+          {/* Tarjetas (móvil) */}
+          <div className="space-y-3 md:hidden">
+            {filteredVisitas.map(({ visita, equipo, ubicacion, sede, cliente, completeness }) => {
+              const estado = ESTADO_CONFIG[visita.estado_visita];
+              return (
+                <Link key={visita.id} href={`/dashboard/visitas/${visita.id}`}>
+                  <Card className="border-none shadow-sm hover:shadow-lg transition-all duration-300 rounded-2xl md:rounded-3xl bg-white group cursor-pointer overflow-hidden mb-3">
+                    <CardContent className="p-4 sm:p-5 md:p-6">
+                      <div className="flex items-start justify-between gap-3">
+                        {/* Info principal */}
+                        <div className="flex-1 min-w-0 space-y-2">
+                          {/* Cliente */}
+                          <div className="flex items-start gap-2">
+                            <Building2 className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
+                            <p className="font-black text-slate-900 text-sm sm:text-base leading-tight">
+                              {cliente?.nombre_cliente ?? "Sin cliente"}
+                            </p>
+                          </div>
+
+                          {/* Ubicación y equipo */}
+                          <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] sm:text-xs text-slate-500 font-medium">
+                            <span className="flex items-center gap-1">
+                              <MapPin className="w-3 h-3" />
+                              {sede?.ciudad ?? "—"}, {ubicacion?.nombre_servicio ?? "—"}
+                            </span>
+                            <span className="flex items-center gap-1">
+                              <Radio className="w-3 h-3" />
+                              {equipo?.gen_marca} {equipo?.gen_modelo}
+                            </span>
+                            <span className="flex items-center gap-1">
+                              <Calendar className="w-3 h-3" />
+                              {visita.fecha_visita ?? "Sin fecha"}
+                            </span>
+                          </div>
+
+                          {/* Badges + Progress */}
+                          <div className="flex flex-wrap items-center gap-2 pt-1">
+                            <span
+                              className={`px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest ${estado.bgColor} ${estado.color} border ${estado.borderColor}`}
+                            >
+                              {estado.label}
+                            </span>
+                            {equipo?.tipo_equipo && (
+                              <span className="px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest bg-slate-100 text-slate-500 border border-slate-200">
+                                {equipo.tipo_equipo.replace(/_/g, " ")}
+                              </span>
+                            )}
+                            {/* Progress pill */}
+                            {visita.estado_visita !== "asignada" &&
+                              visita.estado_visita !== "aprobada" && (
+                                <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary border border-primary/20">
+                                  {completeness.completed}/{completeness.total}
+                                </span>
+                              )}
+                          </div>
+                        </div>
+
+                        {/* Flecha */}
+                        <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-1 group-hover:text-primary transition-colors" />
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              );
+            })}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/components/role-provider.tsx
+++ b/src/components/role-provider.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { createClient } from "@/lib/supabase/client";
-import type { RolUsuario, RolPermiso } from "@/lib/db/types";
+import type { RolUsuario, RolPermiso, AccionPermiso, ModuloApp } from "@/lib/db/types";
+import { resolverPermiso } from "@/lib/db/types";
 
 export interface ActiveRole {
   usuarioId: number;
@@ -17,7 +26,8 @@ interface RoleContextValue {
   role: ActiveRole | null;
   isAdmin: boolean;
   isReady: boolean;
-  hasPermission: (modulo: string) => boolean;
+  /** Permiso del rol activo sobre un módulo. Sin acción = "ver". */
+  hasPermission: (modulo: string, accion?: AccionPermiso) => boolean;
 }
 
 const RoleContext = createContext<RoleContextValue>({
@@ -33,8 +43,6 @@ export function useRole() {
 
 export function RoleProvider({ children }: { children: ReactNode }) {
   const { isReady: dbReady } = useDb();
-  const [role, setRole] = useState<ActiveRole | null>(null);
-  const [providerReady, setProviderReady] = useState(false);
   const [authChecked, setAuthChecked] = useState(false);
   const [authUid, setAuthUid] = useState<string | null>(null);
   const [authEmail, setAuthEmail] = useState<string | null>(null);
@@ -82,52 +90,40 @@ export function RoleProvider({ children }: { children: ReactNode }) {
       } else if (navigator.onLine) {
         setAuthUid(null);
         setAuthEmail(null);
-        setRole(null);
       }
     });
 
     return () => subscription.unsubscribe();
   }, []);
 
-  useEffect(() => {
-    if (!dbReady || usuarios.length === 0 || !authChecked) return;
+  // El rol activo es estado derivado: usuario de Dexie que coincide
+  // con la sesión de Supabase (por auth_uid, o por email como fallback)
+  const role = useMemo<ActiveRole | null>(() => {
+    if (!authUid || usuarios.length === 0) return null;
 
-    if (authUid) {
-      const byUid = usuarios.find((u) => u.auth_uid === authUid);
-      if (byUid) {
-        setRole({
-          usuarioId: byUid.id!,
-          nombre: byUid.nombre,
-          cargo: byUid.cargo,
-        });
-        setProviderReady(true);
-        return;
-      }
-
-      if (authEmail) {
-        const byEmail = usuarios.find((u) => u.email?.toLowerCase() === authEmail.toLowerCase());
-        if (byEmail) {
-          setRole({
-            usuarioId: byEmail.id!,
-            nombre: byEmail.nombre,
-            cargo: byEmail.cargo,
-          });
-          setProviderReady(true);
-          return;
-        }
-      }
-
-      console.warn("[Role] No se encontró usuario por auth_uid ni email");
+    const byUid = usuarios.find((u) => u.auth_uid === authUid);
+    if (byUid) {
+      return { usuarioId: byUid.id!, nombre: byUid.nombre, cargo: byUid.cargo };
     }
 
-    setProviderReady(true);
-  }, [dbReady, usuarios, authUid, authEmail, authChecked]);
+    if (authEmail) {
+      const byEmail = usuarios.find((u) => u.email?.toLowerCase() === authEmail.toLowerCase());
+      if (byEmail) {
+        return { usuarioId: byEmail.id!, nombre: byEmail.nombre, cargo: byEmail.cargo };
+      }
+    }
+
+    console.warn("[Role] No se encontró usuario por auth_uid ni email");
+    return null;
+  }, [usuarios, authUid, authEmail]);
+
+  const providerReady = dbReady && authChecked && usuarios.length > 0;
 
   const hasPermission = useCallback(
-    (modulo: string): boolean => {
+    (modulo: string, accion: AccionPermiso = "ver"): boolean => {
       if (!role) return false;
       const permiso = permisos.find((p: RolPermiso) => p.rol === role.cargo && p.modulo === modulo);
-      return permiso?.activo ?? false;
+      return resolverPermiso(permiso, role.cargo, modulo as ModuloApp, accion);
     },
     [role, permisos]
   );

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// ============================================================
+//  Primitivos de tabla con el estilo Sievert
+//  (mismo look que la matriz de permisos en Configuración)
+// ============================================================
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn(
+        "[&_tr]:border-b [&_tr]:border-slate-100 [&_tr]:hover:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn("border-b border-slate-50 transition-colors hover:bg-slate-50/50", className)}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-left p-3 sm:p-4 font-black text-slate-800 text-xs uppercase tracking-wider whitespace-nowrap",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td data-slot="table-cell" className={cn("p-3 sm:p-4 align-middle", className)} {...props} />
+  );
+}
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/src/lib/db/permisos.test.ts
+++ b/src/lib/db/permisos.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import {
+  permisoDefault,
+  accionesEfectivas,
+  resolverPermiso,
+  ROLES_DISPONIBLES,
+  MODULOS_APP,
+  ACCIONES_PERMISO,
+} from "./types";
+import type { RolPermiso } from "./types";
+
+// ============================================================
+//  Permisos granulares por rol y módulo
+//  - permisoDefault: matriz de defaults por rol
+//  - accionesEfectivas: registro + fallback a defaults
+//  - resolverPermiso: regla "sin ver no hay acciones"
+// ============================================================
+
+describe("permisoDefault", () => {
+  it("coordinador tiene acceso total a todos los módulos", () => {
+    for (const modulo of MODULOS_APP) {
+      const p = permisoDefault("coordinador", modulo);
+      for (const accion of ACCIONES_PERMISO) {
+        expect(p[accion], `coordinador.${modulo}.${accion}`).toBe(true);
+      }
+    }
+  });
+
+  it("eliminar es exclusivo del coordinador por defecto", () => {
+    for (const rol of ROLES_DISPONIBLES) {
+      if (rol === "coordinador") continue;
+      for (const modulo of MODULOS_APP) {
+        expect(permisoDefault(rol, modulo).eliminar, `${rol}.${modulo}.eliminar`).toBe(false);
+      }
+    }
+  });
+
+  it("comercial gestiona clientes y solicitudes (crear y editar)", () => {
+    for (const modulo of ["clientes", "solicitudes"] as const) {
+      const p = permisoDefault("comercial", modulo);
+      expect(p.ver).toBe(true);
+      expect(p.crear).toBe(true);
+      expect(p.editar).toBe(true);
+    }
+  });
+
+  it("comercial no accede a visitas, revision, informes ni configuracion", () => {
+    for (const modulo of ["visitas", "revision", "informes", "configuracion"] as const) {
+      expect(permisoDefault("comercial", modulo).ver, `comercial.${modulo}`).toBe(false);
+    }
+  });
+
+  it("tecnico ejecuta visitas y equipos (editar sin crear)", () => {
+    for (const modulo of ["visitas", "equipos"] as const) {
+      const p = permisoDefault("tecnico", modulo);
+      expect(p.ver).toBe(true);
+      expect(p.editar).toBe(true);
+      expect(p.crear).toBe(false);
+    }
+  });
+
+  it("tecnico no accede a clientes ni solicitudes", () => {
+    expect(permisoDefault("tecnico", "clientes").ver).toBe(false);
+    expect(permisoDefault("tecnico", "solicitudes").ver).toBe(false);
+  });
+
+  it("programador gestiona solicitudes y visitas", () => {
+    for (const modulo of ["solicitudes", "visitas"] as const) {
+      const p = permisoDefault("programador", modulo);
+      expect(p.ver).toBe(true);
+      expect(p.crear).toBe(true);
+      expect(p.editar).toBe(true);
+    }
+  });
+
+  it("programador solo consulta clientes y equipos", () => {
+    for (const modulo of ["clientes", "equipos"] as const) {
+      const p = permisoDefault("programador", modulo);
+      expect(p.ver).toBe(true);
+      expect(p.crear).toBe(false);
+      expect(p.editar).toBe(false);
+    }
+  });
+
+  it("solo el coordinador ve configuracion por defecto", () => {
+    expect(permisoDefault("coordinador", "configuracion").ver).toBe(true);
+    for (const rol of ["programador", "tecnico", "comercial"] as const) {
+      expect(permisoDefault(rol, "configuracion").ver).toBe(false);
+    }
+  });
+
+  it("módulo sin acceso de ver tampoco tiene acciones (matriz consistente)", () => {
+    for (const rol of ROLES_DISPONIBLES) {
+      for (const modulo of MODULOS_APP) {
+        const p = permisoDefault(rol, modulo);
+        if (!p.ver) {
+          expect(p.crear, `${rol}.${modulo}.crear`).toBe(false);
+          expect(p.editar, `${rol}.${modulo}.editar`).toBe(false);
+          expect(p.eliminar, `${rol}.${modulo}.eliminar`).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+describe("accionesEfectivas", () => {
+  it("sin registro, ver es false (no se confía en el default para ver)", () => {
+    const e = accionesEfectivas(undefined, "comercial", "clientes");
+    expect(e.ver).toBe(false);
+  });
+
+  it("acción sin definir cae al default del rol", () => {
+    // Registro previo a permisos granulares: solo tiene activo
+    const legacy: RolPermiso = { rol: "comercial", modulo: "clientes", activo: true };
+    const e = accionesEfectivas(legacy, "comercial", "clientes");
+    expect(e.ver).toBe(true);
+    expect(e.crear).toBe(true); // default comercial.clientes
+    expect(e.editar).toBe(true);
+    expect(e.eliminar).toBe(false);
+  });
+
+  it("null se trata igual que sin definir (columnas de Supabase sin migrar)", () => {
+    const p: RolPermiso = {
+      rol: "comercial",
+      modulo: "clientes",
+      activo: true,
+      crear: null,
+      editar: null,
+      eliminar: null,
+    };
+    const e = accionesEfectivas(p, "comercial", "clientes");
+    expect(e.crear).toBe(true);
+    expect(e.editar).toBe(true);
+    expect(e.eliminar).toBe(false);
+  });
+
+  it("un override explícito false gana sobre un default true", () => {
+    const p: RolPermiso = { rol: "comercial", modulo: "clientes", activo: true, crear: false };
+    expect(accionesEfectivas(p, "comercial", "clientes").crear).toBe(false);
+  });
+
+  it("un override explícito true gana sobre un default false", () => {
+    const p: RolPermiso = { rol: "tecnico", modulo: "equipos", activo: true, crear: true };
+    expect(accionesEfectivas(p, "tecnico", "equipos").crear).toBe(true);
+  });
+
+  it("expone los valores crudos aunque ver esté apagado (para la UI de configuración)", () => {
+    // Apagar "ver" no debe borrar los overrides guardados
+    const p: RolPermiso = { rol: "comercial", modulo: "clientes", activo: false, crear: true };
+    const e = accionesEfectivas(p, "comercial", "clientes");
+    expect(e.ver).toBe(false);
+    expect(e.crear).toBe(true);
+  });
+});
+
+describe("resolverPermiso", () => {
+  it("sin registro, ninguna acción está permitida", () => {
+    for (const accion of ACCIONES_PERMISO) {
+      expect(resolverPermiso(undefined, "coordinador", "clientes", accion)).toBe(false);
+    }
+  });
+
+  it("sin ver, ninguna acción pasa aunque esté en true", () => {
+    const p: RolPermiso = {
+      rol: "comercial",
+      modulo: "clientes",
+      activo: false,
+      crear: true,
+      editar: true,
+      eliminar: true,
+    };
+    for (const accion of ACCIONES_PERMISO) {
+      expect(resolverPermiso(p, "comercial", "clientes", accion)).toBe(false);
+    }
+  });
+
+  it("la acción por defecto es ver", () => {
+    const p: RolPermiso = { rol: "tecnico", modulo: "visitas", activo: true };
+    expect(resolverPermiso(p, "tecnico", "visitas")).toBe(true);
+  });
+
+  it("con ver activo, cada acción se resuelve por su valor efectivo", () => {
+    const p: RolPermiso = {
+      rol: "tecnico",
+      modulo: "equipos",
+      activo: true,
+      crear: false,
+      editar: true,
+    };
+    expect(resolverPermiso(p, "tecnico", "equipos", "crear")).toBe(false);
+    expect(resolverPermiso(p, "tecnico", "equipos", "editar")).toBe(true);
+    expect(resolverPermiso(p, "tecnico", "equipos", "eliminar")).toBe(false); // default tecnico
+  });
+});

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -1,6 +1,6 @@
 import { db } from "./index";
-import type { PruebaDefinicion, TipoEquipo, RolUsuario, ModuloApp, RolPermiso } from "./types";
-import { ROLES_DISPONIBLES, MODULOS_APP } from "./types";
+import type { PruebaDefinicion, TipoEquipo, RolPermiso } from "./types";
+import { ROLES_DISPONIBLES, MODULOS_APP, permisoDefault } from "./types";
 import type { EquipmentPackage } from "@/lib/equipos/types";
 
 // ============================================================
@@ -253,22 +253,6 @@ const PRUEBAS_CATALOGO: Omit<PruebaDefinicion, "id" | "creado_en">[] = [
   },
 ];
 
-const PERMISOS_DEFAULT: Record<RolUsuario, ModuloApp[]> = {
-  coordinador: [...MODULOS_APP],
-  programador: [
-    "dashboard",
-    "clientes",
-    "solicitudes",
-    "visitas",
-    "revision",
-    "equipos",
-    "informes",
-    "sync",
-  ],
-  tecnico: ["dashboard", "visitas", "revision", "equipos", "informes", "sync"],
-  comercial: ["dashboard", "clientes", "solicitudes"],
-};
-
 export async function seedRolPermisos(): Promise<void> {
   const count = await db.rol_permisos.count();
   if (count > 0) return;
@@ -277,12 +261,15 @@ export async function seedRolPermisos(): Promise<void> {
   const records: Omit<RolPermiso, "id">[] = [];
 
   for (const rol of ROLES_DISPONIBLES) {
-    const modulosActivos = PERMISOS_DEFAULT[rol];
     for (const modulo of MODULOS_APP) {
+      const acciones = permisoDefault(rol, modulo);
       records.push({
         rol,
         modulo,
-        activo: modulosActivos.includes(modulo),
+        activo: acciones.ver,
+        crear: acciones.crear,
+        editar: acciones.editar,
+        eliminar: acciones.eliminar,
         modificado_en: now,
       });
     }

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -54,7 +54,13 @@ export interface Contacto extends Partial<SyncFields> {
   id?: number;
   cliente_id: number;
   nombre: string;
-  cargo?: "medico_responsable" | "tecnologo" | "opr" | "representante" | "responsable_visita" | "otro";
+  cargo?:
+    | "medico_responsable"
+    | "tecnologo"
+    | "opr"
+    | "representante"
+    | "responsable_visita"
+    | "otro";
   cedula?: string;
   telefono?: string;
   email?: string;
@@ -270,12 +276,127 @@ export interface Usuario {
   creado_en?: string;
 }
 
+// ─── Acciones de permiso por módulo ───
+
+export type AccionPermiso = "ver" | "crear" | "editar" | "eliminar";
+
+export const ACCIONES_PERMISO: AccionPermiso[] = ["ver", "crear", "editar", "eliminar"];
+
+export const ACCION_LABELS: Record<AccionPermiso, string> = {
+  ver: "Ver",
+  crear: "Crear",
+  editar: "Editar",
+  eliminar: "Eliminar",
+};
+
+export interface AccionesPermiso {
+  ver: boolean;
+  crear: boolean;
+  editar: boolean;
+  eliminar: boolean;
+}
+
 export interface RolPermiso {
   id?: number;
   rol: RolUsuario;
   modulo: ModuloApp;
+  /** Permiso de ver el módulo (nombre legacy, equivale a la acción "ver") */
   activo: boolean;
+  /** null/undefined = usar el default del rol (permisoDefault) */
+  crear?: boolean | null;
+  editar?: boolean | null;
+  eliminar?: boolean | null;
   modificado_en?: string;
+}
+
+const ACCESO_TOTAL: AccionesPermiso = { ver: true, crear: true, editar: true, eliminar: true };
+const SOLO_VER: AccionesPermiso = { ver: true, crear: false, editar: false, eliminar: false };
+const SIN_ACCESO: AccionesPermiso = { ver: false, crear: false, editar: false, eliminar: false };
+const GESTIONAR: AccionesPermiso = { ver: true, crear: true, editar: true, eliminar: false };
+const EJECUTAR: AccionesPermiso = { ver: true, crear: false, editar: true, eliminar: false };
+
+/**
+ * Matriz de permisos por defecto. Se usa para sembrar `rol_permisos`
+ * y como fallback cuando un registro no tiene definida una acción
+ * (datos anteriores a la migración de permisos granulares).
+ */
+const PERMISOS_DEFAULT_MATRIZ: Record<RolUsuario, Partial<Record<ModuloApp, AccionesPermiso>>> = {
+  coordinador: {
+    dashboard: ACCESO_TOTAL,
+    clientes: ACCESO_TOTAL,
+    solicitudes: ACCESO_TOTAL,
+    visitas: ACCESO_TOTAL,
+    revision: ACCESO_TOTAL,
+    equipos: ACCESO_TOTAL,
+    informes: ACCESO_TOTAL,
+    sync: ACCESO_TOTAL,
+    configuracion: ACCESO_TOTAL,
+  },
+  programador: {
+    dashboard: SOLO_VER,
+    clientes: SOLO_VER,
+    solicitudes: GESTIONAR,
+    visitas: GESTIONAR,
+    revision: SOLO_VER,
+    equipos: SOLO_VER,
+    informes: SOLO_VER,
+    sync: SOLO_VER,
+  },
+  tecnico: {
+    dashboard: SOLO_VER,
+    visitas: EJECUTAR,
+    revision: SOLO_VER,
+    equipos: EJECUTAR,
+    informes: SOLO_VER,
+    sync: SOLO_VER,
+  },
+  comercial: {
+    dashboard: SOLO_VER,
+    clientes: GESTIONAR,
+    solicitudes: GESTIONAR,
+  },
+};
+
+/** Permisos por defecto de un rol sobre un módulo */
+export function permisoDefault(rol: RolUsuario, modulo: ModuloApp): AccionesPermiso {
+  return PERMISOS_DEFAULT_MATRIZ[rol][modulo] ?? SIN_ACCESO;
+}
+
+/**
+ * Estado efectivo de las 4 acciones de un registro de permiso:
+ * el valor guardado, o el default del rol cuando la acción no está
+ * definida (null/undefined, datos previos a permisos granulares).
+ * Nota: no aplica la regla "sin ver no hay acciones" — eso lo hace
+ * `resolverPermiso`; aquí se exponen los valores crudos para que la
+ * UI de configuración pueda editarlos sin perder overrides.
+ */
+export function accionesEfectivas(
+  permiso: RolPermiso | undefined,
+  rol: RolUsuario,
+  modulo: ModuloApp
+): AccionesPermiso {
+  const defaults = permisoDefault(rol, modulo);
+  return {
+    ver: permiso?.activo ?? false,
+    crear: permiso?.crear ?? defaults.crear,
+    editar: permiso?.editar ?? defaults.editar,
+    eliminar: permiso?.eliminar ?? defaults.eliminar,
+  };
+}
+
+/**
+ * Resuelve si un rol puede realizar una acción sobre un módulo.
+ * Sin permiso de ver el módulo, ninguna acción está permitida.
+ */
+export function resolverPermiso(
+  permiso: RolPermiso | undefined,
+  rol: RolUsuario,
+  modulo: ModuloApp,
+  accion: AccionPermiso = "ver"
+): boolean {
+  const efectivas = accionesEfectivas(permiso, rol, modulo);
+  if (!efectivas.ver) return false;
+  return efectivas[accion];
 }
 
 // ─── Comercial ───

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -129,6 +129,9 @@ export interface Database {
           rol: "coordinador" | "programador" | "tecnico" | "comercial";
           modulo: string;
           activo: boolean;
+          crear: boolean | null;
+          editar: boolean | null;
+          eliminar: boolean | null;
           modificado_en: string;
         };
         Insert: Omit<


### PR DESCRIPTION
## Resumen

### Permisos granulares por rol y modulo
- Nuevas acciones **ver, crear, editar, eliminar** en `rol_permisos`, con matriz de defaults por rol y fallback cuando la accion no esta definida (datos legacy o Supabase sin migrar).
- `hasPermission(modulo, accion)` en el RoleProvider; sin accion equivale a "ver" (compatibilidad total con el codigo existente).
- Matriz editable en **Configuracion → Roles y Permisos** con 4 mini-toggles por celda; ahora persiste tambien en Supabase (antes los cambios solo eran locales y el sync los revertia).
- Gates `isAdmin` hardcodeados reemplazados por permisos en clientes, solicitudes, equipos y programacion de visitas.

### Edicion inline
- Botones de edicion (lapiz) para **sede, ubicacion y equipo** en la ficha del cliente — los dialogs ya soportaban edicion pero no habia forma de abrirlos.
- Lapiz de edicion en el **inventario de Equipos** (editar sin navegar al cliente).
- `key` por entidad en los dialogs para que el formulario se reinicialice correctamente entre crear y editar.

### UX
- Arbol de sedes con **chips de nivel** (Sede / Ubicacion RX / Equipo), encabezados de seccion al expandir y titulo del equipo con fallback.
- Listas de **clientes, solicitudes y visitas en formato tabla** en escritorio (nuevos primitivos `ui/table.tsx`); las tarjetas se mantienen en movil para uso en campo.

### Otros
- RoleProvider: rol derivado con `useMemo` (corrige error de lint `set-state-in-effect`).
- **20 tests nuevos** de la logica de permisos (`permisos.test.ts`): matriz de defaults, fallbacks de `null`/`undefined`, overrides explicitos y la regla "sin ver no hay acciones".

## Requiere migracion en Supabase

```sql
alter table public.rol_permisos
  add column if not exists crear boolean,
  add column if not exists editar boolean,
  add column if not exists eliminar boolean;
```

Columnas nullable a proposito: `null` = usar el default del rol. La app funciona sin la migracion (fallback), pero los cambios de permisos no persisten en el servidor hasta aplicarla.

## Verificacion

- `npm run build` OK
- `npm run test:run` 88/88
- ESLint limpio en los archivos tocados

🤖 Generated with [Claude Code](https://claude.com/claude-code)
