### PR TITLE
feat: informe convencional (2.1/2.2) + ajustes de UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,9 @@ yarn-error.log*
 
 # vercel
 .vercel
+recovery-codes-vercel.txt
 
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -107,7 +107,7 @@ export default function DashboardPage() {
         </h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-5">
           <ActionCard
-            title="Mis Visitas"
+            title="Visitas"
             description="Ver servicios asignados"
             href="/dashboard/visitas"
             icon={<ClipboardCheck className="text-primary w-4 h-4 sm:w-5 sm:h-5" />}

--- a/src/app/dashboard/solicitudes/[id]/page.tsx
+++ b/src/app/dashboard/solicitudes/[id]/page.tsx
@@ -344,6 +344,11 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
           <div className="space-y-2">
             {visitas.map((visita) => {
               const eq = equipos.find((e) => e.id === visita.equipo_id);
+              const eqNombre = eq
+                ? [eq.gen_marca, eq.gen_modelo].filter(Boolean).join(" ") ||
+                  eq.tipo_equipo ||
+                  `Equipo #${eq.id}`
+                : null;
               return (
                 <Link key={visita.id} href={`/dashboard/visitas/${visita.id}`}>
                   <Card className="border-none shadow-sm hover:shadow-lg transition-all rounded-2xl bg-white group cursor-pointer overflow-hidden mb-2">
@@ -356,7 +361,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                           <div className="min-w-0">
                             <p className="text-sm font-black text-slate-900 truncate">
                               Visita #{visita.id}
-                              {eq ? ` — ${eq.gen_marca} ${eq.gen_modelo}` : ""}
+                              {eqNombre ? ` — ${eqNombre}` : ""}
                             </p>
                             <p className="text-[11px] text-slate-400 font-medium">
                               Estado: {visita.estado_visita.replace("_", " ")}
@@ -397,7 +402,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                   Técnico Asignado *
                 </Label>
                 <Select value={tecnicoValue} onValueChange={(v) => setTecnicoSel(v ?? "")}>
-                  <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium bg-white">
+                  <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 data-[size=default]:h-11 font-medium bg-white">
                     <SelectValue placeholder="Seleccionar técnico..." />
                   </SelectTrigger>
                   <SelectContent>

--- a/src/app/dashboard/visitas/[id]/conv/grupo-a/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-a/page.tsx
@@ -391,7 +391,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
     const existing = data?.evidencias?.find(
-      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot,
+      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
       await db.conv_evidencias.update(existing.id, { blob_local: blob });
@@ -409,7 +409,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
 
   async function removeImage(pruebaCodigo: string, slot: string) {
     const existing = data?.evidencias?.find(
-      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot,
+      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) await db.conv_evidencias.delete(existing.id);
   }
@@ -435,7 +435,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
 
   const inspeccionEquipo = (data?.inspeccion ?? []).filter((i) => i.seccion === "equipo");
   const condicionesOp = (data?.inspeccion ?? []).filter(
-    (i) => i.seccion === "condiciones_operacion",
+    (i) => i.seccion === "condiciones_operacion"
   );
 
   function getEvidencia(prueba: string, slot: string) {
@@ -659,7 +659,10 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                   W estándar (mA·min/sem)
                 </label>
                 <div className="h-9 flex items-center text-sm font-bold text-slate-700 bg-slate-50 rounded-xl px-3">
-                  {W_ESTANDAR} <span className="ml-2 text-[10px] text-slate-400 font-medium">fija — TECDOC-1958</span>
+                  {W_ESTANDAR}{" "}
+                  <span className="ml-2 text-[10px] text-slate-400 font-medium">
+                    fija — TECDOC-1958
+                  </span>
                 </div>
               </div>
               <div className="space-y-1">
@@ -757,8 +760,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                           defaultValue={m.ubicacion_descripcion}
                           placeholder="Ej: Puerta principal"
                           onBlur={(e) =>
-                            m.id &&
-                            updateMedicion(m.id, { ubicacion_descripcion: e.target.value })
+                            m.id && updateMedicion(m.id, { ubicacion_descripcion: e.target.value })
                           }
                         />
                       </td>
@@ -814,8 +816,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                           className="rounded-lg border border-slate-200 h-7 text-xs font-medium px-1 bg-white w-full"
                           defaultValue={m.tipo_area ?? ""}
                           onChange={(e) =>
-                            m.id &&
-                            updateMedicion(m.id, { tipo_area: e.target.value || undefined })
+                            m.id && updateMedicion(m.id, { tipo_area: e.target.value || undefined })
                           }
                         >
                           <option value="">—</option>
@@ -1026,14 +1027,14 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                     </td>
                     <td className="py-1.5 px-1.5">
                       <select
-                        className="rounded-lg border border-slate-200 h-7 text-xs font-medium px-1 bg-white w-full"
+                        className="rounded-xl font-bold text-xs h-9 px-2 border border-slate-200 bg-white text-slate-600 min-w-[110px]"
                         defaultValue={elem.tipo_paciente ?? ""}
                         onChange={(e) =>
                           elem.id &&
                           updateElemento(elem.id, { tipo_paciente: e.target.value || undefined })
                         }
                       >
-                        <option value="">—</option>
+                        <option value="">Seleccionar</option>
                         <option value="adulto">Adulto</option>
                         <option value="pediatrico">Pediátrico</option>
                       </select>

--- a/src/app/dashboard/visitas/[id]/conv/grupo-a/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-a/page.tsx
@@ -32,27 +32,10 @@ import type { ConvInspeccionItem } from "@/lib/equipos/convencional/db/types";
 
 // ─── Constants ───
 
-const ITEMS_INSPECCION_EQUIPO = [
-  "Inspección del estado de los accesorios del equipo: mesa radiográfica, soporte del tubo de rayos X, consola del generador y cables de alimentación y control, verificando ausencia de desgaste o deterioro.",
-  "Verificación de la estabilidad del cabezal del tubo y del funcionamiento mecánico del sistema de colimación, así como de los movimientos y frenos del soporte del tubo, mesa radiográfica y Bucky vertical.",
-  "Inspección visual del cabezal del tubo para identificar posibles fugas de aceite o deterioro del encapsulado.",
-  "Verificación del funcionamiento de los indicadores del panel del generador: indicador de exposición, selección de punto focal y parámetros de irradiación (kV, mA, tiempo o mAs).",
-];
-
-const ITEMS_CONDICIONES_OPERACION = [
-  "Indicadores de parámetros técnicos visibles y con funcionamiento adecuado.",
-  "Existe señal luminosa y/o sonora en el panel durante el disparo.",
-  "Instalación eléctrica en buen estado (luces indicadoras, cables, conectores).",
-  "Existe indicación visible del tubo seleccionado.",
-  "Demarcación de áreas visible.",
-  "Señales de protección al paciente con indicaciones de radioprotección.",
-  "Disparador fuera de la sala.",
-  "Las puertas son plomadas.",
-  "Las puertas permiten cierre total.",
-  "Señales de advertencia externas durante la realización de un examen.",
-  "La información de parámetros técnicos del equipo está completa (mA, T, kV, rectificación y punto focal).",
-  "Número de equipos en funcionamiento en la sala.",
-];
+import {
+  ITEMS_INSPECCION_EQUIPO,
+  ITEMS_CONDICIONES_OPERACION,
+} from "@/lib/equipos/convencional/inspeccion-items";
 
 /** Catálogo de elementos de protección radiológica estandarizados */
 const CATALOGO_ELEMENTOS_PROTECCION = [
@@ -314,12 +297,18 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
 
   // ─── Save helpers ───
   const setupTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Acumula los campos pendientes — con un solo timer, editar varios campos
+  // seguidos descartaba todos menos el último.
+  const setupPending = useRef<Record<string, unknown>>({});
 
   function updateSetup(fields: Record<string, unknown>) {
     if (!data?.setup?.id) return;
+    Object.assign(setupPending.current, fields);
     if (setupTimer.current) clearTimeout(setupTimer.current);
     setupTimer.current = setTimeout(() => {
-      db.conv_levantamiento_setup.update(data.setup!.id!, fields);
+      const payload = setupPending.current;
+      setupPending.current = {};
+      db.conv_levantamiento_setup.update(data.setup!.id!, payload);
     }, 600);
   }
 
@@ -825,7 +814,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                         </select>
                       </td>
                       <td className="py-1.5 px-1.5 font-black text-primary font-mono">
-                        {dosis > 0 ? dosis.toFixed(4) : "—"}
+                        {dosis > 0 ? dosis.toFixed(6) : "—"}
                       </td>
                       <td className="py-1.5 px-1.5">
                         <span
@@ -896,11 +885,24 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                   <div className="flex flex-col sm:flex-row gap-2 pl-9">
                     <ConceptoSelect
                       value={item?.concepto}
-                      onChange={(v) => item?.id && updateInspeccionItem(item.id, { concepto: v })}
+                      onChange={(v) =>
+                        item?.id &&
+                        updateInspeccionItem(item.id, {
+                          concepto: v,
+                          // La observación solo aplica a no conformidades — limpiar al cambiar
+                          ...(v !== "No_conforme" ? { observacion: undefined } : {}),
+                        })
+                      }
                     />
                     <Input
-                      className="rounded-xl h-9 text-xs font-medium flex-1"
-                      placeholder="Observaciones (opcional)"
+                      key={`${item?.id}-${item?.concepto}`}
+                      className="rounded-xl h-9 text-xs font-medium flex-1 disabled:bg-slate-100 disabled:text-slate-400 disabled:cursor-not-allowed"
+                      placeholder={
+                        item?.concepto === "No_conforme"
+                          ? "Describe la no conformidad"
+                          : "Solo aplica si es no conforme"
+                      }
+                      disabled={item?.concepto !== "No_conforme"}
                       defaultValue={item?.observacion ?? ""}
                       onBlur={(e) =>
                         item?.id && updateInspeccionItem(item.id, { observacion: e.target.value })
@@ -940,11 +942,24 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                   <div className="flex flex-col sm:flex-row gap-2 pl-9">
                     <ConceptoSelect
                       value={item?.concepto}
-                      onChange={(v) => item?.id && updateInspeccionItem(item.id, { concepto: v })}
+                      onChange={(v) =>
+                        item?.id &&
+                        updateInspeccionItem(item.id, {
+                          concepto: v,
+                          // La observación solo aplica a no conformidades — limpiar al cambiar
+                          ...(v !== "No_conforme" ? { observacion: undefined } : {}),
+                        })
+                      }
                     />
                     <Input
-                      className="rounded-xl h-9 text-xs font-medium flex-1"
-                      placeholder="Observaciones (opcional)"
+                      key={`${item?.id}-${item?.concepto}`}
+                      className="rounded-xl h-9 text-xs font-medium flex-1 disabled:bg-slate-100 disabled:text-slate-400 disabled:cursor-not-allowed"
+                      placeholder={
+                        item?.concepto === "No_conforme"
+                          ? "Describe la no conformidad"
+                          : "Solo aplica si es no conforme"
+                      }
+                      disabled={item?.concepto !== "No_conforme"}
                       defaultValue={item?.observacion ?? ""}
                       onBlur={(e) =>
                         item?.id && updateInspeccionItem(item.id, { observacion: e.target.value })

--- a/src/app/dashboard/visitas/page.tsx
+++ b/src/app/dashboard/visitas/page.tsx
@@ -161,7 +161,7 @@ export default function VisitasPage() {
       {/* Header */}
       <div>
         <h2 className="text-2xl sm:text-3xl md:text-4xl font-black text-slate-900 tracking-tighter">
-          Mis Visitas
+          Visitas
         </h2>
         <p className="text-slate-500 font-medium text-sm md:text-lg mt-1">
           Servicios asignados y en progreso

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -55,7 +55,7 @@ const menuItems: MenuGroup[] = [
         icon: Briefcase,
         module: "solicitudes",
       },
-      { title: "Mis Visitas", href: "/dashboard/visitas", icon: ClipboardCheck, module: "visitas" },
+      { title: "Visitas", href: "/dashboard/visitas", icon: ClipboardCheck, module: "visitas" },
       { title: "Revisión", href: "/dashboard/revision", icon: ShieldCheck, module: "revision" },
     ],
   },

--- a/src/components/cliente-form-dialog.tsx
+++ b/src/components/cliente-form-dialog.tsx
@@ -186,7 +186,7 @@ export function ClienteFormDialog({
               value={form.naturaleza ?? ""}
               onValueChange={(val) => update("naturaleza", (val ?? "") as string)}
             >
-              <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
+              <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 data-[size=default]:h-11 font-medium">
                 <SelectValue placeholder="Seleccionar..." />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/contacto-form-dialog.tsx
+++ b/src/components/contacto-form-dialog.tsx
@@ -148,7 +148,7 @@ export function ContactoFormDialog({
               Cargo
             </Label>
             <Select value={cargo} onValueChange={(v) => setCargo(v ?? "")}>
-              <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
+              <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 data-[size=default]:h-11 font-medium">
                 <SelectValue placeholder="Seleccionar cargo..." />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/equipo-form-dialog.tsx
+++ b/src/components/equipo-form-dialog.tsx
@@ -259,7 +259,7 @@ export function EquipoFormDialog({
                 Tipo de Equipo
               </Label>
               <Select value={tipoEquipo} onValueChange={(v) => setTipoEquipo(v ?? "")}>
-                <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
+                <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 data-[size=default]:h-11 font-medium">
                   <SelectValue placeholder="Seleccionar tipo..." />
                 </SelectTrigger>
                 <SelectContent>
@@ -278,13 +278,15 @@ export function EquipoFormDialog({
                   Sistema Adquisición
                 </Label>
                 <Select value={sistemaAdq} onValueChange={(v) => setSistemaAdq(v ?? "")}>
-                  <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
+                  <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 data-[size=default]:h-11 font-medium">
                     <SelectValue placeholder="Seleccionar..." />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="Digital">Digital</SelectItem>
                     <SelectItem value="Digitalizado">Digitalizado</SelectItem>
-                    <SelectItem value="Análogo: Revelado manual">Análogo: Revelado manual</SelectItem>
+                    <SelectItem value="Análogo: Revelado manual">
+                      Análogo: Revelado manual
+                    </SelectItem>
                     <SelectItem value="Análogo: Revelado automático">
                       Análogo: Revelado automático
                     </SelectItem>
@@ -298,7 +300,7 @@ export function EquipoFormDialog({
                   Bucky
                 </Label>
                 <Select value={bucky} onValueChange={(v) => setBucky(v ?? "")}>
-                  <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
+                  <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 data-[size=default]:h-11 font-medium">
                     <SelectValue placeholder="Seleccionar..." />
                   </SelectTrigger>
                   <SelectContent>
@@ -322,7 +324,6 @@ export function EquipoFormDialog({
                 onChange={(e) => setDistanciaFoco(e.target.value)}
               />
             </div>
-
           </CollapsibleSection>
 
           {/* Generador */}
@@ -380,7 +381,7 @@ export function EquipoFormDialog({
                 Fase
               </Label>
               <Select value={genFase} onValueChange={(v) => setGenFase(v ?? "")}>
-                <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 font-medium">
+                <SelectTrigger className="w-full rounded-xl border-slate-200 h-11 data-[size=default]:h-11 font-medium">
                   <SelectValue placeholder="Seleccionar fase..." />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/components/sede-form-dialog.tsx
+++ b/src/components/sede-form-dialog.tsx
@@ -212,7 +212,7 @@ export function SedeFormDialog({
                     setMunicipioIdState("");
                   }}
                 >
-                  <SelectTrigger className={`${inputClass} w-full`}>
+                  <SelectTrigger className={`${inputClass} w-full data-[size=default]:h-11`}>
                     <SelectValue placeholder="Seleccionar..." />
                   </SelectTrigger>
                   <SelectContent>
@@ -231,7 +231,7 @@ export function SedeFormDialog({
                   onValueChange={(v) => setMunicipioIdState(v ?? "")}
                   disabled={!departamentoId}
                 >
-                  <SelectTrigger className={`${inputClass} w-full`}>
+                  <SelectTrigger className={`${inputClass} w-full data-[size=default]:h-11`}>
                     <SelectValue
                       placeholder={departamentoId ? "Seleccionar..." : "Elige departamento"}
                     />

--- a/src/components/solicitud-form-dialog.tsx
+++ b/src/components/solicitud-form-dialog.tsx
@@ -207,7 +207,8 @@ export function SolicitudFormDialog({
 
   const labelClass = "text-xs font-black text-slate-600 uppercase tracking-wider";
   const addButtonClass = "h-7 rounded-lg text-primary font-black text-xs hover:bg-primary/5";
-  const selectTriggerClass = "w-full rounded-xl border-slate-200 h-11 font-medium";
+  const selectTriggerClass =
+    "w-full rounded-xl border-slate-200 h-11 data-[size=default]:h-11 font-medium";
 
   return (
     <>

--- a/src/lib/equipos/convencional/inspeccion-items.ts
+++ b/src/lib/equipos/convencional/inspeccion-items.ts
@@ -1,0 +1,28 @@
+// ============================================================
+//  Textos del checklist de inspección visual (prueba 2.2)
+//  Compartidos entre la página del Grupo A y el pre-informe PDF.
+//  conv_inspeccion_items guarda solo item_numero — el texto sale
+//  de estos arreglos (índice = item_numero - 1).
+// ============================================================
+
+export const ITEMS_INSPECCION_EQUIPO = [
+  "Inspección del estado de los accesorios del equipo: mesa radiográfica, soporte del tubo de rayos X, consola del generador y cables de alimentación y control, verificando ausencia de desgaste o deterioro.",
+  "Verificación de la estabilidad del cabezal del tubo y del funcionamiento mecánico del sistema de colimación, así como de los movimientos y frenos del soporte del tubo, mesa radiográfica y Bucky vertical.",
+  "Inspección visual del cabezal del tubo para identificar posibles fugas de aceite o deterioro del encapsulado.",
+  "Verificación del funcionamiento de los indicadores del panel del generador: indicador de exposición, selección de punto focal y parámetros de irradiación (kV, mA, tiempo o mAs).",
+];
+
+export const ITEMS_CONDICIONES_OPERACION = [
+  "Indicadores de parámetros técnicos visibles y con funcionamiento adecuado.",
+  "Existe señal luminosa y/o sonora en el panel durante el disparo.",
+  "Instalación eléctrica en buen estado (luces indicadoras, cables, conectores).",
+  "Existe indicación visible del tubo seleccionado.",
+  "Demarcación de áreas visible.",
+  "Señales de protección al paciente con indicaciones de radioprotección.",
+  "Disparador fuera de la sala.",
+  "Las puertas son plomadas.",
+  "Las puertas permiten cierre total.",
+  "Señales de advertencia externas durante la realización de un examen.",
+  "La información de parámetros técnicos del equipo está completa (mA, T, kV, rectificación y punto focal).",
+  "Número de equipos en funcionamiento en la sala.",
+];

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -16,6 +16,15 @@ import type {
   ElementoProteccion,
   ParteEquipo,
 } from "@/lib/db/types";
+import { hasPackage } from "@/lib/equipos/registry";
+import { getCatalogoSeccion } from "@/lib/equipos/convencional/informe-secciones";
+import {
+  recopilarDatosConv,
+  renderResultadosSeccion,
+  renderDiagramaRadiometrico,
+  type InformeCtx,
+} from "./secciones-convencional";
+
 let _logoCache: string | null = null;
 
 async function getLogoBase64(): Promise<string> {
@@ -52,11 +61,11 @@ interface DatosInforme {
 
 // ─── Constantes de estilo ───
 
-const COLOR_PRIMARY: [number, number, number] = [130, 90, 242];
-const COLOR_HEADER_BG: [number, number, number] = [245, 241, 255];
+const COLOR_PRIMARY: [number, number, number] = [51, 65, 85];
+const COLOR_HEADER_BG: [number, number, number] = [241, 245, 249];
 const COLOR_GRAY: [number, number, number] = [100, 116, 139];
 const COLOR_BLACK: [number, number, number] = [30, 30, 30];
-const COLOR_ALT_ROW: [number, number, number] = [250, 248, 255];
+const COLOR_ALT_ROW: [number, number, number] = [248, 250, 252];
 const MARGIN = 20;
 const PAGE_WIDTH = 210;
 const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
@@ -252,6 +261,10 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
   const datosRaw = await recopilarDatos(visitaId);
   if (!datosRaw) return null;
   const datos: DatosInforme = datosRaw;
+
+  // Equipos con paquete dedicado (CONVENCIONAL) usan las tablas conv_*
+  const esConv = !!datos.equipo?.tipo_equipo && hasPackage(datos.equipo.tipo_equipo);
+  const conv = esConv ? await recopilarDatosConv(visitaId) : null;
 
   const doc = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
   let y = MARGIN;
@@ -646,8 +659,149 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
   y += 4;
   y = addSectionTitle(doc, "2. PRUEBAS DE CONTROL DE CALIDAD EN RADIOLOGÍA GENERAL", y);
 
-  // ─── Para cada prueba ───
-  const pruebasOrdenadas = datos.pruebas.filter((p) => p.completado);
+  // ─── Acumuladores para el resumen final (ambos flujos) ───
+  const resumenRows: [string, string][] = [];
+  const accionesPendientes: string[] = [];
+  let conceptoGeneralOk = true;
+
+  // ═══ Flujo CONVENCIONAL: secciones desde conv_informe_secciones (estructura CE_NIT) ═══
+  if (conv) {
+    const ctx: InformeCtx = {
+      doc,
+      autoTable,
+      get y() {
+        return y;
+      },
+      set y(v: number) {
+        y = v;
+      },
+      checkPage,
+      addParagraph,
+      addSubsectionTitle,
+    };
+
+    const incluidas = conv.secciones.filter((s) => s.incluida).sort((a, b) => a.orden - b.orden);
+
+    for (const seccion of incluidas) {
+      const cat = getCatalogoSeccion(seccion.prueba_codigo);
+      if (!cat) continue;
+      const codigo = seccion.prueba_codigo;
+
+      // Título de la prueba
+      checkPage(60);
+      y += 2;
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(11);
+      doc.setTextColor(...COLOR_PRIMARY);
+      const tituloLines = doc.splitTextToSize(`${codigo} ${cat.nombre}`, CONTENT_WIDTH);
+      doc.text(tituloLines, MARGIN, y);
+      y += (tituloLines.length - 1) * 5 + 2;
+      doc.setDrawColor(...COLOR_PRIMARY);
+      doc.setLineWidth(0.3);
+      doc.line(MARGIN, y, MARGIN + CONTENT_WIDTH, y);
+      y += 6;
+
+      addSubsectionTitle(`${codigo}.1.`, "Objetivo");
+      addParagraph(cat.objetivo);
+      addSubsectionTitle(`${codigo}.2.`, "Instrumentación");
+      addParagraph(cat.instrumentacion);
+      addSubsectionTitle(`${codigo}.3.`, "Metodología");
+      addParagraph(cat.metodologia);
+
+      // Resultados (+ análisis en 2.1, descripción en 2.2)
+      let nextSub: number;
+      if (seccion.concepto === "No_aplica") {
+        addSubsectionTitle(`${codigo}.4.`, "Resultados");
+        addParagraph("NO APLICA.");
+        nextSub = 5;
+      } else {
+        nextSub = renderResultadosSeccion(ctx, codigo, datos.visita, conv, datos.sala);
+      }
+
+      // Criterio de aceptación
+      addSubsectionTitle(`${codigo}.${nextSub}.`, "Criterio de aceptación");
+      addParagraph(cat.criterio);
+      nextSub++;
+
+      // Diagrama radiométrico (solo 2.1)
+      if (codigo === "2.1" && seccion.concepto !== "No_aplica") {
+        renderDiagramaRadiometrico(ctx, conv);
+        nextSub = 8;
+      }
+
+      // Concepto — en la 2.1 se deriva de las mediciones (el físico solo decide "No aplica")
+      checkPage(15);
+      addSubsectionTitle(`${codigo}.${nextSub}.`, "Concepto");
+      nextSub++;
+      const c = seccion.concepto;
+      const esAuto21 = codigo === "2.1" && c !== "No_aplica";
+
+      let conceptoLabel: string;
+      let conceptoParrafo: string | undefined;
+      let esNoConforme = c === "No_conforme";
+      let accionesTexto = seccion.acciones_correctivas?.trim()
+        ? seccion.acciones_correctivas
+        : "No se requieren acciones correctivas.";
+
+      if (esAuto21) {
+        const hayMediciones = conv.mediciones.length > 0;
+        esNoConforme = hayMediciones && conv.mediciones.some((m) => m.concepto === "No_conforme");
+        if (!hayMediciones) {
+          conceptoLabel = "PENDIENTE";
+        } else if (esNoConforme) {
+          conceptoLabel = "NO FAVORABLE";
+          conceptoParrafo =
+            "Las dosis equivalentes anuales estimadas en algunas áreas evaluadas superan los niveles de restricción de dosis establecidos para áreas supervisadas, por lo que las condiciones radiológicas de la instalación requieren evaluación y adopción de medidas correctivas.";
+          accionesTexto =
+            "Se recomienda evaluar las condiciones de blindaje de la instalación, revisar la carga de trabajo del equipo y adoptar las medidas de protección radiológica necesarias para garantizar el cumplimiento de los niveles de restricción de dosis establecidos. Una vez subsanada la condición identificada, se deberá repetir el estudio radiométrico para verificar el cumplimiento de los criterios establecidos.";
+        } else {
+          conceptoLabel = "FAVORABLE";
+          conceptoParrafo =
+            "Las dosis equivalentes anuales estimadas en las áreas evaluadas se encuentran por debajo de los niveles de restricción de dosis establecidos para áreas controladas y supervisadas, por lo que las condiciones radiológicas de la instalación se consideran aceptables para la operación del equipo evaluado.";
+          accionesTexto = "No se requieren acciones correctivas.";
+        }
+      } else {
+        conceptoLabel =
+          c === "Conforme"
+            ? "CONFORME"
+            : c === "No_conforme"
+              ? "NO CONFORME"
+              : c === "No_aplica"
+                ? "NO APLICA"
+                : "PENDIENTE";
+      }
+
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(9);
+      if (conceptoLabel === "CONFORME" || conceptoLabel === "FAVORABLE")
+        doc.setTextColor(16, 150, 80);
+      else if (conceptoLabel === "NO CONFORME" || conceptoLabel === "NO FAVORABLE")
+        doc.setTextColor(220, 50, 50);
+      else doc.setTextColor(...COLOR_GRAY);
+      doc.text(conceptoLabel, MARGIN, y);
+      y += 6;
+      if (conceptoParrafo) {
+        addParagraph(conceptoParrafo);
+      }
+      if (seccion.observaciones?.trim()) {
+        addParagraph(seccion.observaciones);
+      }
+
+      // Acciones correctivas
+      addSubsectionTitle(`${codigo}.${nextSub}.`, "Acciones Correctivas");
+      addParagraph(accionesTexto);
+      y += 4;
+
+      resumenRows.push([`${codigo} ${cat.nombre}`, conceptoLabel]);
+      if (esNoConforme) {
+        conceptoGeneralOk = false;
+        accionesPendientes.push(`• ${cat.nombre}: ${accionesTexto}`);
+      }
+    }
+  }
+
+  // ─── Para cada prueba (flujo legacy — equipos sin paquete dedicado) ───
+  const pruebasOrdenadas = conv ? [] : datos.pruebas.filter((p) => p.completado);
 
   for (let idx = 0; idx < pruebasOrdenadas.length; idx++) {
     const prueba = pruebasOrdenadas[idx];
@@ -855,6 +1009,14 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
     );
 
     y += 4;
+
+    resumenRows.push([`${numPrueba} ${nombre}`, conceptoText]);
+    if (prueba.concepto === "NO_FAVORABLE") {
+      conceptoGeneralOk = false;
+      accionesPendientes.push(
+        `• ${nombre}: ${prueba.acciones_correctivas ?? "Se requieren acciones correctivas."}`
+      );
+    }
   }
 
   // ═══════════════════════════════════════════════════════════
@@ -867,14 +1029,7 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
     startY: y,
     margin: { left: MARGIN, right: MARGIN },
     head: [["Prueba realizada", "Concepto"]],
-    body: pruebasOrdenadas.map((p, i) => [
-      `2.${i + 1} ${p.definicion?.nombre ?? "—"}`,
-      p.concepto === "FAVORABLE"
-        ? "FAVORABLE"
-        : p.concepto === "NO_FAVORABLE"
-          ? "NO FAVORABLE"
-          : "NO APLICA",
-    ]),
+    body: resumenRows,
     theme: "grid",
     headStyles: {
       fillColor: COLOR_PRIMARY,
@@ -888,10 +1043,10 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
     didParseCell: (data) => {
       if (data.section === "body" && data.column.index === 1) {
         const val = String(data.cell.raw);
-        if (val === "FAVORABLE") {
+        if (val === "FAVORABLE" || val === "CONFORME") {
           data.cell.styles.textColor = [16, 150, 80];
           data.cell.styles.fontStyle = "bold";
-        } else if (val === "NO FAVORABLE") {
+        } else if (val === "NO FAVORABLE" || val === "NO CONFORME") {
           data.cell.styles.textColor = [220, 50, 50];
           data.cell.styles.fontStyle = "bold";
         } else {
@@ -907,10 +1062,7 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
   checkPage(30);
   y = addSectionTitle(doc, "CONCEPTO", y);
 
-  const todosF = pruebasOrdenadas.every(
-    (p) => p.concepto === "FAVORABLE" || p.concepto === "NO_APLICA"
-  );
-  const conceptoGeneral = todosF ? "FAVORABLE" : "NO FAVORABLE";
+  const conceptoGeneral = conceptoGeneralOk ? "FAVORABLE" : "NO FAVORABLE";
 
   addParagraph(
     "Con base en los resultados obtenidos en las pruebas de control de calidad realizadas al equipo de radiografía general, y de acuerdo con los criterios establecidos en los protocolos de control de calidad aplicables, se concluye que el desempeño del equipo evaluado es:"
@@ -918,21 +1070,22 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
 
   doc.setFont("helvetica", "bold");
   doc.setFontSize(14);
-  doc.setTextColor(todosF ? 16 : 220, todosF ? 150 : 50, todosF ? 80 : 50);
+  doc.setTextColor(
+    conceptoGeneralOk ? 16 : 220,
+    conceptoGeneralOk ? 150 : 50,
+    conceptoGeneralOk ? 80 : 50
+  );
   doc.text(conceptoGeneral, PAGE_WIDTH / 2, y, { align: "center" });
   y += 10;
 
   // ACCIONES CORRECTIVAS
   y = addSectionTitle(doc, "ACCIONES CORRECTIVAS", y);
 
-  const pruebasNoFav = pruebasOrdenadas.filter((p) => p.concepto === "NO_FAVORABLE");
-  if (pruebasNoFav.length === 0) {
+  if (accionesPendientes.length === 0) {
     addParagraph("No se requieren acciones correctivas.");
   } else {
-    for (const p of pruebasNoFav) {
-      addParagraph(
-        `• ${p.definicion?.nombre ?? ""}: ${p.acciones_correctivas ?? "Se requieren acciones correctivas."}`
-      );
+    for (const accion of accionesPendientes) {
+      addParagraph(accion);
     }
   }
 

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1,0 +1,487 @@
+import type { jsPDF } from "jspdf";
+import type autoTableType from "jspdf-autotable";
+import { db } from "@/lib/db";
+import type { VisitaEjecucion, SalaDimensiones } from "@/lib/db/types";
+import type {
+  ConvLevantamientoSetup,
+  ConvMedicionRadiometrica,
+  ConvInspeccionItem,
+  ConvElementoProteccion,
+  ConvEvidencia,
+  ConvResultadoPrueba,
+  ConvInformeSeccion,
+} from "@/lib/equipos/convencional/db/types";
+import {
+  ITEMS_INSPECCION_EQUIPO,
+  ITEMS_CONDICIONES_OPERACION,
+} from "@/lib/equipos/convencional/inspeccion-items";
+import { CATALOGO_SECCIONES } from "@/lib/equipos/convencional/informe-secciones";
+
+// ============================================================
+//  Secciones del pre-informe para el equipo CONVENCIONAL
+//  Estructura basada en la hoja CE_NIT de la plantilla Excel.
+//  Cada prueba 2.X renderiza sus resultados desde las tablas
+//  conv_*; 2.1 y 2.2 tienen renderizador completo, el resto
+//  usa el esqueleto genérico hasta que se implemente el suyo.
+// ============================================================
+
+// ─── Estilo (espejo de generar-pre-informe.ts) ───
+
+const COLOR_PRIMARY: [number, number, number] = [51, 65, 85];
+const COLOR_GRAY: [number, number, number] = [100, 116, 139];
+const COLOR_BLACK: [number, number, number] = [30, 30, 30];
+const COLOR_ALT_ROW: [number, number, number] = [248, 250, 252];
+const MARGIN = 20;
+
+const TABLE_STYLE = {
+  theme: "grid" as const,
+  headStyles: {
+    fillColor: COLOR_PRIMARY,
+    textColor: [255, 255, 255] as [number, number, number],
+    fontStyle: "bold" as const,
+    fontSize: 7,
+  },
+  bodyStyles: { fontSize: 7, textColor: COLOR_BLACK },
+  alternateRowStyles: { fillColor: COLOR_ALT_ROW },
+  margin: { left: MARGIN, right: MARGIN },
+};
+
+/** Contexto que el generador comparte con los renderizadores */
+export interface InformeCtx {
+  doc: jsPDF;
+  autoTable: typeof autoTableType;
+  /** Cursor vertical — getter/setter sobre la variable del generador */
+  y: number;
+  checkPage: (needed: number) => void;
+  addParagraph: (text: string, fontSize?: number, indent?: number) => void;
+  addSubsectionTitle: (number: string, title: string) => void;
+}
+
+// ─── Datos convencionales ───
+
+export interface DatosConvencional {
+  secciones: ConvInformeSeccion[];
+  setup?: ConvLevantamientoSetup;
+  mediciones: ConvMedicionRadiometrica[];
+  inspeccion: ConvInspeccionItem[];
+  elementos: ConvElementoProteccion[];
+  resultados: Map<string, ConvResultadoPrueba>;
+  /** Imagen del plano radiométrico (2.1) como dataURL, si existe */
+  planoRadiometrico?: { dataUrl: string; width: number; height: number };
+}
+
+async function blobADataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function cargarImagen(
+  evidencia: ConvEvidencia | undefined
+): Promise<DatosConvencional["planoRadiometrico"]> {
+  if (!evidencia?.blob_local) return undefined;
+  try {
+    const bitmap = await createImageBitmap(evidencia.blob_local);
+    const dataUrl = await blobADataUrl(evidencia.blob_local);
+    return { dataUrl, width: bitmap.width, height: bitmap.height };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias] =
+    await Promise.all([
+      db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
+      db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
+      db.conv_mediciones.where("visita_id").equals(visitaId).sortBy("punto_numero"),
+      db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray(),
+      db.conv_elementos_proteccion.where("visita_id").equals(visitaId).toArray(),
+      db.conv_resultados_prueba.where("visita_id").equals(visitaId).toArray(),
+      db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+    ]);
+
+  // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
+  const seccionesEfectivas: ConvInformeSeccion[] =
+    secciones.length > 0
+      ? secciones
+      : CATALOGO_SECCIONES.map((c) => ({
+          visita_id: visitaId,
+          prueba_codigo: c.codigo,
+          orden: c.orden,
+          incluida: true,
+        }));
+
+  const planoEv = evidencias.find(
+    (e) => e.prueba_codigo === "2.1" && e.slot === "plano_radiometrico"
+  );
+
+  return {
+    secciones: seccionesEfectivas,
+    setup,
+    mediciones,
+    inspeccion,
+    elementos,
+    resultados: new Map(resultadosArr.map((r) => [r.prueba_codigo, r])),
+    planoRadiometrico: await cargarImagen(planoEv),
+  };
+}
+
+// ─── Helpers de render ───
+
+function num(v: number | undefined | null): number {
+  return v == null || isNaN(v) ? 0 : v;
+}
+
+function fmt(v: number | undefined | null, decimals = 1): string {
+  return v == null ? "—" : v.toFixed(decimals);
+}
+
+function capitalizar(s: string | undefined): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : "—";
+}
+
+function conceptoLabel(c: string | undefined): string {
+  if (c === "Conforme") return "Conforme";
+  if (c === "No_conforme") return "No conforme";
+  if (c === "No_aplica") return "No aplica";
+  return "—";
+}
+
+/** Caption en negrita para tablas y figuras (estilo CE_NIT) */
+function addCaption(ctx: InformeCtx, text: string) {
+  ctx.checkPage(8);
+  ctx.doc.setFont("helvetica", "bold");
+  ctx.doc.setFontSize(8);
+  ctx.doc.setTextColor(...COLOR_GRAY);
+  ctx.doc.text(text, MARGIN, ctx.y);
+  ctx.y += 4;
+}
+
+function finalY(doc: jsPDF): number {
+  return (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY;
+}
+
+/** Pinta verde/rojo las celdas de concepto de una tabla */
+function colorearConcepto(columnIndex: number) {
+  return (data: {
+    section: string;
+    column: { index: number };
+    cell: { raw: unknown; styles: { textColor: unknown; fontStyle: string } };
+  }) => {
+    if (data.section === "body" && data.column.index === columnIndex) {
+      const val = String(data.cell.raw);
+      if (val === "Conforme") {
+        data.cell.styles.textColor = [16, 150, 80];
+        data.cell.styles.fontStyle = "bold";
+      } else if (val === "No conforme") {
+        data.cell.styles.textColor = [220, 50, 50];
+        data.cell.styles.fontStyle = "bold";
+      }
+    }
+  };
+}
+
+// ─── Renderizador 2.1: Levantamiento radiométrico ───
+
+function render21(ctx: InformeCtx, visita: VisitaEjecucion, conv: DatosConvencional): number {
+  const { doc, autoTable } = ctx;
+  const setup = conv.setup;
+  const cod = "2.1";
+
+  // .4 Resultados
+  ctx.addSubsectionTitle(`${cod}.4.`, "Resultados");
+  ctx.addParagraph(
+    "Se registraron las lecturas de tasa de dosis equivalente ambiental H*(10) en los puntos de medición definidos en el diagrama radiométrico de la instalación."
+  );
+
+  const tecnica = [
+    `Tensión (kV): ${fmt(setup?.tecnica_kv, 0)}`,
+    `Corriente (mA): ${fmt(setup?.tecnica_ma, 0)}`,
+    `Tiempo (s): ${fmt(setup?.tecnica_tiempo_s, 2)}`,
+    `Exposición (mAs): ${fmt(setup?.tecnica_mas, 0)}`,
+  ].join("    ");
+  ctx.addParagraph(`Técnica utilizada:    ${tecnica}`);
+  ctx.addParagraph(
+    `Fondo natural de radiación ionizante (mSv/h): ${
+      setup?.fondo_natural_usv_h != null ? (setup.fondo_natural_usv_h / 1000).toFixed(5) : "—"
+    }`
+  );
+  ctx.addParagraph(
+    "En cada punto se realizaron varias mediciones consecutivas, registrándose el valor máximo obtenido para su posterior análisis."
+  );
+
+  if (conv.mediciones.length === 0) {
+    ctx.addParagraph("Sin mediciones registradas.");
+  } else {
+    ctx.checkPage(30);
+    addCaption(
+      ctx,
+      "Tabla 2.1.1. Registro de lecturas de tasa de dosis equivalente ambiental H*(10)"
+    );
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      startY: ctx.y,
+      head: [["Sitio", "Punto de Medición", "Lectura (mSv/h)"]],
+      body: conv.mediciones.map((m) => [
+        String(m.punto_numero),
+        m.ubicacion_descripcion || "—",
+        m.tasa_dosis_msv_h != null ? m.tasa_dosis_msv_h.toFixed(5) : "—",
+      ]),
+      columnStyles: { 0: { cellWidth: 14 } },
+    });
+    ctx.y = finalY(doc) + 4;
+  }
+
+  // .5 Análisis (carga de trabajo + tabla de dosis anual)
+  ctx.addSubsectionTitle(`${cod}.5.`, "Análisis");
+  ctx.addParagraph(
+    "Las lecturas de tasa de dosis equivalente ambiental H*(10) obtenidas en los puntos de medición fueron utilizadas para estimar la dosis equivalente anual en cada una de las áreas evaluadas. La estimación se realizó considerando la carga de trabajo del equipo, el factor de uso del haz y el factor de ocupación de cada área, siguiendo la metodología descrita en el documento IAEA-TECDOC-1958."
+  );
+
+  const nr = num(visita.radiografias_por_semana);
+  const masMax = num(visita.mas_maximo_usado);
+  const wEstimada = (nr * masMax) / 60;
+  const wEstandar = setup?.w_estandar ?? 160;
+  const wUsado = Math.max(wEstimada, wEstandar);
+  const semanas = setup?.semanas_laborales ?? 50;
+
+  ctx.checkPage(34);
+  addCaption(ctx, "Carga de trabajo");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Parámetro", "Valor"]],
+    body: [
+      ["Radiografías por semana (NR)", fmt(nr, 0)],
+      ["Exposición máxima clínica (mAs)", fmt(masMax, 0)],
+      ["Carga de trabajo W estimada (mA·min/sem)", fmt(wEstimada)],
+      ["Carga de trabajo estándar (mA·min/sem)", fmt(wEstandar, 0)],
+      ["Carga de trabajo W usada = max(estimada, estándar)", fmt(wUsado)],
+      ["Corriente utilizada en la prueba I (mA)", fmt(setup?.tecnica_ma, 0)],
+      ["Factor de uso (U)", "Según punto de medición (Tabla 2.1.2)"],
+      ["Semanas laborales", fmt(semanas, 0)],
+    ],
+    columnStyles: { 0: { cellWidth: 110 } },
+  });
+  ctx.y = finalY(doc) + 4;
+
+  if (conv.mediciones.length > 0) {
+    ctx.checkPage(30);
+    addCaption(ctx, "Tabla 2.1.2. Cálculo de la dosis equivalente anual (mSv/año)");
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      startY: ctx.y,
+      head: [
+        [
+          "Sitio",
+          "Punto de Medición",
+          "T",
+          "U",
+          "Dosis Anual (mSv/año)",
+          "Tipo de área",
+          "Concepto",
+        ],
+      ],
+      body: conv.mediciones.map((m) => [
+        String(m.punto_numero),
+        m.ubicacion_descripcion || "—",
+        fmt(m.factor_ocupacion_t, 3).replace(/\.?0+$/, "") || "—",
+        fmt(m.factor_uso_u, 1),
+        m.dosis_anual_msv != null ? m.dosis_anual_msv.toFixed(6) : "—",
+        capitalizar(m.tipo_area),
+        conceptoLabel(m.concepto),
+      ]),
+      columnStyles: { 0: { cellWidth: 12 } },
+      didParseCell: colorearConcepto(6),
+    });
+    ctx.y = finalY(doc) + 4;
+  }
+
+  // .6 Criterio (lo agrega el generador con el texto del catálogo)
+  // .7 Diagrama radiométrico
+  return 6;
+}
+
+/** Subsección extra de la 2.1: diagrama radiométrico (después del criterio) */
+export function renderDiagramaRadiometrico(ctx: InformeCtx, conv: DatosConvencional) {
+  ctx.addSubsectionTitle("2.1.7.", "Diagrama radiométrico");
+  const plano = conv.planoRadiometrico;
+  if (!plano) {
+    ctx.addParagraph("No se adjuntó el plano radiométrico de la instalación.");
+    return;
+  }
+  const maxW = 130;
+  const maxH = 90;
+  const scale = Math.min(maxW / plano.width, maxH / plano.height);
+  const w = plano.width * scale;
+  const h = plano.height * scale;
+  ctx.checkPage(h + 12);
+  try {
+    const x = MARGIN + (170 - w) / 2;
+    ctx.doc.addImage(plano.dataUrl, x, ctx.y, w, h);
+    ctx.y += h + 4;
+    addCaption(ctx, "Figura 2.1.1. Diagrama radiométrico de la instalación");
+    ctx.y += 2;
+  } catch {
+    ctx.addParagraph("No fue posible incluir la imagen del plano radiométrico.");
+  }
+}
+
+// ─── Renderizador 2.2: Inspección visual ───
+
+function render22(
+  ctx: InformeCtx,
+  conv: DatosConvencional,
+  sala: SalaDimensiones | undefined
+): number {
+  const { doc, autoTable } = ctx;
+  const cod = "2.2";
+
+  // .4 Descripción de la instalación y blindajes
+  ctx.addSubsectionTitle(`${cod}.4.`, "Descripción de la instalación y blindajes");
+  ctx.addParagraph(
+    "La distribución de las áreas colindantes y de las barreras estructurales de protección radiológica se presenta en el diagrama radiométrico de la instalación (Figura 2.1.1)."
+  );
+  if (sala?.ancho_m || sala?.largo_m || sala?.alto_m) {
+    const area =
+      sala.ancho_m && sala.largo_m ? ` — Área: ${(sala.ancho_m * sala.largo_m).toFixed(2)} m²` : "";
+    ctx.addParagraph(
+      `Las dimensiones de la sala son: Ancho: ${fmt(sala.ancho_m)} m — Largo: ${fmt(
+        sala.largo_m
+      )} m — Altura: ${fmt(sala.alto_m)} m${area}.`
+    );
+  }
+
+  // .5 Resultados
+  ctx.addSubsectionTitle(`${cod}.5.`, "Resultados");
+
+  const equipoItems = conv.inspeccion
+    .filter((i) => i.seccion === "equipo")
+    .sort((a, b) => a.item_numero - b.item_numero);
+  const operacionItems = conv.inspeccion
+    .filter((i) => i.seccion === "condiciones_operacion")
+    .sort((a, b) => a.item_numero - b.item_numero);
+
+  const tablaInspeccion = (
+    caption: string,
+    items: ConvInspeccionItem[],
+    descripciones: string[]
+  ) => {
+    if (items.length === 0) return;
+    ctx.checkPage(30);
+    addCaption(ctx, caption);
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      startY: ctx.y,
+      head: [["No.", "Descripción", "Concepto", "Observaciones"]],
+      body: items.map((i) => [
+        String(i.item_numero),
+        descripciones[i.item_numero - 1] ?? "—",
+        conceptoLabel(i.concepto),
+        i.observacion?.trim() || "Ninguna.",
+      ]),
+      columnStyles: { 0: { cellWidth: 10 }, 1: { cellWidth: 95 }, 2: { cellWidth: 22 } },
+      didParseCell: colorearConcepto(2),
+    });
+    ctx.y = finalY(doc) + 4;
+  };
+
+  if (equipoItems.length === 0 && operacionItems.length === 0) {
+    ctx.addParagraph("Sin datos de inspección registrados.");
+  } else {
+    tablaInspeccion(
+      "Tabla 2.2.1. Inspección visual del equipo",
+      equipoItems,
+      ITEMS_INSPECCION_EQUIPO
+    );
+    tablaInspeccion(
+      "Tabla 2.2.2. Condiciones de operación del equipo",
+      operacionItems,
+      ITEMS_CONDICIONES_OPERACION
+    );
+  }
+
+  if (conv.elementos.length > 0) {
+    ctx.checkPage(30);
+    addCaption(ctx, "Tabla 2.2.3. Elementos de protección radiológica");
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      startY: ctx.y,
+      head: [["No.", "Descripción", "Cantidad", "Tipo", "Concepto", "Observaciones"]],
+      body: conv.elementos.map((e, i) => [
+        String(i + 1),
+        e.descripcion || "—",
+        e.cantidad != null ? String(e.cantidad) : "—",
+        e.tipo_paciente === "adulto"
+          ? "Adulto"
+          : e.tipo_paciente === "pediatrico"
+            ? "Pediátrico"
+            : "—",
+        conceptoLabel(e.concepto),
+        e.observacion?.trim() || "Ninguna.",
+      ]),
+      columnStyles: { 0: { cellWidth: 10 }, 2: { cellWidth: 16 }, 3: { cellWidth: 18 } },
+      didParseCell: colorearConcepto(4),
+    });
+    ctx.y = finalY(doc) + 4;
+  }
+
+  return 6;
+}
+
+// ─── Renderizador genérico (esqueleto para grupos B–E) ───
+
+function renderGenerico(ctx: InformeCtx, codigo: string, conv: DatosConvencional): number {
+  ctx.addSubsectionTitle(`${codigo}.4.`, "Resultados");
+  const resultado = conv.resultados.get(codigo);
+
+  if (!resultado || (!resultado.completado && resultado.resultado_principal == null)) {
+    ctx.addParagraph("Sin datos registrados para esta prueba.");
+    return 5;
+  }
+
+  const lineas: string[] = [];
+  if (resultado.resultado_principal != null) {
+    lineas.push(`Resultado principal: ${resultado.resultado_principal}`);
+  }
+  if (resultado.resultado_secundario != null) {
+    lineas.push(`Resultado secundario: ${resultado.resultado_secundario}`);
+  }
+  for (const [clave, valor] of Object.entries(resultado.datos_calculados ?? {})) {
+    if (valor == null || typeof valor === "object") continue;
+    lineas.push(`${clave.replace(/_/g, " ")}: ${String(valor)}`);
+  }
+  if (lineas.length === 0) {
+    ctx.addParagraph("Prueba ejecutada — los resultados detallados se registran en la aplicación.");
+  } else {
+    for (const linea of lineas) ctx.addParagraph(linea);
+  }
+  return 5;
+}
+
+// ─── Entrada principal por sección ───
+
+/**
+ * Renderiza las subsecciones de resultados de una prueba (a partir de la .4).
+ * Retorna el número de la siguiente subsección disponible (para Criterio).
+ */
+export function renderResultadosSeccion(
+  ctx: InformeCtx,
+  codigo: string,
+  visita: VisitaEjecucion,
+  conv: DatosConvencional,
+  sala: SalaDimensiones | undefined
+): number {
+  switch (codigo) {
+    case "2.1":
+      return render21(ctx, visita, conv);
+    case "2.2":
+      return render22(ctx, conv, sala);
+    default:
+      return renderGenerico(ctx, codigo, conv);
+  }
+}


### PR DESCRIPTION
## Resumen

Dos commits de `dev` a `main`:

### Visualización del informe convencional — pruebas 2.1 y 2.2 (`54b5ac1`)

Renderiza el pre-informe PDF desde las tablas `conv_*` siguiendo la estructura de la hoja CE_NIT de la plantilla Excel.

- **2.1 (levantamiento radiométrico):** técnica utilizada, fondo natural, Tabla 2.1.1 de lecturas, tabla de carga de trabajo (W estimada/estándar/usada, I, semanas; U por punto), Tabla 2.1.2 de dosis anual con T y U por punto, criterio, Figura 2.1.1 con el plano radiométrico capturado. El **concepto y las acciones correctivas se derivan automáticamente** de las mediciones (réplica de las fórmulas del Excel); el físico solo decide si la prueba aplica.
- **2.2 (inspección visual):** descripción de la instalación con dimensiones de sala, Tablas 2.2.1/2.2.2 de inspección del equipo y condiciones de operación, Tabla 2.2.3 de elementos de protección con tipo adulto/pediátrico.
- **Esqueleto genérico para grupos B–E**: objetivo/instrumentación/metodología/criterio del catálogo + resultados desde `conv_resultados_prueba`. Cada grupo nuevo se enchufa con un `case` en `renderResultadosSeccion`.
- El generador detecta equipos con paquete dedicado y usa el flujo nuevo respetando el orden/inclusión configurado por el físico; los equipos sin paquete siguen con el flujo legacy.
- Paleta del PDF: de morado vibrante a azul pizarra neutro.
- Dosis anual H*(10) con 6 decimales (pantalla y PDF).
- Fix: `updateSetup` descartaba campos al editar la técnica rápido (debounce con un solo timer).
- Inspección 2.2: observaciones habilitadas solo si el ítem es "No conforme", con borrado automático al cambiar el concepto.

### Ajustes de UI (`2c117c0`)

- Altura de los selects pareja con los inputs en todos los formularios.
- Select Adulto/Pediátrico con el estilo de Concepto.
- Visitas creadas sin "null null" (usa marca+modelo o tipo de equipo).
- "Mis Visitas" → "Visitas" en sidebar y dashboard.

## Test plan

- [x] Generar el pre-informe de una visita convencional con 2.1 y 2.2 llenas y verificar que coincide con CE_NIT.
- [x] 2.1 con todos los puntos conformes → concepto FAVORABLE; con algún no conforme → NO FAVORABLE + acción correctiva automática.
- [x] Marcar 2.1 como "No aplica" → el PDF muestra NO APLICA sin cálculo.
- [x] Editar la técnica (kV, mA, tiempo, mAs) rápido y verificar que se guardan los cuatro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
