### PR TITLE
feat: refinamientos del informe convencional (2.1/2.2)

### DIFF
--- a/src/app/dashboard/visitas/[id]/conv/grupo-a/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-a/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState, useCallback, useRef, useEffect } from "react";
+import { use, useState, useRef, useEffect } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
@@ -18,7 +18,6 @@ import {
   ChevronDown,
   ChevronUp,
   Camera,
-  Check,
   ImageIcon,
   BookOpen,
 } from "lucide-react";
@@ -53,6 +52,15 @@ const CATALOGO_ELEMENTOS_PROTECCION = [
 
 const SLOTS_IMAGEN_21 = [
   { slot: "plano_radiometrico", label: "Plano / Croquis radiométrico de la sala" },
+];
+
+/** Slots de fotografías de la prueba 2.2 (van a la sección 2.2.8 del informe) */
+const SLOTS_FOTOS_22 = [
+  { slot: "equipo_rayos_x", label: "Equipo de rayos X" },
+  { slot: "consola", label: "Consola del equipo" },
+  { slot: "aviso_proteccion_1", label: "Aviso de protección 1" },
+  { slot: "aviso_proteccion_2", label: "Aviso de protección 2" },
+  { slot: "aviso_proteccion_3", label: "Aviso de protección 3" },
 ];
 
 /** Carga de trabajo estándar para radiografía convencional (mA·min/sem) — piso del cálculo, metodología IAEA-TECDOC-1958 */
@@ -236,6 +244,72 @@ function ImageSlot({
   );
 }
 
+/** Captura compacta de foto para una fila de tabla (elementos de protección) */
+function ElementoFotoCell({
+  evidencia,
+  onCapture,
+  onRemove,
+}: {
+  evidencia?: { id?: number; blob_local?: Blob };
+  onCapture: (file: File) => void;
+  onRemove: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (evidencia?.blob_local) {
+      const url = URL.createObjectURL(evidencia.blob_local);
+      setPreview(url);
+      return () => URL.revokeObjectURL(url);
+    }
+    setPreview(null);
+  }, [evidencia?.blob_local]);
+
+  return (
+    <>
+      {preview ? (
+        <div className="relative w-10 h-10">
+          <img
+            src={preview}
+            alt="Foto"
+            className="w-10 h-10 object-cover rounded-lg border border-slate-200"
+          />
+          <button
+            type="button"
+            onClick={onRemove}
+            className="absolute -top-1.5 -right-1.5 bg-red-500 text-white rounded-full p-0.5 hover:bg-red-600"
+            aria-label="Quitar foto"
+          >
+            <Trash2 className="w-2.5 h-2.5" />
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          className="w-10 h-10 border-2 border-dashed border-slate-300 rounded-lg flex items-center justify-center text-slate-400 hover:border-primary hover:text-primary transition-colors"
+          aria-label="Tomar foto del elemento"
+        >
+          <Camera className="w-4 h-4" />
+        </button>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onCapture(file);
+          e.target.value = "";
+        }}
+      />
+    </>
+  );
+}
+
 // ─── Main Page ───
 
 export default function GrupoAPage({ params }: { params: Promise<{ id: string }> }) {
@@ -375,6 +449,11 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
 
   async function removeElemento(id: number) {
     await db.conv_elementos_proteccion.delete(id);
+    // Limpiar la foto asociada al elemento para no dejar evidencias huérfanas
+    const foto = data?.evidencias?.find(
+      (e) => e.prueba_codigo === "2.2" && e.slot === `elemento_${id}`
+    );
+    if (foto?.id) await db.conv_evidencias.delete(foto.id);
   }
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
@@ -497,15 +576,22 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
           PRUEBA 2.1 — LEVANTAMIENTO RADIOMÉTRICO
           ════════════════════════════════════════════ */}
 
-      {/* Imágenes de la prueba 2.1 */}
+      {/* Imágenes y fotografías (plano 2.1 + fotos 2.2) */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Prueba 2.1 — Imágenes" title="Plano radiométrico" icon={ImageIcon}>
-            Captura el croquis/plano de la sala con los puntos de medición.
+          <StepHeader
+            step="Pruebas 2.1 y 2.2 — Imágenes"
+            title="Imágenes y fotografías"
+            icon={ImageIcon}
+          >
+            Captura el plano radiométrico de la sala, el equipo de rayos X, la consola y los avisos
+            de protección radiológica. Las fotos de los elementos de protección se cargan en su
+            tabla más abajo.
           </StepHeader>
           <Tip>
-            Usa planos anteriores si están vigentes. Lo ideal es solicitar un plano de la sala al
-            cliente antes de la visita.
+            Usa planos anteriores si están vigentes; lo ideal es solicitar el plano al cliente antes
+            de la visita. Los avisos de protección pueden ser varios: usa los tres espacios
+            disponibles.
           </Tip>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {SLOTS_IMAGEN_21.map((s) => (
@@ -515,6 +601,15 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                 evidencia={getEvidencia("2.1", s.slot)}
                 onCapture={(file) => captureImage("2.1", s.slot, file)}
                 onRemove={() => removeImage("2.1", s.slot)}
+              />
+            ))}
+            {SLOTS_FOTOS_22.map((s) => (
+              <ImageSlot
+                key={s.slot}
+                label={s.label}
+                evidencia={getEvidencia("2.2", s.slot)}
+                onCapture={(file) => captureImage("2.2", s.slot, file)}
+                onRemove={() => removeImage("2.2", s.slot)}
               />
             ))}
           </div>
@@ -986,7 +1081,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
           </StepHeader>
 
           <div className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
-            <table className="w-full min-w-[700px] text-xs">
+            <table className="w-full min-w-[760px] text-xs">
               <thead>
                 <tr className="border-b border-slate-200">
                   {[
@@ -996,6 +1091,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                     ["Tipo", "w-24"],
                     ["Concepto", "w-28"],
                     ["Observaciones", "min-w-[160px]"],
+                    ["Foto", "w-16"],
                     ["", "w-8"],
                   ].map(([label, cls]) => (
                     <th
@@ -1069,6 +1165,15 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
                           elem.id && updateElemento(elem.id, { observacion: e.target.value })
                         }
                       />
+                    </td>
+                    <td className="py-1.5 px-1.5">
+                      {elem.id && (
+                        <ElementoFotoCell
+                          evidencia={getEvidencia("2.2", `elemento_${elem.id}`)}
+                          onCapture={(file) => captureImage("2.2", `elemento_${elem.id}`, file)}
+                          onRemove={() => removeImage("2.2", `elemento_${elem.id}`)}
+                        />
+                      )}
                     </td>
                     <td className="py-1.5 px-1.5">
                       <button

--- a/src/app/dashboard/visitas/[id]/info/page.tsx
+++ b/src/app/dashboard/visitas/[id]/info/page.tsx
@@ -5,6 +5,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
+import { pushSingle } from "@/lib/supabase/sync-engine";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
@@ -82,7 +83,7 @@ function EditableField({
         setTimeout(() => setSaved(false), 1500);
       }, 800);
     },
-    [onSave],
+    [onSave]
   );
 
   return (
@@ -147,6 +148,55 @@ function SelectField({
   );
 }
 
+function EditableTextArea({
+  label,
+  value,
+  onSave,
+  placeholder = "—",
+}: {
+  label: string;
+  value: string;
+  onSave: (v: string) => void;
+  placeholder?: string;
+}) {
+  const [local, setLocal] = useState(value);
+  const [saved, setSaved] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    setLocal(value);
+  }, [value]);
+
+  const handleChange = useCallback(
+    (v: string) => {
+      setLocal(v);
+      setSaved(false);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => {
+        onSave(v);
+        setSaved(true);
+        setTimeout(() => setSaved(false), 1500);
+      }, 800);
+    },
+    [onSave]
+  );
+
+  return (
+    <div className="space-y-1">
+      <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
+        {label}
+        {saved && <Check className="w-3 h-3 text-emerald-500" />}
+      </p>
+      <textarea
+        className="w-full rounded-xl border border-slate-200 p-2.5 text-sm font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+        value={local}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}
+
 function ReadonlyField({
   label,
   value,
@@ -171,8 +221,7 @@ function ReadonlyField({
 // ─── Progress bar ───
 
 function ProgressBar({ percent, label }: { percent: number; label: string }) {
-  const color =
-    percent === 100 ? "bg-emerald-500" : percent >= 50 ? "bg-amber-400" : "bg-red-400";
+  const color = percent === 100 ? "bg-emerald-500" : percent >= 50 ? "bg-amber-400" : "bg-red-400";
   return (
     <div className="flex items-center gap-3">
       <div className="flex-1 bg-slate-100 rounded-full h-2 overflow-hidden">
@@ -262,10 +311,6 @@ export default function InfoGeneralPage({ params }: { params: Promise<{ id: stri
       : [];
     const tubo = tubos[0];
 
-    const sala = visita.ubicacion_id
-      ? await db.sala_dimensiones.where("ubicacion_id").equals(visita.ubicacion_id).first()
-      : undefined;
-
     const contactos = cliente?.id
       ? await db.contactos.where("cliente_id").equals(cliente.id).toArray()
       : [];
@@ -279,7 +324,6 @@ export default function InfoGeneralPage({ params }: { params: Promise<{ id: stri
       solicitud,
       tubo,
       nroTubos: tubos.length,
-      sala,
       contactos,
     };
   }, [isReady, visitaId]);
@@ -290,37 +334,73 @@ export default function InfoGeneralPage({ params }: { params: Promise<{ id: stri
     return data?.contactos?.find((c) => c.cargo === cargo);
   }
 
+  const now = () => new Date().toISOString();
+
   async function saveCliente(field: string, value: string) {
     const id = data?.cliente?.id;
     if (!id) return;
-    await db.clientes.update(id, { [field]: value || undefined });
+    await db.clientes.update(id, {
+      [field]: value || undefined,
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("clientes", id);
   }
 
   async function saveSede(field: string, value: string) {
     const id = data?.sede?.id;
     if (!id) return;
-    await db.sedes.update(id, { [field]: value || undefined });
+    await db.sedes.update(id, {
+      [field]: value || undefined,
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("sedes", id);
   }
 
   async function saveUbicacion(field: string, value: string, numeric = false) {
     const id = data?.ubicacion?.id;
     if (!id) return;
     const parsed = numeric ? (value === "" ? undefined : parseFloat(value)) : value || undefined;
-    await db.ubicaciones_rx.update(id, { [field]: parsed });
+    await db.ubicaciones_rx.update(id, {
+      [field]: parsed,
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("ubicaciones_rx", id);
+  }
+
+  // Guarda una dimensión de la sala y recalcula el área (ancho × largo)
+  async function saveUbicacionDim(field: "ancho_m" | "largo_m" | "alto_m", value: string) {
+    const id = data?.ubicacion?.id;
+    if (!id) return;
+    const parsed = value === "" ? undefined : parseFloat(value);
+    const ancho = field === "ancho_m" ? parsed : data?.ubicacion?.ancho_m;
+    const largo = field === "largo_m" ? parsed : data?.ubicacion?.largo_m;
+    const area = ancho && largo ? Math.round(ancho * largo * 100) / 100 : undefined;
+    await db.ubicaciones_rx.update(id, {
+      [field]: parsed,
+      area_m2: area,
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("ubicaciones_rx", id);
   }
 
   async function saveEquipo(field: string, value: string, numeric = false) {
     const id = data?.equipo?.id;
     if (!id) return;
     const parsed = numeric ? (value === "" ? undefined : parseFloat(value)) : value || undefined;
-    await db.equipos.update(id, { [field]: parsed });
+    await db.equipos.update(id, { [field]: parsed, sync_status: "pending", last_modified: now() });
+    pushSingle("equipos", id);
   }
 
   async function saveTubo(field: string, value: string, numeric = false) {
     const id = data?.tubo?.id;
     if (!id) return;
     const parsed = numeric ? (value === "" ? undefined : parseFloat(value)) : value || undefined;
-    await db.tubos.update(id, { [field]: parsed });
+    await db.tubos.update(id, { [field]: parsed, sync_status: "pending", last_modified: now() });
+    pushSingle("tubos", id);
   }
 
   async function saveVisita(field: string, value: string, numeric = false) {
@@ -331,26 +411,35 @@ export default function InfoGeneralPage({ params }: { params: Promise<{ id: stri
       last_modified: new Date().toISOString(),
       sync_status: "pending",
     });
+    pushSingle("visitas", visitaId);
   }
 
   async function saveContacto(
     cargo: "medico_responsable" | "tecnologo" | "opr" | "responsable_visita",
     field: string,
-    value: string,
+    value: string
   ) {
     const clienteId = data?.cliente?.id;
     if (!clienteId) return;
     const existing = getContacto(cargo);
     if (existing?.id) {
-      await db.contactos.update(existing.id, { [field]: value || undefined });
+      await db.contactos.update(existing.id, {
+        [field]: value || undefined,
+        sync_status: "pending",
+        last_modified: now(),
+      });
+      pushSingle("contactos", existing.id);
     } else {
-      await db.contactos.add({
+      const newId = (await db.contactos.add({
         cliente_id: clienteId,
         nombre: field === "nombre" ? value : "",
         cargo,
         ...(field !== "nombre" ? { [field]: value || undefined } : {}),
         para_programar: false,
-      });
+        sync_status: "pending",
+        last_modified: now(),
+      })) as number;
+      pushSingle("contactos", newId);
     }
   }
 
@@ -384,8 +473,7 @@ export default function InfoGeneralPage({ params }: { params: Promise<{ id: stri
     );
   }
 
-  const { visita, equipo, ubicacion, sede, cliente, solicitud, tubo, nroTubos, sala, contactos } =
-    data;
+  const { visita, equipo, ubicacion, sede, cliente, solicitud, tubo, nroTubos, contactos } = data;
 
   const medico = getContacto("medico_responsable");
   const tecnologo = getContacto("tecnologo");
@@ -464,7 +552,7 @@ export default function InfoGeneralPage({ params }: { params: Promise<{ id: stri
     sede?.departamento,
   ]);
 
-  const progSala = computeProgress([sala?.ancho_m, sala?.largo_m, sala?.alto_m]);
+  const progSala = computeProgress([ubicacion?.ancho_m, ubicacion?.largo_m, ubicacion?.alto_m]);
 
   const allValues = [
     progInfoGeneral,
@@ -974,44 +1062,57 @@ export default function InfoGeneralPage({ params }: { params: Promise<{ id: stri
         </div>
       </SectionCard>
 
-      {/* 7. Dimensiones de la Sala */}
-      {sala && (
+      {/* 7. Dimensiones de la Sala (editable; también se captura en la ubicación RX) */}
+      {ubicacion && (
         <SectionCard
           icon={Ruler}
           title="Sala — Dimensiones y Blindaje"
           subtitle="Características del recinto"
           progress={progSala}
         >
+          <EditableField
+            label="Ubicación física del equipo"
+            value={toStr(ubicacion.ubicacion_fisica)}
+            onSave={(v) => saveUbicacion("ubicacion_fisica", v)}
+          />
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <ReadonlyField label="Ancho (m)" value={sala.ancho_m} />
-            <ReadonlyField label="Largo (m)" value={sala.largo_m} />
-            <ReadonlyField label="Alto (m)" value={sala.alto_m} />
-            <ReadonlyField label="Área (m²)" value={sala.area_m2} />
+            <EditableField
+              label="Ancho (m)"
+              value={toStr(ubicacion.ancho_m)}
+              type="number"
+              onSave={(v) => saveUbicacionDim("ancho_m", v)}
+            />
+            <EditableField
+              label="Largo (m)"
+              value={toStr(ubicacion.largo_m)}
+              type="number"
+              onSave={(v) => saveUbicacionDim("largo_m", v)}
+            />
+            <EditableField
+              label="Alto (m)"
+              value={toStr(ubicacion.alto_m)}
+              type="number"
+              onSave={(v) => saveUbicacionDim("alto_m", v)}
+            />
+            <ReadonlyField label="Área (m²)" value={ubicacion.area_m2} />
           </div>
 
-          {(sala.zona_a_desc || sala.zona_b_desc || sala.zona_c_desc || sala.zona_d_desc) && (
-            <div className="space-y-3 pt-3 border-t border-slate-100">
-              <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                Descripción de zonas
-              </p>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {(["a", "b", "c", "d"] as const).map((z) => {
-                  const desc = sala[`zona_${z}_desc` as keyof typeof sala];
-                  if (!desc) return null;
-                  return (
-                    <div key={z} className="bg-slate-50 rounded-xl p-3 space-y-1">
-                      <p className="text-[10px] font-black text-primary uppercase tracking-widest">
-                        Zona {z.toUpperCase()}
-                      </p>
-                      <p className="text-xs text-slate-600 font-medium leading-relaxed">
-                        {String(desc)}
-                      </p>
-                    </div>
-                  );
-                })}
-              </div>
+          <div className="space-y-3 pt-3 border-t border-slate-100">
+            <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+              Descripción de zonas
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {(["a", "b", "c", "d"] as const).map((z) => (
+                <EditableTextArea
+                  key={z}
+                  label={`Zona ${z.toUpperCase()}`}
+                  value={toStr(ubicacion[`zona_${z}_desc` as keyof typeof ubicacion] as string)}
+                  placeholder="Limita con… / puertas / barreras"
+                  onSave={(v) => saveUbicacion(`zona_${z}_desc`, v)}
+                />
+              ))}
             </div>
-          )}
+          </div>
         </SectionCard>
       )}
     </div>

--- a/src/app/dashboard/visitas/[id]/pre-informe/page.tsx
+++ b/src/app/dashboard/visitas/[id]/pre-informe/page.tsx
@@ -47,6 +47,8 @@ type ConceptoType = "Conforme" | "No_conforme" | "No_aplica";
 function SeccionCard({
   seccion,
   catalogo,
+  autoConcepto,
+  conceptoEfectivo,
   expanded,
   onToggleExpand,
   onToggleIncluida,
@@ -60,10 +62,15 @@ function SeccionCard({
 }: {
   seccion: ConvInformeSeccion;
   catalogo: (typeof CATALOGO_SECCIONES)[0];
+  /** Si true, el concepto se calcula automáticamente (prueba 2.1) y el físico
+   *  solo decide si la prueba aplica. */
+  autoConcepto: boolean;
+  /** Concepto a mostrar en el badge (calculado para 2.1, manual para el resto). */
+  conceptoEfectivo?: ConceptoType;
   expanded: boolean;
   onToggleExpand: () => void;
   onToggleIncluida: () => void;
-  onUpdateConcepto: (v: ConceptoType) => void;
+  onUpdateConcepto: (v: ConceptoType | undefined) => void;
   onUpdateAcciones: (v: string) => void;
   onUpdateObservaciones: (v: string) => void;
   onDragStart: () => void;
@@ -94,11 +101,7 @@ function SeccionCard({
         </div>
 
         {/* Toggle */}
-        <button
-          type="button"
-          onClick={onToggleIncluida}
-          className="flex-shrink-0"
-        >
+        <button type="button" onClick={onToggleIncluida} className="flex-shrink-0">
           {seccion.incluida ? (
             <ToggleRight className="w-6 h-6 text-primary" />
           ) : (
@@ -138,10 +141,8 @@ function SeccionCard({
           </p>
         </div>
 
-        {/* Concepto badge */}
-        {seccion.incluida && (
-          <ConceptoBadgeSmall concepto={seccion.concepto} />
-        )}
+        {/* Concepto badge — incluye el estado del switch (apagado = No aplica) */}
+        <ConceptoBadgeSmall concepto={conceptoEfectivo} />
 
         {/* Expand */}
         <button type="button" onClick={onToggleExpand} className="p-1 flex-shrink-0">
@@ -157,31 +158,40 @@ function SeccionCard({
       {expanded && seccion.incluida && (
         <div className="px-3 pb-3 space-y-3 border-t border-slate-100 pt-3 ml-8">
           {/* Concepto selector */}
-          <div className="space-y-1">
-            <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-              Concepto
-            </label>
-            <div className="flex gap-2">
-              {(
-                [
-                  ["Conforme", "bg-emerald-50 border-emerald-300 text-emerald-700"],
-                  ["No_conforme", "bg-red-50 border-red-300 text-red-700"],
-                  ["No_aplica", "bg-slate-50 border-slate-300 text-slate-500"],
-                ] as const
-              ).map(([val, cls]) => (
-                <button
-                  key={val}
-                  type="button"
-                  onClick={() => onUpdateConcepto(val)}
-                  className={`px-3 py-1.5 rounded-lg text-[10px] font-bold border transition-all ${
-                    seccion.concepto === val ? cls : "bg-white border-slate-200 text-slate-400"
-                  }`}
-                >
-                  {val === "Conforme" ? "Conforme" : val === "No_conforme" ? "No conforme" : "No aplica"}
-                </button>
-              ))}
+          {autoConcepto ? (
+            <div className="rounded-xl bg-slate-50 border border-slate-100 p-2.5">
+              <p className="text-[10px] text-slate-500 font-medium leading-relaxed">
+                El concepto (Conforme / No conforme) se calcula automáticamente a partir de las
+                mediciones radiométricas. Usa el interruptor para marcar la prueba como no
+                aplicable.
+              </p>
             </div>
-          </div>
+          ) : (
+            <div className="space-y-1">
+              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                Concepto
+              </label>
+              <div className="flex gap-2">
+                {(
+                  [
+                    ["Conforme", "bg-emerald-50 border-emerald-300 text-emerald-700"],
+                    ["No_conforme", "bg-red-50 border-red-300 text-red-700"],
+                  ] as const
+                ).map(([val, cls]) => (
+                  <button
+                    key={val}
+                    type="button"
+                    onClick={() => onUpdateConcepto(val)}
+                    className={`px-3 py-1.5 rounded-lg text-[10px] font-bold border transition-all ${
+                      seccion.concepto === val ? cls : "bg-white border-slate-200 text-slate-400"
+                    }`}
+                  >
+                    {val === "Conforme" ? "Conforme" : "No conforme"}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Acciones correctivas */}
           {seccion.concepto === "No_conforme" && (
@@ -198,18 +208,20 @@ function SeccionCard({
             </div>
           )}
 
-          {/* Observaciones */}
-          <div className="space-y-1">
-            <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-              Observaciones (opcional)
-            </label>
-            <textarea
-              className="w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none h-16 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-              defaultValue={seccion.observaciones ?? ""}
-              placeholder="Notas adicionales para esta prueba..."
-              onBlur={(e) => onUpdateObservaciones(e.target.value)}
-            />
-          </div>
+          {/* Observaciones — no aplican a la 2.1 (concepto automático) */}
+          {!autoConcepto && (
+            <div className="space-y-1">
+              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                Observaciones (opcional)
+              </label>
+              <textarea
+                className="w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none h-16 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                defaultValue={seccion.observaciones ?? ""}
+                placeholder="Notas adicionales para esta prueba..."
+                onBlur={(e) => onUpdateObservaciones(e.target.value)}
+              />
+            </div>
+          )}
 
           {/* Preview de textos TECDOC (colapsado) */}
           <details className="group">
@@ -285,8 +297,19 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
       .equals(visitaId)
       .sortBy("orden");
 
-    return { visita, secciones };
+    // Mediciones de la 2.1 — su concepto se deriva de aquí, no del campo manual
+    const mediciones = await db.conv_mediciones.where("visita_id").equals(visitaId).toArray();
+
+    return { visita, secciones, mediciones };
   }, [isReady, visitaId]);
+
+  // Concepto calculado de la 2.1: No conforme si algún punto lo es; Conforme
+  // si hay puntos y todos pasan; indefinido (pendiente) si aún no hay puntos.
+  const concepto21 = useMemo<ConceptoType | undefined>(() => {
+    const mediciones = data?.mediciones ?? [];
+    if (mediciones.length === 0) return undefined;
+    return mediciones.some((m) => m.concepto === "No_conforme") ? "No_conforme" : "Conforme";
+  }, [data?.mediciones]);
 
   // ─── Initialize secciones from catalog ───
   useEffect(() => {
@@ -333,26 +356,33 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
     arr.splice(targetIdx, 0, moved);
 
     // Update order for all affected
-    await Promise.all(arr.map((s, i) => s.id && db.conv_informe_secciones.update(s.id, { orden: i + 1 })));
+    await Promise.all(
+      arr.map((s, i) => s.id && db.conv_informe_secciones.update(s.id, { orden: i + 1 }))
+    );
     setDragIdx(null);
   }
 
   // ─── Toggle all ───
   async function toggleAll(incluida: boolean) {
     await Promise.all(
-      secciones.map((s) => s.id && db.conv_informe_secciones.update(s.id, { incluida })),
+      secciones.map((s) => s.id && db.conv_informe_secciones.update(s.id, { incluida }))
     );
   }
 
   // ─── Stats ───
   const stats = useMemo(() => {
-    const incluidas = secciones.filter((s) => s.incluida);
-    const conformes = incluidas.filter((s) => s.concepto === "Conforme").length;
-    const noConformes = incluidas.filter((s) => s.concepto === "No_conforme").length;
-    const noAplica = incluidas.filter((s) => s.concepto === "No_aplica").length;
-    const sinConcepto = incluidas.filter((s) => !s.concepto).length;
-    return { total: incluidas.length, conformes, noConformes, noAplica, sinConcepto };
-  }, [secciones]);
+    // Todas las pruebas van al informe; el switch apagado = No aplica.
+    // Para la 2.1 el concepto se deriva de las mediciones, no del campo manual.
+    const conceptoDe = (s: ConvInformeSeccion): ConceptoType | undefined => {
+      if (!s.incluida) return "No_aplica";
+      return s.prueba_codigo === "2.1" ? concepto21 : s.concepto;
+    };
+    const conformes = secciones.filter((s) => conceptoDe(s) === "Conforme").length;
+    const noConformes = secciones.filter((s) => conceptoDe(s) === "No_conforme").length;
+    const noAplica = secciones.filter((s) => conceptoDe(s) === "No_aplica").length;
+    const sinConcepto = secciones.filter((s) => !conceptoDe(s)).length;
+    return { total: secciones.length, conformes, noConformes, noAplica, sinConcepto };
+  }, [secciones, concepto21]);
 
   // ─── Generate PDF ───
   const handleGenerar = useCallback(async () => {
@@ -423,9 +453,7 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
 
       {/* Header */}
       <div>
-        <p className="text-[10px] font-black text-primary uppercase tracking-widest">
-          Pre-Informe
-        </p>
+        <p className="text-[10px] font-black text-primary uppercase tracking-widest">Pre-Informe</p>
         <h2 className="text-xl sm:text-2xl font-black text-slate-900 tracking-tighter">
           Editor del Informe
         </h2>
@@ -441,7 +469,7 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
             <div className="flex gap-4">
               <div className="text-center">
                 <p className="text-lg font-black text-primary">{stats.total}</p>
-                <p className="text-[9px] font-bold text-slate-400 uppercase">Incluidas</p>
+                <p className="text-[9px] font-bold text-slate-400 uppercase">Pruebas</p>
               </div>
               <div className="text-center">
                 <p className="text-lg font-black text-emerald-600">{stats.conformes}</p>
@@ -492,7 +520,10 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
         </p>
         {[
           { label: "Portada", desc: "Identificacion del equipo e instalacion" },
-          { label: "Informacion de la practica", desc: "Datos generales, generador, tubo, colimador" },
+          {
+            label: "Informacion de la practica",
+            desc: "Datos generales, generador, tubo, colimador",
+          },
           { label: "Introduccion", desc: "Texto TECDOC normativo" },
         ].map((s) => (
           <div
@@ -528,18 +559,24 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
               key={seccion.id}
               seccion={seccion}
               catalogo={cat}
+              autoConcepto={seccion.prueba_codigo === "2.1"}
+              conceptoEfectivo={
+                !seccion.incluida
+                  ? "No_aplica"
+                  : seccion.prueba_codigo === "2.1"
+                    ? concepto21
+                    : seccion.concepto
+              }
               expanded={expandedCodigo === seccion.prueba_codigo}
               onToggleExpand={() =>
                 setExpandedCodigo(
-                  expandedCodigo === seccion.prueba_codigo ? null : seccion.prueba_codigo,
+                  expandedCodigo === seccion.prueba_codigo ? null : seccion.prueba_codigo
                 )
               }
               onToggleIncluida={() =>
                 seccion.id && updateSeccion(seccion.id, { incluida: !seccion.incluida })
               }
-              onUpdateConcepto={(v) =>
-                seccion.id && updateSeccion(seccion.id, { concepto: v })
-              }
+              onUpdateConcepto={(v) => seccion.id && updateSeccion(seccion.id, { concepto: v })}
               onUpdateAcciones={(v) =>
                 seccion.id && updateSeccion(seccion.id, { acciones_correctivas: v || undefined })
               }
@@ -642,7 +679,11 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
             </div>
 
             <div className="rounded-xl overflow-hidden border border-slate-200">
-              <iframe src={pdfUrl} className="w-full h-[600px] sm:h-[700px]" title="Pre-informe PDF" />
+              <iframe
+                src={pdfUrl}
+                className="w-full h-[600px] sm:h-[700px]"
+                title="Pre-informe PDF"
+              />
             </div>
           </CardContent>
         </Card>

--- a/src/app/dashboard/visitas/[id]/pre-informe/page.tsx
+++ b/src/app/dashboard/visitas/[id]/pre-informe/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useCallback, useEffect, useMemo, useState } from "react";
+import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
@@ -20,6 +20,7 @@ import {
   ChevronUp,
   ToggleLeft,
   ToggleRight,
+  RotateCcw,
   Zap,
   Gauge,
   SlidersHorizontal,
@@ -79,6 +80,7 @@ function SeccionCard({
   isDragging: boolean;
 }) {
   const Icon = GRUPO_ICONS[catalogo.grupo] ?? FileText;
+  const analisisRef = useRef<HTMLTextAreaElement>(null);
 
   return (
     <div
@@ -161,9 +163,9 @@ function SeccionCard({
           {autoConcepto ? (
             <div className="rounded-xl bg-slate-50 border border-slate-100 p-2.5">
               <p className="text-[10px] text-slate-500 font-medium leading-relaxed">
-                El concepto (Conforme / No conforme) se calcula automáticamente a partir de las
-                mediciones radiométricas. Usa el interruptor para marcar la prueba como no
-                aplicable.
+                {catalogo.codigo === "2.2"
+                  ? "El concepto (Favorable / No favorable) se calcula automáticamente a partir de la inspección visual, las condiciones de operación y los elementos de protección. Usa el interruptor para marcar la prueba como no aplicable."
+                  : "El concepto (Conforme / No conforme) se calcula automáticamente a partir de las mediciones radiométricas. Usa el interruptor para marcar la prueba como no aplicable."}
               </p>
             </div>
           ) : (
@@ -208,16 +210,42 @@ function SeccionCard({
             </div>
           )}
 
-          {/* Observaciones — no aplican a la 2.1 (concepto automático) */}
-          {!autoConcepto && (
+          {/* Observaciones — no aplican a la 2.1 (concepto automático).
+              Para secciones con texto de análisis (2.2) el campo se llama
+              "Análisis" y trae el texto por defecto editable, y se muestra
+              aunque el concepto sea automático. */}
+          {(catalogo.analisis || !autoConcepto) && (
             <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                Observaciones (opcional)
-              </label>
+              <div className="flex items-center justify-between gap-2">
+                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                  {catalogo.analisis ? "Análisis" : "Observaciones (opcional)"}
+                </label>
+                {catalogo.analisis && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const def = catalogo.analisis ?? "";
+                      if (analisisRef.current) analisisRef.current.value = def;
+                      onUpdateObservaciones(def);
+                    }}
+                    className="inline-flex items-center gap-1 text-[10px] font-bold text-slate-400 hover:text-primary transition-colors"
+                  >
+                    <RotateCcw className="w-3 h-3" />
+                    Restaurar predeterminado
+                  </button>
+                )}
+              </div>
               <textarea
-                className="w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none h-16 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                defaultValue={seccion.observaciones ?? ""}
-                placeholder="Notas adicionales para esta prueba..."
+                ref={analisisRef}
+                className={`w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary ${
+                  catalogo.analisis ? "h-40" : "h-16"
+                }`}
+                defaultValue={seccion.observaciones ?? catalogo.analisis ?? ""}
+                placeholder={
+                  catalogo.analisis
+                    ? "Análisis de la inspección visual..."
+                    : "Notas adicionales para esta prueba..."
+                }
                 onBlur={(e) => onUpdateObservaciones(e.target.value)}
               />
             </div>
@@ -300,7 +328,14 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
     // Mediciones de la 2.1 — su concepto se deriva de aquí, no del campo manual
     const mediciones = await db.conv_mediciones.where("visita_id").equals(visitaId).toArray();
 
-    return { visita, secciones, mediciones };
+    // Inspección y elementos de la 2.2 — su concepto también se deriva de aquí
+    const inspeccion = await db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray();
+    const elementos = await db.conv_elementos_proteccion
+      .where("visita_id")
+      .equals(visitaId)
+      .toArray();
+
+    return { visita, secciones, mediciones, inspeccion, elementos };
   }, [isReady, visitaId]);
 
   // Concepto calculado de la 2.1: No conforme si algún punto lo es; Conforme
@@ -310,6 +345,16 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
     if (mediciones.length === 0) return undefined;
     return mediciones.some((m) => m.concepto === "No_conforme") ? "No_conforme" : "Conforme";
   }, [data?.mediciones]);
+
+  // Concepto calculado de la 2.2: No conforme si algún ítem de inspección o
+  // elemento de protección lo es; Conforme en caso contrario (FAVORABLE por
+  // defecto, igual que la fórmula de la plantilla).
+  const concepto22 = useMemo<ConceptoType>(() => {
+    const hayNoConforme =
+      (data?.inspeccion ?? []).some((i) => i.concepto === "No_conforme") ||
+      (data?.elementos ?? []).some((e) => e.concepto === "No_conforme");
+    return hayNoConforme ? "No_conforme" : "Conforme";
+  }, [data?.inspeccion, data?.elementos]);
 
   // ─── Initialize secciones from catalog ───
   useEffect(() => {
@@ -375,7 +420,9 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
     // Para la 2.1 el concepto se deriva de las mediciones, no del campo manual.
     const conceptoDe = (s: ConvInformeSeccion): ConceptoType | undefined => {
       if (!s.incluida) return "No_aplica";
-      return s.prueba_codigo === "2.1" ? concepto21 : s.concepto;
+      if (s.prueba_codigo === "2.1") return concepto21;
+      if (s.prueba_codigo === "2.2") return concepto22;
+      return s.concepto;
     };
     const conformes = secciones.filter((s) => conceptoDe(s) === "Conforme").length;
     const noConformes = secciones.filter((s) => conceptoDe(s) === "No_conforme").length;
@@ -559,13 +606,15 @@ export default function PreInformePage({ params }: { params: Promise<{ id: strin
               key={seccion.id}
               seccion={seccion}
               catalogo={cat}
-              autoConcepto={seccion.prueba_codigo === "2.1"}
+              autoConcepto={seccion.prueba_codigo === "2.1" || seccion.prueba_codigo === "2.2"}
               conceptoEfectivo={
                 !seccion.incluida
                   ? "No_aplica"
                   : seccion.prueba_codigo === "2.1"
                     ? concepto21
-                    : seccion.concepto
+                    : seccion.prueba_codigo === "2.2"
+                      ? concepto22
+                      : seccion.concepto
               }
               expanded={expandedCodigo === seccion.prueba_codigo}
               onToggleExpand={() =>

--- a/src/components/ubicacion-form-dialog.tsx
+++ b/src/components/ubicacion-form-dialog.tsx
@@ -43,7 +43,20 @@ export function UbicacionFormDialog({
   const [fechaExp, setFechaExp] = useState(ubicacion?.fecha_expiracion_licencia ?? "");
   const [codigo, setCodigo] = useState(ubicacion?.codigo_habilitacion ?? "");
   const [horas, setHoras] = useState(ubicacion?.horas_x_dia?.toString() ?? "");
+  // Sala y blindaje
+  const [ubicFisica, setUbicFisica] = useState(ubicacion?.ubicacion_fisica ?? "");
+  const [ancho, setAncho] = useState(ubicacion?.ancho_m?.toString() ?? "");
+  const [largo, setLargo] = useState(ubicacion?.largo_m?.toString() ?? "");
+  const [alto, setAlto] = useState(ubicacion?.alto_m?.toString() ?? "");
+  const [zonaA, setZonaA] = useState(ubicacion?.zona_a_desc ?? "");
+  const [zonaB, setZonaB] = useState(ubicacion?.zona_b_desc ?? "");
+  const [zonaC, setZonaC] = useState(ubicacion?.zona_c_desc ?? "");
+  const [zonaD, setZonaD] = useState(ubicacion?.zona_d_desc ?? "");
   const [saving, setSaving] = useState(false);
+
+  // Área = ancho × largo (autocalculada)
+  const areaCalc =
+    ancho && largo ? Math.round(parseFloat(ancho) * parseFloat(largo) * 100) / 100 : undefined;
 
   function resetForm() {
     setNombre(ubicacion?.nombre_servicio ?? "");
@@ -51,6 +64,14 @@ export function UbicacionFormDialog({
     setFechaExp(ubicacion?.fecha_expiracion_licencia ?? "");
     setCodigo(ubicacion?.codigo_habilitacion ?? "");
     setHoras(ubicacion?.horas_x_dia?.toString() ?? "");
+    setUbicFisica(ubicacion?.ubicacion_fisica ?? "");
+    setAncho(ubicacion?.ancho_m?.toString() ?? "");
+    setLargo(ubicacion?.largo_m?.toString() ?? "");
+    setAlto(ubicacion?.alto_m?.toString() ?? "");
+    setZonaA(ubicacion?.zona_a_desc ?? "");
+    setZonaB(ubicacion?.zona_b_desc ?? "");
+    setZonaC(ubicacion?.zona_c_desc ?? "");
+    setZonaD(ubicacion?.zona_d_desc ?? "");
   }
 
   async function handleSave() {
@@ -65,6 +86,15 @@ export function UbicacionFormDialog({
         fecha_expiracion_licencia: fechaExp || undefined,
         codigo_habilitacion: codigo || undefined,
         horas_x_dia: horas ? parseInt(horas, 10) : undefined,
+        ubicacion_fisica: ubicFisica || undefined,
+        ancho_m: ancho ? parseFloat(ancho) : undefined,
+        largo_m: largo ? parseFloat(largo) : undefined,
+        alto_m: alto ? parseFloat(alto) : undefined,
+        area_m2: areaCalc,
+        zona_a_desc: zonaA || undefined,
+        zona_b_desc: zonaB || undefined,
+        zona_c_desc: zonaC || undefined,
+        zona_d_desc: zonaD || undefined,
         creado_en: now,
         sync_status: "pending",
         last_modified: now,
@@ -97,7 +127,7 @@ export function UbicacionFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="rounded-3xl border-none shadow-2xl p-0 overflow-hidden sm:max-w-md">
+      <DialogContent className="rounded-3xl border-none shadow-2xl p-0 overflow-hidden sm:max-w-lg">
         <DialogHeader className="bg-gradient-to-br from-primary/5 to-primary/10 p-6 border-b border-primary/10">
           <DialogTitle className="text-xl font-black text-slate-900 tracking-tight">
             {isEdit ? "Editar Ubicación" : "Nueva Ubicación RX"}
@@ -107,7 +137,7 @@ export function UbicacionFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="p-6 space-y-4">
+        <div className="p-6 space-y-4 max-h-[65vh] overflow-y-auto">
           <div className="space-y-2">
             <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
               Nombre del Servicio *
@@ -170,6 +200,101 @@ export function UbicacionFormDialog({
                 value={horas}
                 onChange={(e) => setHoras(e.target.value)}
               />
+            </div>
+          </div>
+
+          {/* ─── Sala y blindaje ─── */}
+          <div className="pt-2 border-t border-slate-100">
+            <p className="text-xs font-black text-primary uppercase tracking-widest mb-1">
+              Sala y blindaje
+            </p>
+            <p className="text-[11px] text-slate-400 font-medium mb-3">
+              Dimensiones del recinto y colindancias — se usan en la prueba 2.2 del informe.
+            </p>
+
+            <div className="space-y-2 mb-3">
+              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                Ubicación física del equipo
+              </Label>
+              <Input
+                className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
+                placeholder="Ej: primer piso de las instalaciones"
+                value={ubicFisica}
+                onChange={(e) => setUbicFisica(e.target.value)}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
+              <div className="space-y-2">
+                <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                  Ancho (m)
+                </Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
+                  placeholder="3.40"
+                  value={ancho}
+                  onChange={(e) => setAncho(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                  Largo (m)
+                </Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
+                  placeholder="6.10"
+                  value={largo}
+                  onChange={(e) => setLargo(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                  Alto (m)
+                </Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
+                  placeholder="2.30"
+                  value={alto}
+                  onChange={(e) => setAlto(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                  Área (m²)
+                </Label>
+                <div className="rounded-xl bg-slate-50 border border-slate-200 font-bold text-slate-700 h-11 flex items-center px-3">
+                  {areaCalc != null ? areaCalc.toFixed(2) : "—"}
+                </div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {(
+                [
+                  ["A", zonaA, setZonaA],
+                  ["B", zonaB, setZonaB],
+                  ["C", zonaC, setZonaC],
+                  ["D", zonaD, setZonaD],
+                ] as const
+              ).map(([z, val, setter]) => (
+                <div key={z} className="space-y-2">
+                  <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                    Zona {z}
+                  </Label>
+                  <textarea
+                    className="w-full rounded-xl border border-slate-200 p-2.5 text-sm font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                    placeholder="Limita con… / puertas / barreras"
+                    value={val}
+                    onChange={(e) => setter(e.target.value)}
+                  />
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -107,6 +107,18 @@ export interface UbicacionRx extends Partial<SyncFields> {
   fecha_expiracion_licencia?: string;
   codigo_habilitacion?: string;
   horas_x_dia?: number;
+  // Sala y blindaje (precarga del informe 2.2)
+  /** Ubicación física del equipo: "primer piso de las instalaciones..." */
+  ubicacion_fisica?: string;
+  ancho_m?: number;
+  largo_m?: number;
+  alto_m?: number;
+  /** Área en m² — calculada al guardar (ancho × largo) */
+  area_m2?: number;
+  zona_a_desc?: string;
+  zona_b_desc?: string;
+  zona_c_desc?: string;
+  zona_d_desc?: string;
   creado_en?: string;
 }
 

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -17,6 +17,8 @@ export interface SeccionInfoCatalogo {
   metodologia: string;
   /** Texto del criterio de aceptación para el PDF */
   criterio: string;
+  /** Texto por defecto del análisis (editable por el físico, p.ej. 2.2) */
+  analisis?: string;
 }
 
 export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
@@ -36,17 +38,19 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
   },
   {
     codigo: "2.2",
-    nombre: "Inspeccion visual, descripcion de la instalacion y blindajes",
+    nombre: "Inspección visual, descripción de la instalación y blindajes",
     grupo: "A",
     orden: 2,
     objetivo:
-      "Verificar mediante inspeccion visual el estado fisico y las condiciones de seguridad del equipo de radiografia general y de su instalacion.",
+      "Verificar mediante inspección visual el estado físico y las condiciones de seguridad del equipo de radiografía general y de su instalación, con el fin de identificar posibles deterioros, defectos mecánicos o condiciones que puedan afectar la protección radiológica del operador, los pacientes o el público.",
     instrumentacion:
-      "Inspeccion visual directa del equipo y de la instalacion, utilizando herramientas basicas de verificacion cuando aplica.",
+      "Inspección visual directa del equipo y de la instalación, utilizando herramientas básicas de verificación cuando aplica.",
     metodologia:
-      "Se realizo una inspeccion visual del equipo y de las condiciones de operacion de la instalacion mediante una lista de verificacion basada en los lineamientos del IAEA-TECDOC-1958.",
+      "Se realizó una inspección visual del equipo y de las condiciones de operación de la instalación mediante una lista de verificación basada en los lineamientos del IAEA-TECDOC-1958 y en los criterios de seguridad aplicables a equipos de radiología general.",
     criterio:
-      "La inspeccion visual se considera aceptable cuando los componentes visibles del equipo y las condiciones de operacion se encuentran en buen estado fisico.",
+      "La inspección visual se considera aceptable cuando los componentes visibles del equipo y las condiciones de operación de la instalación se encuentran en buen estado físico, sin deterioros, fugas o defectos que puedan comprometer la protección radiológica del operador, los pacientes o el público.",
+    analisis:
+      "La inspección visual realizada al equipo de radiografía general y a las condiciones de operación de la instalación permitió verificar que los componentes visibles del sistema de rayos X se encuentran en adecuado estado físico, con el fin de identificar deterioros, fugas de aceite, daños mecánicos o anomalías en los cables de alimentación y control.\n\nAsimismo, se revisaron las condiciones de operación del equipo, la señalización de radioprotección y los elementos de seguridad presentes en la instalación para determinar si son consistentes con los requerimientos para la operación segura del equipo evaluado.",
   },
   {
     codigo: "2.3",
@@ -98,8 +102,7 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     instrumentacion: "Analizador de rayos X RaySafe X2 con detector para radiodiagnostico.",
     metodologia:
       "Se posiciono el medidor no invasivo sobre la mesa, en el centro del haz de radiacion. Se realizaron exposiciones registrando la CHR reportada por el analizador.",
-    criterio:
-      "CHR a 60 kVp >= 1.8 mm Al, a 70 kVp >= 2.1, a 80 kVp >= 2.3, a 90 kVp >= 2.5.",
+    criterio: "CHR a 60 kVp >= 1.8 mm Al, a 70 kVp >= 2.1, a 80 kVp >= 2.3, a 90 kVp >= 2.5.",
   },
   {
     codigo: "2.7",
@@ -111,8 +114,7 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     instrumentacion: "Analizador de rayos X RaySafe X2 con detector para radiodiagnostico.",
     metodologia:
       "Se posiciono el detector del sistema dosimetrico a aproximadamente 100 cm del foco del tubo de rayos X. Se selecciono un valor de 80 kV como tension de referencia.",
-    criterio:
-      "CV de repetibilidad <= 5%. Desviacion de linealidad <= 10%.",
+    criterio: "CV de repetibilidad <= 5%. Desviacion de linealidad <= 10%.",
   },
   {
     codigo: "2.8",
@@ -121,8 +123,7 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     orden: 8,
     objetivo:
       "Verificar si el medidor de dosis-area (DAP meter) del equipo esta calibrado correctamente, calculando un factor de correccion.",
-    instrumentacion:
-      "Sensor RaySafe X2 RF, cinta metrica, regla para medir campo de irradiacion.",
+    instrumentacion: "Sensor RaySafe X2 RF, cinta metrica, regla para medir campo de irradiacion.",
     metodologia:
       "Se usaron los mismos programas clinicos (Extremidad, Torax, Columna). Se midio el Kerma en aire con el sensor y el area del campo de irradiacion.",
     criterio:
@@ -181,8 +182,7 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     nombre: "Umbral de sensibilidad a bajo contraste",
     grupo: "E",
     orden: 13,
-    objetivo:
-      "Evaluar la capacidad del sistema para detectar diferencias sutiles de contraste.",
+    objetivo: "Evaluar la capacidad del sistema para detectar diferencias sutiles de contraste.",
     instrumentacion:
       "Patron de bajo contraste (phantom con insertos de diferente densidad), Detector de imagen.",
     metodologia:

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -30,7 +30,7 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     instrumentacion:
       "Sistema dosimetrico calibrado para mediciones en proteccion radiologica (camara de ionizacion o detector de estado solido), material equivalente simulador de radiacion dispersa y cinta metrica.",
     metodologia:
-      "Se realizo el levantamiento radiometrico mediante mediciones de radiacion dispersa en puntos representativos del area donde se encuentra instalado el equipo de radiologia general. Las mediciones se efectuaron utilizando una camara de ionizacion o un detector de estado solido calibrado en terminos de dosis equivalente ambiental H*(10).",
+      "Se realizó el levantamiento radiométrico mediante mediciones de radiación dispersa en puntos representativos del área donde se encuentra instalado el equipo de radiología general. Las mediciones se efectuaron utilizando una cámara de ionización o un detector de estado sólido calibrado en términos de dosis equivalente ambiental H*(10), posicionando un simulador de dispersión en la ubicación habitual del paciente durante la exposición, aplicando la técnica máxima utilizada en la práctica clínica. Los puntos de medición evaluados se presentan en el diagrama radiométrico de la instalación.",
     criterio:
       "Area controlada (trabajadores): H*(10) <= 5 mSv/ano. Area supervisada (publico): H*(10) <= 0.5 mSv/ano.",
   },

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -22,6 +22,7 @@ import {
   recopilarDatosConv,
   renderResultadosSeccion,
   renderDiagramaRadiometrico,
+  renderFotos22,
   type InformeCtx,
 } from "./secciones-convencional";
 
@@ -718,7 +719,15 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         addParagraph("NO APLICA.");
         nextSub = 5;
       } else {
-        nextSub = renderResultadosSeccion(ctx, codigo, datos.visita, conv, datos.sala);
+        nextSub = renderResultadosSeccion(ctx, codigo, datos.visita, conv, datos.ubicacion);
+      }
+
+      // Análisis (solo 2.2) — usa el campo observaciones como texto editable,
+      // con el texto por defecto del catálogo si el físico no lo modificó.
+      if (codigo === "2.2" && aplica) {
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Análisis");
+        addParagraph(seccion.observaciones?.trim() || cat.analisis || "");
+        nextSub++;
       }
 
       // Criterio de aceptación
@@ -732,12 +741,21 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         nextSub = 8;
       }
 
+      // Fotografías (solo 2.2) — entre Criterio y Concepto
+      if (codigo === "2.2" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Fotografías");
+        renderFotos22(ctx, conv);
+        nextSub++;
+      }
+
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
       addSubsectionTitle(`${codigo}.${nextSub}.`, "Concepto");
       nextSub++;
       const c = seccion.concepto;
       const esAuto21 = codigo === "2.1" && aplica;
+      const esAuto22 = codigo === "2.2" && aplica;
 
       let conceptoLabel: string;
       let conceptoParrafo: string | undefined;
@@ -746,7 +764,26 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         ? seccion.acciones_correctivas
         : "No se requieren acciones correctivas.";
 
-      if (esAuto21) {
+      if (esAuto22) {
+        // Concepto derivado de la inspección visual: NO FAVORABLE si hay algún
+        // "No conforme" en inspección del equipo, condiciones de operación o
+        // elementos de protección.
+        esNoConforme =
+          conv.inspeccion.some((i) => i.concepto === "No_conforme") ||
+          conv.elementos.some((e) => e.concepto === "No_conforme");
+        if (esNoConforme) {
+          conceptoLabel = "NO FAVORABLE";
+          conceptoParrafo =
+            "La inspección visual evidenció condiciones que requieren corrección, al identificarse elementos que no cumplen con los criterios de aceptación establecidos para el estado físico del equipo, las condiciones de operación o los elementos de protección radiológica.";
+          accionesTexto =
+            "Se recomienda corregir las condiciones no conformes identificadas durante la inspección visual y verificar nuevamente el cumplimiento de los criterios establecidos antes de continuar con la operación del equipo.";
+        } else {
+          conceptoLabel = "FAVORABLE";
+          conceptoParrafo =
+            "La inspección visual evidenció que el estado físico del equipo, las condiciones de operación de la instalación y los elementos de protección radiológica cumplen con los criterios establecidos para la operación segura del equipo evaluado.";
+          accionesTexto = "No se requieren acciones correctivas.";
+        }
+      } else if (esAuto21) {
         const hayMediciones = conv.mediciones.length > 0;
         esNoConforme = hayMediciones && conv.mediciones.some((m) => m.concepto === "No_conforme");
         if (!hayMediciones) {
@@ -783,8 +820,9 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
       if (conceptoParrafo) {
         addParagraph(conceptoParrafo);
       }
-      // La 2.1 no lleva observaciones (concepto automático)
-      if (codigo !== "2.1" && seccion.observaciones?.trim()) {
+      // La 2.1 no lleva observaciones (concepto automático); la 2.2 usa el
+      // campo observaciones como Análisis (renderizado arriba), no aquí.
+      if (codigo !== "2.1" && codigo !== "2.2" && seccion.observaciones?.trim()) {
         addParagraph(seccion.observaciones);
       }
 

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -680,12 +680,15 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
       addSubsectionTitle,
     };
 
-    const incluidas = conv.secciones.filter((s) => s.incluida).sort((a, b) => a.orden - b.orden);
+    // Todas las pruebas aparecen en el informe; el switch (incluida) decide si
+    // la prueba APLICA (se evalúa) o NO APLICA (se documenta como no aplicable).
+    const todasSecciones = [...conv.secciones].sort((a, b) => a.orden - b.orden);
 
-    for (const seccion of incluidas) {
+    for (const seccion of todasSecciones) {
       const cat = getCatalogoSeccion(seccion.prueba_codigo);
       if (!cat) continue;
       const codigo = seccion.prueba_codigo;
+      const aplica = seccion.incluida;
 
       // Título de la prueba
       checkPage(60);
@@ -710,7 +713,7 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
 
       // Resultados (+ análisis en 2.1, descripción en 2.2)
       let nextSub: number;
-      if (seccion.concepto === "No_aplica") {
+      if (!aplica) {
         addSubsectionTitle(`${codigo}.4.`, "Resultados");
         addParagraph("NO APLICA.");
         nextSub = 5;
@@ -724,17 +727,17 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
       nextSub++;
 
       // Diagrama radiométrico (solo 2.1)
-      if (codigo === "2.1" && seccion.concepto !== "No_aplica") {
+      if (codigo === "2.1" && aplica) {
         renderDiagramaRadiometrico(ctx, conv);
         nextSub = 8;
       }
 
-      // Concepto — en la 2.1 se deriva de las mediciones (el físico solo decide "No aplica")
+      // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
       addSubsectionTitle(`${codigo}.${nextSub}.`, "Concepto");
       nextSub++;
       const c = seccion.concepto;
-      const esAuto21 = codigo === "2.1" && c !== "No_aplica";
+      const esAuto21 = codigo === "2.1" && aplica;
 
       let conceptoLabel: string;
       let conceptoParrafo: string | undefined;
@@ -760,15 +763,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
             "Las dosis equivalentes anuales estimadas en las áreas evaluadas se encuentran por debajo de los niveles de restricción de dosis establecidos para áreas controladas y supervisadas, por lo que las condiciones radiológicas de la instalación se consideran aceptables para la operación del equipo evaluado.";
           accionesTexto = "No se requieren acciones correctivas.";
         }
+      } else if (!aplica) {
+        conceptoLabel = "NO APLICA";
+        esNoConforme = false;
       } else {
         conceptoLabel =
-          c === "Conforme"
-            ? "CONFORME"
-            : c === "No_conforme"
-              ? "NO CONFORME"
-              : c === "No_aplica"
-                ? "NO APLICA"
-                : "PENDIENTE";
+          c === "Conforme" ? "CONFORME" : c === "No_conforme" ? "NO CONFORME" : "PENDIENTE";
       }
 
       doc.setFont("helvetica", "bold");
@@ -783,7 +783,8 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
       if (conceptoParrafo) {
         addParagraph(conceptoParrafo);
       }
-      if (seccion.observaciones?.trim()) {
+      // La 2.1 no lleva observaciones (concepto automático)
+      if (codigo !== "2.1" && seccion.observaciones?.trim()) {
         addParagraph(seccion.observaciones);
       }
 

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -195,23 +195,40 @@ function render21(ctx: InformeCtx, visita: VisitaEjecucion, conv: DatosConvencio
   // .4 Resultados
   ctx.addSubsectionTitle(`${cod}.4.`, "Resultados");
   ctx.addParagraph(
-    "Se registraron las lecturas de tasa de dosis equivalente ambiental H*(10) en los puntos de medición definidos en el diagrama radiométrico de la instalación."
+    "Se registraron las lecturas de tasa de dosis equivalente ambiental H*(10) en los puntos de medición definidos en el diagrama radiométrico. Las mediciones se realizaron utilizando la técnica radiográfica máxima empleada en la práctica clínica del equipo evaluado."
   );
 
-  const tecnica = [
-    `Tensión (kV): ${fmt(setup?.tecnica_kv, 0)}`,
-    `Corriente (mA): ${fmt(setup?.tecnica_ma, 0)}`,
-    `Tiempo (s): ${fmt(setup?.tecnica_tiempo_s, 2)}`,
-    `Exposición (mAs): ${fmt(setup?.tecnica_mas, 0)}`,
-  ].join("    ");
-  ctx.addParagraph(`Técnica utilizada:    ${tecnica}`);
+  // Técnica utilizada y fondo natural — tabla compacta de 4 columnas (clave/valor)
+  ctx.checkPage(24);
+  addCaption(ctx, "Técnica radiográfica utilizada en la prueba");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    body: [
+      ["Tensión (kV)", fmt(setup?.tecnica_kv, 0), "Tiempo (s)", fmt(setup?.tecnica_tiempo_s, 2)],
+      ["Corriente (mA)", fmt(setup?.tecnica_ma, 0), "Exposición (mAs)", fmt(setup?.tecnica_mas, 0)],
+      [
+        "Fondo natural (mSv/h)",
+        {
+          content:
+            setup?.fondo_natural_usv_h != null
+              ? (setup.fondo_natural_usv_h / 1000).toFixed(5)
+              : "—",
+          colSpan: 3,
+          styles: { fontStyle: "normal", fillColor: [255, 255, 255] },
+        },
+      ],
+    ],
+    columnStyles: {
+      0: { cellWidth: 45, fontStyle: "bold", fillColor: COLOR_ALT_ROW },
+      1: { cellWidth: 40 },
+      2: { cellWidth: 45, fontStyle: "bold", fillColor: COLOR_ALT_ROW },
+      3: { cellWidth: 40 },
+    },
+  });
+  ctx.y = finalY(doc) + 4;
   ctx.addParagraph(
-    `Fondo natural de radiación ionizante (mSv/h): ${
-      setup?.fondo_natural_usv_h != null ? (setup.fondo_natural_usv_h / 1000).toFixed(5) : "—"
-    }`
-  );
-  ctx.addParagraph(
-    "En cada punto se realizaron varias mediciones consecutivas, registrándose el valor máximo obtenido para su posterior análisis."
+    "En cada punto se realizaron varias mediciones consecutivas, registrándose el valor máximo obtenido para su posterior análisis. Los resultados se presentan a continuación."
   );
 
   if (conv.mediciones.length === 0) {
@@ -323,9 +340,7 @@ export function renderDiagramaRadiometrico(ctx: InformeCtx, conv: DatosConvencio
   try {
     const x = MARGIN + (170 - w) / 2;
     ctx.doc.addImage(plano.dataUrl, x, ctx.y, w, h);
-    ctx.y += h + 4;
-    addCaption(ctx, "Figura 2.1.1. Diagrama radiométrico de la instalación");
-    ctx.y += 2;
+    ctx.y += h + 6;
   } catch {
     ctx.addParagraph("No fue posible incluir la imagen del plano radiométrico.");
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1,7 +1,7 @@
 import type { jsPDF } from "jspdf";
 import type autoTableType from "jspdf-autotable";
 import { db } from "@/lib/db";
-import type { VisitaEjecucion, SalaDimensiones } from "@/lib/db/types";
+import type { VisitaEjecucion, UbicacionRx } from "@/lib/db/types";
 import type {
   ConvLevantamientoSetup,
   ConvMedicionRadiometrica,
@@ -68,6 +68,8 @@ export interface DatosConvencional {
   resultados: Map<string, ConvResultadoPrueba>;
   /** Imagen del plano radiométrico (2.1) como dataURL, si existe */
   planoRadiometrico?: { dataUrl: string; width: number; height: number };
+  /** Fotografías de la 2.2 (equipo, consola, avisos, elementos) para la sección 2.2.8 */
+  fotos22?: { label: string; dataUrl: string; width: number; height: number }[];
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -119,6 +121,28 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     (e) => e.prueba_codigo === "2.1" && e.slot === "plano_radiometrico"
   );
 
+  // Fotografías de la 2.2 (sección 2.2.8): orden fijo + una por elemento
+  const SLOTS_FOTOS_22: [string, string][] = [
+    ["equipo_rayos_x", "Equipo de rayos X"],
+    ["consola", "Consola del equipo"],
+    ["aviso_proteccion_1", "Aviso de protección radiológica"],
+    ["aviso_proteccion_2", "Aviso de protección radiológica"],
+    ["aviso_proteccion_3", "Aviso de protección radiológica"],
+  ];
+  const fotos22: NonNullable<DatosConvencional["fotos22"]> = [];
+  for (const [slot, label] of SLOTS_FOTOS_22) {
+    const ev = evidencias.find((e) => e.prueba_codigo === "2.2" && e.slot === slot);
+    const img = await cargarImagen(ev);
+    if (img) fotos22.push({ label, ...img });
+  }
+  for (const elem of elementos) {
+    const ev = evidencias.find(
+      (e) => e.prueba_codigo === "2.2" && e.slot === `elemento_${elem.id}`
+    );
+    const img = await cargarImagen(ev);
+    if (img) fotos22.push({ label: elem.descripcion?.trim() || "Elemento de protección", ...img });
+  }
+
   return {
     secciones: seccionesEfectivas,
     setup,
@@ -127,6 +151,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     elementos,
     resultados: new Map(resultadosArr.map((r) => [r.prueba_codigo, r])),
     planoRadiometrico: await cargarImagen(planoEv),
+    fotos22,
   };
 }
 
@@ -346,12 +371,51 @@ export function renderDiagramaRadiometrico(ctx: InformeCtx, conv: DatosConvencio
   }
 }
 
+/** Subsección 2.2.8: fotografías de la inspección (equipo, consola, avisos, elementos) */
+export function renderFotos22(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos22 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntaron fotografías de la inspección visual.");
+    return;
+  }
+
+  const colW = 82; // ancho por columna (mm)
+  const gap = 6;
+  const maxImgH = 55;
+
+  for (let i = 0; i < fotos.length; i += 2) {
+    const pair = fotos.slice(i, i + 2).map((f) => {
+      const scale = Math.min(colW / f.width, maxImgH / f.height);
+      return { ...f, w: f.width * scale, h: f.height * scale };
+    });
+    const rowH = Math.max(...pair.map((r) => r.h)) + 7; // imagen + rótulo
+    ctx.checkPage(rowH + 2);
+    const startY = ctx.y;
+
+    pair.forEach((r, idx) => {
+      const x = MARGIN + idx * (colW + gap);
+      try {
+        doc.addImage(r.dataUrl, x, startY, r.w, r.h);
+      } catch {
+        // imagen no renderizable — se omite el cuadro
+      }
+      doc.setFont("helvetica", "italic");
+      doc.setFontSize(7);
+      doc.setTextColor(...COLOR_GRAY);
+      doc.text(`Fig. ${r.label}`, x, startY + r.h + 4);
+    });
+
+    ctx.y = startY + rowH + 2;
+  }
+}
+
 // ─── Renderizador 2.2: Inspección visual ───
 
 function render22(
   ctx: InformeCtx,
   conv: DatosConvencional,
-  sala: SalaDimensiones | undefined
+  ubicacion: UbicacionRx | undefined
 ): number {
   const { doc, autoTable } = ctx;
   const cod = "2.2";
@@ -359,16 +423,63 @@ function render22(
   // .4 Descripción de la instalación y blindajes
   ctx.addSubsectionTitle(`${cod}.4.`, "Descripción de la instalación y blindajes");
   ctx.addParagraph(
-    "La distribución de las áreas colindantes y de las barreras estructurales de protección radiológica se presenta en el diagrama radiométrico de la instalación (Figura 2.1.1)."
+    "La distribución de las áreas colindantes y de las barreras estructurales de protección radiológica se presenta en el diagrama radiométrico de la instalación."
   );
-  if (sala?.ancho_m || sala?.largo_m || sala?.alto_m) {
+  if (ubicacion?.ubicacion_fisica?.trim()) {
+    ctx.addParagraph(`El equipo se encuentra ubicado en el ${ubicacion.ubicacion_fisica.trim()}.`);
+  }
+
+  // Zonas colindantes en tabla (en vez de párrafos sueltos)
+  const zonas = (
+    [
+      ["A", ubicacion?.zona_a_desc],
+      ["B", ubicacion?.zona_b_desc],
+      ["C", ubicacion?.zona_c_desc],
+      ["D", ubicacion?.zona_d_desc],
+    ] as const
+  )
+    .filter(([, desc]) => desc?.trim())
+    .map(([z, desc]) => [z, desc!.trim()]);
+
+  if (zonas.length > 0) {
+    ctx.checkPage(14 + zonas.length * 8);
+    addCaption(ctx, "Áreas colindantes y barreras estructurales");
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      startY: ctx.y,
+      head: [["Zona", "Descripción de la colindancia y barreras"]],
+      body: zonas,
+      columnStyles: { 0: { cellWidth: 16, halign: "center", fontStyle: "bold" } },
+    });
+    ctx.y = finalY(doc) + 4;
+  }
+
+  // Dimensiones de la sala en mini-tabla horizontal
+  if (ubicacion?.ancho_m || ubicacion?.largo_m || ubicacion?.alto_m) {
     const area =
-      sala.ancho_m && sala.largo_m ? ` — Área: ${(sala.ancho_m * sala.largo_m).toFixed(2)} m²` : "";
-    ctx.addParagraph(
-      `Las dimensiones de la sala son: Ancho: ${fmt(sala.ancho_m)} m — Largo: ${fmt(
-        sala.largo_m
-      )} m — Altura: ${fmt(sala.alto_m)} m${area}.`
-    );
+      ubicacion.area_m2 != null
+        ? `${ubicacion.area_m2.toFixed(2)} m²`
+        : ubicacion.ancho_m && ubicacion.largo_m
+          ? `${(ubicacion.ancho_m * ubicacion.largo_m).toFixed(2)} m²`
+          : "—";
+    ctx.checkPage(20);
+    addCaption(ctx, "Dimensiones de la sala");
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      startY: ctx.y,
+      head: [["Ancho", "Largo", "Altura", "Área"]],
+      body: [
+        [
+          `${fmt(ubicacion.ancho_m)} m`,
+          `${fmt(ubicacion.largo_m)} m`,
+          `${fmt(ubicacion.alto_m)} m`,
+          area,
+        ],
+      ],
+      bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" },
+      headStyles: { ...TABLE_STYLE.headStyles, halign: "center" },
+    });
+    ctx.y = finalY(doc) + 4;
   }
 
   // .5 Resultados
@@ -489,13 +600,13 @@ export function renderResultadosSeccion(
   codigo: string,
   visita: VisitaEjecucion,
   conv: DatosConvencional,
-  sala: SalaDimensiones | undefined
+  ubicacion: UbicacionRx | undefined
 ): number {
   switch (codigo) {
     case "2.1":
       return render21(ctx, visita, conv);
     case "2.2":
-      return render22(ctx, conv, sala);
+      return render22(ctx, conv, ubicacion);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -95,6 +95,15 @@ export interface Database {
           fecha_expiracion_licencia: string | null;
           codigo_habilitacion: string | null;
           horas_x_dia: number | null;
+          ubicacion_fisica: string | null;
+          ancho_m: number | null;
+          largo_m: number | null;
+          alto_m: number | null;
+          area_m2: number | null;
+          zona_a_desc: string | null;
+          zona_b_desc: string | null;
+          zona_c_desc: string | null;
+          zona_d_desc: string | null;
           creado_en: string;
         };
         Insert: Omit<Database["public"]["Tables"]["ubicaciones_rx"]["Row"], "id" | "creado_en"> & {

--- a/supabase/migrations/008_ubicacion_sala_blindaje.sql
+++ b/supabase/migrations/008_ubicacion_sala_blindaje.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+--  Migración 008: Sala y blindaje en ubicaciones_rx
+--
+--  Se capturan las dimensiones de la sala y la descripción de
+--  zonas A–D directamente en la ubicación RX (no en una tabla
+--  aparte), ya que pertenecen al recinto y se reutilizan en
+--  todas las visitas/equipos de esa sala.
+-- ============================================================
+
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS ubicacion_fisica TEXT;
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS ancho_m NUMERIC(6, 2);
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS largo_m NUMERIC(6, 2);
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS alto_m NUMERIC(6, 2);
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS area_m2 NUMERIC(8, 2);
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS zona_a_desc TEXT;
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS zona_b_desc TEXT;
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS zona_c_desc TEXT;
+ALTER TABLE ubicaciones_rx ADD COLUMN IF NOT EXISTS zona_d_desc TEXT;


### PR DESCRIPTION
## Resumen

Refinamientos del informe convencional (pruebas 2.1 y 2.2) tras revisión contra la plantilla CE_NIT.

- **El switch de cada prueba ahora significa aplica / no aplica.** Todas las pruebas aparecen en el informe; el switch apagado marca la prueba como "NO APLICA" en lugar de omitirla.
- **2.1:** se quita el selector manual de concepto (se calcula automáticamente de las mediciones). Las demás pruebas dejan solo Conforme / No conforme (el "No aplica" lo maneja el switch).
- Badge de cabecera y contador del pre-informe reflejan el concepto efectivo (calculado para la 2.1, switch apagado = No aplica).
- Se quita el pie de figura del diagrama radiométrico que rompía la numeración del informe.
- "Técnica utilizada" y "fondo natural" ahora se muestran en una tabla compacta en vez de texto plano.
- Textos de metodología (2.1.3) y resultados (2.1.4) alineados literalmente con la plantilla CE_NIT.

## Test plan

- [x] Generar el pre-informe de una visita convencional y verificar que las 21 pruebas aparecen; las del switch apagado salen como NO APLICA.
- [x] 2.1 con puntos conformes → FAVORABLE; con algún no conforme → NO FAVORABLE + acción automática.
- [x] Verificar la tabla de técnica/fondo natural y que el diagrama ya no tiene pie de figura.
- [x] Confirmar que metodología y resultados de la 2.1 coinciden con CE_NIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
