### PR TITLE
feat: implementar secciones 2.8–2.13 del informe convencional y correcciones

### DIFF
--- a/AUDITORIA_PRUEBAS.md
+++ b/AUDITORIA_PRUEBAS.md
@@ -204,6 +204,7 @@ El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label 
 | 2.10 | ✅ Completa | Textos corregidos; render210 con Tabla 2.10.1 (CV); 2.10.7 evidencia gráfica; 2.10.8 concepto FAVORABLE/NO FAVORABLE basado en CV del EI |
 | 2.11 | ✅ Completa | Textos corregidos; render211 con Tabla 2.11.1 (AC 0°) y Tabla 2.11.2 (CA 180°) por detector; campos desviación y tolerancia agregados al tipo; 2.11.7 evidencia gráfica (dicom_0 y dicom_180); 2.11.8 concepto FAVORABLE/NO FAVORABLE basado en uniformidad, píxeles defectuosos y artefactos |
 | 2.12 | ✅ Completa | Textos corregidos; render212 con condiciones + tabla pares de líneas + análisis dinámico; 2.12.7 evidencia gráfica (montaje_resolucion); 2.12.8 concepto FAVORABLE/NO FAVORABLE si pares_lineas_plmm >= 2,4 |
+| 2.13 | ✅ Completa | Textos corregidos; render213 con Tabla 2.13.1 (visibilidad 8 niveles contraste) + análisis dinámico; 2.13.7 evidencia gráfica (montaje_bajo_contraste); 2.13.8 concepto FAVORABLE si visibles > 3 o nivel < 4% |
 
 ## Pruebas pendientes
 
@@ -214,7 +215,6 @@ El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label 
 - [ ] 2.5 — Exactitud y repetibilidad de la tensión
 - [ ] 2.6 — Capa hemirreductora (CHR)
 - [ ] 2.7 — Rendimiento, repetibilidad y linealidad
-- [ ] 2.13 — Umbral de sensibilidad a bajo contraste
 - [ ] 2.14 — Integridad y limpieza de cassettes e IP CR
 - [ ] 2.15 — Uniformidad de sensibilidad de pantallas IP CR
 - [ ] 2.16 — MTF

--- a/AUDITORIA_PRUEBAS.md
+++ b/AUDITORIA_PRUEBAS.md
@@ -203,6 +203,7 @@ El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label 
 | 2.9 | ✅ Completa | Textos corregidos; render29 con Tabla 2.9.1 y 2.9.2 (desviación vs base); 2.9.7 evidencia gráfica; 2.9.8 concepto FAVORABLE/NO FAVORABLE; valores base ei_base/di_base persistidos en DB |
 | 2.10 | ✅ Completa | Textos corregidos; render210 con Tabla 2.10.1 (CV); 2.10.7 evidencia gráfica; 2.10.8 concepto FAVORABLE/NO FAVORABLE basado en CV del EI |
 | 2.11 | ✅ Completa | Textos corregidos; render211 con Tabla 2.11.1 (AC 0°) y Tabla 2.11.2 (CA 180°) por detector; campos desviación y tolerancia agregados al tipo; 2.11.7 evidencia gráfica (dicom_0 y dicom_180); 2.11.8 concepto FAVORABLE/NO FAVORABLE basado en uniformidad, píxeles defectuosos y artefactos |
+| 2.12 | ✅ Completa | Textos corregidos; render212 con condiciones + tabla pares de líneas + análisis dinámico; 2.12.7 evidencia gráfica (montaje_resolucion); 2.12.8 concepto FAVORABLE/NO FAVORABLE si pares_lineas_plmm >= 2,4 |
 
 ## Pruebas pendientes
 
@@ -213,7 +214,6 @@ El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label 
 - [ ] 2.5 — Exactitud y repetibilidad de la tensión
 - [ ] 2.6 — Capa hemirreductora (CHR)
 - [ ] 2.7 — Rendimiento, repetibilidad y linealidad
-- [ ] 2.12 — Resolución espacial de alto contraste
 - [ ] 2.13 — Umbral de sensibilidad a bajo contraste
 - [ ] 2.14 — Integridad y limpieza de cassettes e IP CR
 - [ ] 2.15 — Uniformidad de sensibilidad de pantallas IP CR

--- a/AUDITORIA_PRUEBAS.md
+++ b/AUDITORIA_PRUEBAS.md
@@ -202,6 +202,7 @@ El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label 
 | 2.8 | ✅ Completa | Fórmula DAP corregida (d1/d2 por fila); agregadas 2.8.7 evidencia gráfica, 2.8.8 concepto "No aplica" automático, 2.8.9 acciones "No Aplica" |
 | 2.9 | ✅ Completa | Textos corregidos; render29 con Tabla 2.9.1 y 2.9.2 (desviación vs base); 2.9.7 evidencia gráfica; 2.9.8 concepto FAVORABLE/NO FAVORABLE; valores base ei_base/di_base persistidos en DB |
 | 2.10 | ✅ Completa | Textos corregidos; render210 con Tabla 2.10.1 (CV); 2.10.7 evidencia gráfica; 2.10.8 concepto FAVORABLE/NO FAVORABLE basado en CV del EI |
+| 2.11 | ✅ Completa | Textos corregidos; render211 con Tabla 2.11.1 (AC 0°) y Tabla 2.11.2 (CA 180°) por detector; campos desviación y tolerancia agregados al tipo; 2.11.7 evidencia gráfica (dicom_0 y dicom_180); 2.11.8 concepto FAVORABLE/NO FAVORABLE basado en uniformidad, píxeles defectuosos y artefactos |
 
 ## Pruebas pendientes
 
@@ -212,7 +213,6 @@ El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label 
 - [ ] 2.5 — Exactitud y repetibilidad de la tensión
 - [ ] 2.6 — Capa hemirreductora (CHR)
 - [ ] 2.7 — Rendimiento, repetibilidad y linealidad
-- [ ] 2.11 — Uniformidad y artefactos del detector
 - [ ] 2.12 — Resolución espacial de alto contraste
 - [ ] 2.13 — Umbral de sensibilidad a bajo contraste
 - [ ] 2.14 — Integridad y limpieza de cassettes e IP CR

--- a/AUDITORIA_PRUEBAS.md
+++ b/AUDITORIA_PRUEBAS.md
@@ -200,6 +200,8 @@ El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label 
 | Prueba | Estado | Ajustes realizados |
 |---|---|---|
 | 2.8 | ✅ Completa | Fórmula DAP corregida (d1/d2 por fila); agregadas 2.8.7 evidencia gráfica, 2.8.8 concepto "No aplica" automático, 2.8.9 acciones "No Aplica" |
+| 2.9 | ✅ Completa | Textos corregidos; render29 con Tabla 2.9.1 y 2.9.2 (desviación vs base); 2.9.7 evidencia gráfica; 2.9.8 concepto FAVORABLE/NO FAVORABLE; valores base ei_base/di_base persistidos en DB |
+| 2.10 | ✅ Completa | Textos corregidos; render210 con Tabla 2.10.1 (CV); 2.10.7 evidencia gráfica; 2.10.8 concepto FAVORABLE/NO FAVORABLE basado en CV del EI |
 
 ## Pruebas pendientes
 
@@ -210,8 +212,6 @@ El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label 
 - [ ] 2.5 — Exactitud y repetibilidad de la tensión
 - [ ] 2.6 — Capa hemirreductora (CHR)
 - [ ] 2.7 — Rendimiento, repetibilidad y linealidad
-- [ ] 2.9 — Control de calidad DDI/EI en CR
-- [ ] 2.10 — Repetibilidad DDI/EI
 - [ ] 2.11 — Uniformidad y artefactos del detector
 - [ ] 2.12 — Resolución espacial de alto contraste
 - [ ] 2.13 — Umbral de sensibilidad a bajo contraste

--- a/AUDITORIA_PRUEBAS.md
+++ b/AUDITORIA_PRUEBAS.md
@@ -1,0 +1,225 @@
+# Guía de auditoría e implementación — prueba por prueba
+
+Referencia: `Copia de Control de calidad Convencional SURA LOS ALMENDROS (1).xlsx`
+
+## Archivos clave
+
+| Propósito | Archivo |
+|---|---|
+| Definición de prueba (objetivo, metodología, criterio) | `src/lib/equipos/convencional/informe-secciones.ts` |
+| Renderizadores de resultados/análisis en PDF | `src/lib/pdf/secciones-convencional.ts` |
+| Estructura del PDF (subsecciones, concepto, acciones) | `src/lib/pdf/generar-pre-informe.ts` |
+| Tipos de BD (campos de mediciones) | `src/lib/equipos/convencional/db/types.ts` |
+| UI de entrada de datos grupo B | `src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx` |
+
+## Hojas de la plantilla
+
+| Hoja | Contenido |
+|---|---|
+| `CE_NIT` | Informe completo renderizado — fuente de verdad de texto y estructura |
+| `2.4, 5, 6, 7, 21, 8` | Datos y fórmulas grupo B |
+| `2.9 , 10` / `2,14 , 15` / etc. | Datos de otros grupos |
+| `Listado de patrones de prueba` | Numeración oficial y nombre de cada prueba |
+
+---
+
+## Fase 1 — Auditoría (leer y comparar)
+
+### 1. Localizar la sección en CE_NIT
+
+```python
+import openpyxl, sys
+sys.stdout.reconfigure(encoding='utf-8')
+wb = openpyxl.load_workbook('plantilla.xlsx', data_only=True)
+ws = wb['CE_NIT']
+for i, row in enumerate(ws.iter_rows(values_only=True), 1):
+    if any('2.9' in str(v) for v in row if v):  # cambiar código
+        print(i, row[:6])
+```
+
+Anotar: fila de inicio, fila de fin, hoja de datos que la alimenta.
+
+### 2. Extraer texto de referencia
+
+Leer de `CE_NIT` y comparar contra `informe-secciones.ts`:
+
+| Subsección | Campo en `informe-secciones.ts` |
+|---|---|
+| `.1 Objetivo` | `objetivo` |
+| `.2 Instrumentación` | `instrumentacion` |
+| `.3 Metodología` | `metodologia` |
+| `.6 Criterio de aceptación` | `criterio` |
+
+Leer de `CE_NIT` y comparar contra `secciones-convencional.ts` función `renderXX`:
+
+| Subsección | Dónde está en el código |
+|---|---|
+| `.4 Resultados` | cabeceras de `autoTable` + cálculos |
+| `.5 Análisis` | `ctx.addParagraph(...)` después de la tabla |
+
+### 3. Extraer fórmulas de cálculo
+
+```python
+wb2 = openpyxl.load_workbook('plantilla.xlsx')  # sin data_only para ver fórmulas
+ws2 = wb2['hoja-datos']
+for i in range(fila_inicio, fila_fin):
+    row = ws2[i]
+    print([(c.column_letter, c.value) for c in row if c.value])
+```
+
+Comparar cada columna de la hoja de datos contra el código en `renderXX`.
+
+### 4. Verificar estructura de subsecciones
+
+`renderXX` retorna `nextSub` (el número de la siguiente subsección disponible). El flujo en `generar-pre-informe.ts` es siempre:
+
+```
+.1 Objetivo         ← informe-secciones.ts
+.2 Instrumentación  ← informe-secciones.ts
+.3 Metodología      ← informe-secciones.ts
+.4 Resultados  ┐
+.5 Análisis    ┘  ← renderXX (retorna nextSub al salir)
+.N   Criterio       ← generar-pre-informe.ts (nextSub++)
+.N+1 Evidencia      ← generar-pre-informe.ts (solo si hay bloque `codigo === "X.X"`)
+.N+2 Concepto       ← generar-pre-informe.ts
+.N+3 Acciones       ← generar-pre-informe.ts
+```
+
+Checklist:
+- [ ] ¿`renderXX` retorna el `nextSub` correcto? (4 + cantidad de subsecciones que agrega)
+- [ ] ¿La plantilla tiene evidencia gráfica? → ¿existe `if (codigo === "X.X" && aplica)` en `generar-pre-informe.ts`?
+- [ ] ¿Los números `.N` del PDF coinciden con la plantilla?
+
+### 5. Revisar concepto y acciones correctivas de la plantilla
+
+En `CE_NIT`, leer las subsecciones `.8 Concepto` y `.9 Acciones correctivas` y determinar qué tipo son:
+
+| Tipo de concepto | Cómo se ve en la plantilla | Qué hacer en el código |
+|---|---|---|
+| **Automático con lógica** | "Conforme / No conforme" según criterio numérico | Implementar bloque `else if (codigo === "X.X")` con la lógica |
+| **Fijo "No aplica"** | "No aplica: La prueba no define tolerancias..." | Bloque fijo con `conceptoLabel = "NO APLICA"` y párrafo |
+| **Manual** | Campo editable por el físico | Sin bloque especial → cae en el `else` genérico |
+
+### 6. Verificar campos de la UI contra el tipo y el renderizador
+
+En `page.tsx` del grupo correspondiente y en `db/types.ts`:
+- ¿Los campos mostrados en la tabla existen en `ConvRaysafeMedicion`?
+- ¿Los inputs guardan en el campo que lee `renderXX`?  
+  (Trampa común: `"campo_real" as "otro_campo"` solo engaña al tipo; en runtime el key sigue siendo `"campo_real"`. Si `renderXX` lee del setup y el input guarda en la medición, no hay conexión.)
+
+---
+
+## Fase 2 — Implementación de ajustes
+
+### A. Corregir texto (objetivo / metodología / criterio / análisis)
+
+Editar directamente en `informe-secciones.ts` (para `.1`–`.3` y `.6`) o en `renderXX` (para `.5`).
+
+### B. Corregir fórmulas de cálculo
+
+En `secciones-convencional.ts`, función `renderXX`. Verificar numéricamente con los datos de la plantilla:
+
+```js
+node -e "
+const d1=100, d2=102, kerma=0.01266, ancho=26, largo=26, dapNom=6;
+const f = (d2/d1)**2;
+const dapEst = kerma * f * ancho * largo * f;
+console.log('DAP est:', dapEst.toFixed(2), '| FC:', (dapEst/dapNom).toFixed(2));
+"
+```
+
+Si un campo calculado vive en la medición (no en el setup), agregar el campo al tipo en `db/types.ts` y leerlo por fila en `renderXX` con fallback al setup.
+
+### C. Agregar evidencia gráfica faltante
+
+**1. Campo en `DatosConvencional`** (`secciones-convencional.ts`):
+```ts
+fotosXX?: { label: string; dataUrl: string; width: number; height: number }[];
+```
+
+**2. Poblar el campo** (en la función `recopilarDatosConv`):
+```ts
+const fotosXX: NonNullable<DatosConvencional["fotosXX"]> = [];
+if (img24) fotosXX.push({ label: "Fig X.X.1 Implementación de instrumentación en la prueba", ...img24 });
+// ...
+return { ..., fotosXX, ... };
+```
+
+**3. Función `renderFotosXX`** (copiar el patrón de `renderFotos27`):
+```ts
+export function renderFotosXX(ctx: InformeCtx, conv: DatosConvencional) {
+  const fotos = conv.fotosXX ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
+    return;
+  }
+  // ... mismo bloque de render de imagen y caption
+}
+```
+
+**4. Bloque en `generar-pre-informe.ts`** (después del bloque de 2.7):
+```ts
+if (codigo === "X.X" && aplica) {
+  checkPage(20);
+  addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+  renderFotosXX(ctx, conv);
+  nextSub++;
+}
+```
+
+**5. Importar** `renderFotosXX` en `generar-pre-informe.ts`.
+
+### D. Implementar concepto automático
+
+En `generar-pre-informe.ts`, agregar **antes** del bloque `else if (!aplica)`:
+
+```ts
+} else if (codigo === "X.X" && aplica) {
+  // --- Caso "No aplica" fijo (prueba descriptiva sin criterio) ---
+  conceptoLabel = "NO APLICA";
+  conceptoParrafo = "La prueba no define tolerancias, debido a que es de carácter descriptivo y de referencia técnica.";
+  accionesTexto = "No Aplica";
+  esNoConforme = false;
+
+  // --- Caso con lógica derivada de datos ---
+  // const hayDatos = mediciones.length > 0;
+  // const conforme = /* evaluar criterio */;
+  // esNoConforme = hayDatos && !conforme;
+  // conceptoLabel = !hayDatos ? "PENDIENTE" : conforme ? "FAVORABLE" : "NO FAVORABLE";
+  // conceptoParrafo = conforme ? "La prueba se considera conforme..." : "La prueba se considera no conforme...";
+  // accionesTexto = conforme ? "No se requieren acciones correctivas..." : "Se recomienda...";
+}
+```
+
+El texto de `conceptoParrafo` se imprime en párrafo debajo del label. El label usa color verde (FAVORABLE/CONFORME), rojo (NO FAVORABLE/NO CONFORME) o gris (PENDIENTE/NO APLICA) según el valor.
+
+---
+
+## Historial de pruebas auditadas
+
+| Prueba | Estado | Ajustes realizados |
+|---|---|---|
+| 2.8 | ✅ Completa | Fórmula DAP corregida (d1/d2 por fila); agregadas 2.8.7 evidencia gráfica, 2.8.8 concepto "No aplica" automático, 2.8.9 acciones "No Aplica" |
+
+## Pruebas pendientes
+
+- [ ] 2.1 — Evaluación de condiciones ambientales / levantamiento radiométrico
+- [ ] 2.2 — Inspección visual
+- [ ] 2.3 — Sistema de colimación y perpendicularidad
+- [ ] 2.4 — Exactitud y repetibilidad del tiempo de exposición
+- [ ] 2.5 — Exactitud y repetibilidad de la tensión
+- [ ] 2.6 — Capa hemirreductora (CHR)
+- [ ] 2.7 — Rendimiento, repetibilidad y linealidad
+- [ ] 2.9 — Control de calidad DDI/EI en CR
+- [ ] 2.10 — Repetibilidad DDI/EI
+- [ ] 2.11 — Uniformidad y artefactos del detector
+- [ ] 2.12 — Resolución espacial de alto contraste
+- [ ] 2.13 — Umbral de sensibilidad a bajo contraste
+- [ ] 2.14 — Integridad y limpieza de cassettes e IP CR
+- [ ] 2.15 — Uniformidad de sensibilidad de pantallas IP CR
+- [ ] 2.16 — MTF
+- [ ] 2.17 — Sensibilidad del CAE
+- [ ] 2.18 — Consistencia entre sensores del CAE
+- [ ] 2.19 — Repetibilidad del CAE
+- [ ] 2.20 — Compensación del CAE
+- [ ] 2.21 — Dosis al receptor

--- a/src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx
@@ -364,6 +364,28 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
     db.conv_raysafe_mediciones.bulkAdd(rows);
   }, [data, visitaId]);
 
+  // ─── Copiar nominales de con_rejilla → kerma (una sola vez) ───
+  useEffect(() => {
+    if (!data) return;
+    const conRejillaMap = new Map(
+      data.mediciones
+        .filter((m) => m.tipo_medicion === "con_rejilla" && m.programa_clinico)
+        .map((m) => [m.programa_clinico!, m]),
+    );
+    for (const k of data.mediciones.filter((m) => m.tipo_medicion === "kerma")) {
+      if (!k.id || !k.programa_clinico) continue;
+      const ref = conRejillaMap.get(k.programa_clinico);
+      if (!ref) continue;
+      const updates: Record<string, unknown> = {};
+      if (k.kv_nominal == null && ref.kv_nominal != null) updates.kv_nominal = ref.kv_nominal;
+      if (k.ma_nominal == null && ref.ma_nominal != null) updates.ma_nominal = ref.ma_nominal;
+      if (k.tiempo_nominal_s == null && ref.tiempo_nominal_s != null)
+        updates.tiempo_nominal_s = ref.tiempo_nominal_s;
+      if (k.mas_nominal == null && ref.mas_nominal != null) updates.mas_nominal = ref.mas_nominal;
+      if (Object.keys(updates).length > 0) db.conv_raysafe_mediciones.update(k.id, updates);
+    }
+  }, [data, visitaId]);
+
   // ─── RaySafe import handlers ───
   async function importarRaysafe(
     rows: RaysafeRow[],
@@ -1023,14 +1045,10 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
                     <td className="py-1.5 px-1 font-medium text-slate-700">
                       {m.programa_clinico}
                     </td>
-                    <td className="py-1.5 px-1 text-slate-500 font-mono">
-                      {m.kv_nominal ?? "—"}
-                    </td>
-                    <td className="py-1.5 px-1 text-slate-500 font-mono">
-                      {m.mas_nominal ?? "—"}
-                    </td>
                     {(
                       [
+                        "kv_nominal",
+                        "mas_nominal",
                         "dap_nominal",
                         "distancia_foco_sensor_cm" as "dap_nominal",
                         "distancia_foco_detector_cm" as "dap_nominal",

--- a/src/app/dashboard/visitas/[id]/conv/grupo-d/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-d/page.tsx
@@ -312,6 +312,14 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
   const [baseEi29, setBaseEi29] = useState("");
   const [baseDi29, setBaseDi29] = useState("");
 
+  // Initialize base values from DB record once data loads
+  useEffect(() => {
+    const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
+    if (t1?.ei_base != null) setBaseEi29(String(t1.ei_base));
+    if (t1?.di_base != null) setBaseDi29(String(t1.di_base));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [(data?.ddiMediciones.length ?? 0) > 0]);
+
   // ─── Save helpers ───
   async function updateDdi(id: number, fields: Record<string, unknown>) {
     await db.conv_ddi_mediciones.update(id, fields);
@@ -596,6 +604,10 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
                 className="rounded-xl h-9 text-sm font-medium"
                 value={baseEi29}
                 onChange={(e) => setBaseEi29(e.target.value)}
+                onBlur={(e) => {
+                  const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
+                  if (t1?.id) updateDdi(t1.id, { ei_base: parseFloat(e.target.value) || null });
+                }}
                 placeholder="—"
               />
             </div>
@@ -609,6 +621,10 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
                 className="rounded-xl h-9 text-sm font-medium"
                 value={baseDi29}
                 onChange={(e) => setBaseDi29(e.target.value)}
+                onBlur={(e) => {
+                  const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
+                  if (t1?.id) updateDdi(t1.id, { di_base: parseFloat(e.target.value) || null });
+                }}
                 placeholder="—"
               />
             </div>

--- a/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
@@ -612,21 +612,34 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                   defaultValue={ur.det.serie_detector ?? ""}
                   onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { serie_detector: e.target.value || undefined })} />
 
+                {/* Tolerancia */}
+                <div className="flex items-center gap-2">
+                  <label className="text-[10px] font-black text-slate-400 uppercase whitespace-nowrap">Tolerancia (%)</label>
+                  <Input type="number" step="1" className="rounded-lg h-7 text-xs font-medium w-20"
+                    defaultValue={ur.det.tolerancia_pct ?? 15}
+                    onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { tolerancia_pct: e.target.value ? parseFloat(e.target.value) : 15 })} />
+                </div>
+
                 {(["ac", "ca"] as const).map((orient) => (
                   <div key={orient} className="space-y-2">
                     <p className="text-[10px] font-black text-slate-500 uppercase">{orient === "ac" ? "0° (Anodo-Catodo)" : "180° (Catodo-Anodo)"}</p>
                     <div className="grid grid-cols-5 gap-2">
                       {[0, 1, 2, 3, 4].map((i) => {
-                        const field = `roi_${i}_vmp_${orient}` as keyof typeof ur.det;
+                        const vmpField = `roi_${i}_vmp_${orient}` as keyof typeof ur.det;
+                        const desvField = `roi_${i}_desv_${orient}` as keyof typeof ur.det;
                         return (
                           <div key={i} className="space-y-1">
                             <label className="text-[9px] font-black text-slate-400 uppercase">
                               {i === 0 ? "ROIc" : `ROI${i}`}
                             </label>
                             <Input type="number" step="0.1" className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50"
-                              defaultValue={ur.det[field] as number ?? ""}
+                              defaultValue={ur.det[vmpField] as number ?? ""}
                               placeholder="VMP"
-                              onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { [field]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                              onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { [vmpField]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                            <Input type="number" step="0.1" className="rounded-lg h-7 text-xs font-medium border-slate-200"
+                              defaultValue={ur.det[desvField] as number ?? ""}
+                              placeholder="Desv."
+                              onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { [desvField]: e.target.value ? parseFloat(e.target.value) : undefined })} />
                           </div>
                         );
                       })}

--- a/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
@@ -711,7 +711,7 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <ImageSlot label="Foto montaje experimental" evidencia={getEvidencia("2.12", "montaje_resolucion")}
               onCapture={(f) => captureImage("2.12", "montaje_resolucion", f)} onRemove={() => removeImage("2.12", "montaje_resolucion")} />
-            <ImageSlot label="Imagen DICOM patrón resolución" evidencia={getEvidencia("2.12", "dicom_resolucion")}
+            <ImageSlot label="Radiografía del patrón de resolución" evidencia={getEvidencia("2.12", "dicom_resolucion")}
               onCapture={(f) => captureImage("2.12", "dicom_resolucion", f)} onRemove={() => removeImage("2.12", "dicom_resolucion")} />
           </div>
 

--- a/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
@@ -708,10 +708,14 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
             Identifica el grupo de barras mas fino visible en el patron de resolucion.
           </StepHeader>
 
-          <ImageSlot label="Montaje patron de resolucion" evidencia={getEvidencia("2.12", "montaje_resolucion")}
-            onCapture={(f) => captureImage("2.12", "montaje_resolucion", f)} onRemove={() => removeImage("2.12", "montaje_resolucion")} />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <ImageSlot label="Foto montaje experimental" evidencia={getEvidencia("2.12", "montaje_resolucion")}
+              onCapture={(f) => captureImage("2.12", "montaje_resolucion", f)} onRemove={() => removeImage("2.12", "montaje_resolucion")} />
+            <ImageSlot label="Imagen DICOM patrón resolución" evidencia={getEvidencia("2.12", "dicom_resolucion")}
+              onCapture={(f) => captureImage("2.12", "dicom_resolucion", f)} onRemove={() => removeImage("2.12", "dicom_resolucion")} />
+          </div>
 
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             <div className="space-y-1">
               <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">SID (cm)</label>
               <Input type="number" className="rounded-xl h-9 text-sm font-medium" defaultValue={resol?.sid_cm ?? 100}
@@ -727,13 +731,37 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
               <Input type="number" className="rounded-xl h-9 text-sm font-medium" defaultValue={resol?.tecnica_mas ?? ""}
                 onBlur={(e) => updateResolucion({ tecnica_mas: e.target.value ? parseFloat(e.target.value) : undefined })} />
             </div>
-            <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">pl/mm visibles</label>
-              <Input type="number" step="0.1" className="rounded-xl h-9 text-sm font-black border-blue-200 bg-blue-50/50"
-                defaultValue={resol?.pares_lineas_plmm ?? ""} placeholder="Ej: 2.5"
-                onBlur={(e) => updateResolucion({ pares_lineas_plmm: e.target.value ? parseFloat(e.target.value) : undefined })} />
-            </div>
           </div>
+
+          <div className="space-y-1">
+            <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">pl/mm visibles</label>
+            <select
+              className="w-full rounded-xl h-9 text-sm font-black border border-blue-200 bg-blue-50/50 px-3 focus:outline-none focus:ring-2 focus:ring-primary"
+              value={resol?.pares_lineas_plmm ?? ""}
+              onChange={(e) => updateResolucion({ pares_lineas_plmm: e.target.value ? parseFloat(e.target.value) : undefined })}>
+              <option value="">— Seleccionar —</option>
+              {[5.0, 4.6, 4.3, 4.0, 3.9, 3.7, 3.4, 3.1, 2.8, 2.5, 2.4, 2.3, 2.0, 1.8, 1.6, 1.4, 1.2, 1.0, 0.9, 0.8, 0.7, 0.6].map((v) => (
+                <option key={v} value={v}>{v.toFixed(1)} pl/mm</option>
+              ))}
+            </select>
+          </div>
+
+          {resol?.pares_lineas_plmm != null && (() => {
+            const conforme = resol.pares_lineas_plmm >= 2.4;
+            return (
+              <div className={`flex items-center justify-between p-2 rounded-lg ${conforme ? "bg-green-50" : "bg-red-50"}`}>
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-xs font-bold text-slate-700">Resolución espacial</span>
+                  <span className={`text-[10px] font-black ${conforme ? "text-green-700" : "text-red-600"}`}>
+                    {conforme ? "FAVORABLE" : "NO FAVORABLE"}
+                  </span>
+                </div>
+                <span className={`text-xs font-black ${conforme ? "text-green-700" : "text-red-600"}`}>
+                  {resol.pares_lineas_plmm.toFixed(1)} pl/mm
+                </span>
+              </div>
+            );
+          })()}
         </CardContent>
       </Card>
 

--- a/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
@@ -666,12 +666,23 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                   </div>
                 </div>
 
-                {ur.maxGlobal !== null && (
-                  <div className="flex items-center justify-between p-2 bg-slate-50 rounded-lg">
-                    <span className="text-xs font-bold text-slate-700">Uniformidad max global</span>
-                    <span className="text-xs font-black text-primary">{ur.maxGlobal.toFixed(1)}%</span>
-                  </div>
-                )}
+                {ur.maxGlobal !== null && (() => {
+                  const tolerancia = ur.det.tolerancia_pct ?? 15;
+                  const conforme = ur.maxGlobal <= tolerancia && !ur.det.pixeles_defectuosos && !ur.det.artefactos;
+                  return (
+                    <div className={`flex items-center justify-between p-2 rounded-lg ${conforme ? "bg-green-50" : "bg-red-50"}`}>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="text-xs font-bold text-slate-700">Uniformidad max global</span>
+                        <span className={`text-[10px] font-black ${conforme ? "text-green-700" : "text-red-600"}`}>
+                          {conforme ? "FAVORABLE" : "NO FAVORABLE"}
+                        </span>
+                      </div>
+                      <span className={`text-xs font-black ${conforme ? "text-green-700" : "text-red-600"}`}>
+                        {ur.maxGlobal.toFixed(1)}%
+                      </span>
+                    </div>
+                  );
+                })()}
 
                 <button type="button" onClick={() => ur.det.id && removeUniformidadDet(ur.det.id)}
                   className="text-xs text-red-400 hover:text-red-600 font-bold">

--- a/src/lib/equipos/convencional/db/types.ts
+++ b/src/lib/equipos/convencional/db/types.ts
@@ -177,6 +177,10 @@ export interface ConvDdiMedicion {
   ei?: number;
   di?: number;
   tei?: number;
+  /** Valor base del EI para comparación 2.9 (precarga de visita anterior) */
+  ei_base?: number;
+  /** Valor base del D.I. para comparación 2.9 */
+  di_base?: number;
   creado_en?: string;
 }
 

--- a/src/lib/equipos/convencional/db/types.ts
+++ b/src/lib/equipos/convencional/db/types.ts
@@ -131,6 +131,8 @@ export interface ConvRaysafeMedicion {
   dap_nominal?: number;
   ancho_irradiacion_cm?: number;
   largo_irradiacion_cm?: number;
+  distancia_foco_sensor_cm?: number;
+  distancia_foco_detector_cm?: number;
   creado_en?: string;
 }
 

--- a/src/lib/equipos/convencional/db/types.ts
+++ b/src/lib/equipos/convencional/db/types.ts
@@ -251,11 +251,23 @@ export interface ConvUniformidadDetector {
   roi_2_vmp_ac?: number;
   roi_3_vmp_ac?: number;
   roi_4_vmp_ac?: number;
+  roi_0_desv_ac?: number;
+  roi_1_desv_ac?: number;
+  roi_2_desv_ac?: number;
+  roi_3_desv_ac?: number;
+  roi_4_desv_ac?: number;
   roi_0_vmp_ca?: number;
   roi_1_vmp_ca?: number;
   roi_2_vmp_ca?: number;
   roi_3_vmp_ca?: number;
   roi_4_vmp_ca?: number;
+  roi_0_desv_ca?: number;
+  roi_1_desv_ca?: number;
+  roi_2_desv_ca?: number;
+  roi_3_desv_ca?: number;
+  roi_4_desv_ca?: number;
+  /** Tolerancia de uniformidad seleccionada (%, por defecto 15) */
+  tolerancia_pct?: number;
   /** Artefactos observados */
   pixeles_defectuosos?: boolean;
   artefactos?: boolean;

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -169,7 +169,7 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     metodologia:
       "La evaluación de uniformidad del detector se realizó siguiendo el procedimiento descrito en el IAEA-TECDOC-1958, obteniendo imágenes uniformes del detector mediante la interposición de una lámina de cobre y registrando el valor medio de píxel en diferentes regiones de interés (ROI) distribuidas en la imagen. Adicionalmente, se realizó inspección visual para identificar la presencia de píxeles defectuosos o artefactos.",
     criterio:
-      "La imagen uniforme obtenida debe presentar una respuesta homogénea del detector y no evidenciar píxeles defectuosos ni artefactos que afecten la calidad de la imagen. La variación de uniformidad del detector, calculada a partir de los valores máximos y mínimos de señal registrados en las regiones de interés, no debe exceder el 15 %.",
+      "La imagen uniforme obtenida debe presentar una respuesta homogénea del detector y no evidenciar píxeles defectuosos ni artefactos que afecten la calidad de la imagen. La variación de uniformidad del detector, calculada a partir de los valores máximos y mínimos de señal registrados en las regiones de interés, no debe exceder el [TOLERANCIA_PCT] %.",
   },
   {
     codigo: "2.12",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -173,15 +173,16 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
   },
   {
     codigo: "2.12",
-    nombre: "Resolucion espacial de alto contraste",
+    nombre: "Resolución espacial de alto contraste",
     grupo: "E",
     orden: 12,
     objetivo:
-      "Determinar la capacidad del sistema para distinguir objetos pequenos y cercanos entre si. Se mide en pares de lineas por milimetro (pl/mm).",
-    instrumentacion: "Patron de resolucion (tipo barra de plomo), Detector de imagen.",
+      "Evaluar la resolución espacial del sistema a partir de la medición de los grupos de pares de líneas por milímetro (pl/mm) visibles en la imagen.",
+    instrumentacion:
+      "Objeto de prueba para resolución espacial de alto contraste (patrón de pares de líneas), detector de imagen del sistema evaluado (CR o DR) y software de visualización y procesamiento de imágenes del sistema radiográfico.",
     metodologia:
-      "Se coloco el patron de resolucion sobre el detector, se realizo una exposicion y se identifico el grupo de barras mas fino visible.",
-    criterio: "Resolucion >= valor de referencia del sistema.",
+      "Se posicionó el objeto de prueba para resolución espacial sobre el receptor de imagen, asegurando su correcta alineación 45° con el centro del haz de radiación. Posteriormente se realizó una exposición radiográfica utilizando parámetros técnicos representativos de la práctica clínica habitual del equipo evaluado.\n\nLa imagen obtenida fue analizada visualmente mediante el software de visualización del sistema, identificando el grupo de pares de líneas por milímetro (pl/mm) que pueden distinguirse claramente en la imagen radiográfica. La evaluación se realizó de acuerdo con los criterios establecidos en el protocolo IAEA-TECDOC-1958, determinando el valor máximo de resolución espacial reproducible por el sistema.",
+    criterio: "La resolución espacial del sistema debe ser mayor o igual a 2,4 pl/mm.",
   },
   {
     codigo: "2.13",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -156,7 +156,7 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     instrumentacion: "Cassette CR, lámina de cobre 1 mm Cu, software de procesamiento de imagen.",
     metodologia:
       "De acuerdo con el protocolo IAEA-TECDOC-1958, la repetibilidad del indicador de exposición se evalúa realizando varias exposiciones consecutivas bajo las mismas condiciones de irradiación y registrando el valor del indicador de exposición (DDI o EI) reportado por el sistema.",
-    criterio: "El valor del coeficiente de variación debe ser ≤ 20 %.",
+    criterio: "El valor del coeficiente de variación debe ser <= 20 %.",
   },
   {
     codigo: "2.11",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -164,11 +164,12 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "E",
     orden: 11,
     objetivo:
-      "Verificar que el detector de imagen produce una respuesta uniforme y no tiene artefactos que afecten la calidad diagnostica.",
-    instrumentacion: "Detector de imagen (DR o CR), placa de cobre como filtro.",
+      "Evaluar e identificar la fuente de los artefactos visualizados en las imágenes radiográficas digitales. Verificar la uniformidad de la imagen.",
+    instrumentacion: "Detector de imagen CR o DR, lámina de cobre 1 mm Cu, software de procesamiento de imagen.",
     metodologia:
-      "Se coloco el lado mas largo del detector alineado con el tubo. Se coloco un filtro de cobre a la salida del tubo. Se realizo una exposicion uniforme (flat field) y se analizaron 5 ROIs en dos orientaciones.",
-    criterio: "Uniformidad segun especificaciones del fabricante. Sin artefactos visibles.",
+      "La evaluación de uniformidad del detector se realizó siguiendo el procedimiento descrito en el IAEA-TECDOC-1958, obteniendo imágenes uniformes del detector mediante la interposición de una lámina de cobre y registrando el valor medio de píxel en diferentes regiones de interés (ROI) distribuidas en la imagen. Adicionalmente, se realizó inspección visual para identificar la presencia de píxeles defectuosos o artefactos.",
+    criterio:
+      "La imagen uniforme obtenida debe presentar una respuesta homogénea del detector y no evidenciar píxeles defectuosos ni artefactos que afecten la calidad de la imagen. La variación de uniformidad del detector, calculada a partir de los valores máximos y mínimos de señal registrados en las regiones de interés, no debe exceder el 15 %.",
   },
   {
     codigo: "2.12",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -24,17 +24,17 @@ export interface SeccionInfoCatalogo {
 export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
   {
     codigo: "2.1",
-    nombre: "Evaluacion de las condiciones ambientales / Levantamiento radiometrico",
+    nombre: "Evaluación de las condiciones ambientales / Levantamiento radiométrico",
     grupo: "A",
     orden: 1,
     objetivo:
-      "Realizar el levantamiento radiometrico para evaluar las condiciones ambientales del servicio en terminos de proteccion radiologica y verificar los niveles de exposicion ocupacional y del publico.",
+      "Realizar el levantamiento radiométrico para evaluar las condiciones ambientales del servicio en términos de protección radiológica y verificar los niveles de exposición ocupacional y del público.",
     instrumentacion:
-      "Sistema dosimetrico calibrado para mediciones en proteccion radiologica (camara de ionizacion o detector de estado solido), material equivalente simulador de radiacion dispersa y cinta metrica.",
+      "Sistema dosimétrico calibrado para mediciones en protección radiológica (cámara de ionización o detector de estado sólido), material equivalente simulador de radiación dispersa y cinta métrica.",
     metodologia:
       "Se realizó el levantamiento radiométrico mediante mediciones de radiación dispersa en puntos representativos del área donde se encuentra instalado el equipo de radiología general. Las mediciones se efectuaron utilizando una cámara de ionización o un detector de estado sólido calibrado en términos de dosis equivalente ambiental H*(10), posicionando un simulador de dispersión en la ubicación habitual del paciente durante la exposición, aplicando la técnica máxima utilizada en la práctica clínica. Los puntos de medición evaluados se presentan en el diagrama radiométrico de la instalación.",
     criterio:
-      "Area controlada (trabajadores): H*(10) <= 5 mSv/ano. Area supervisada (publico): H*(10) <= 0.5 mSv/ano.",
+      "Área controlada (trabajadores): H*(10) <= 5 mSv/año. Área supervisada (público): H*(10) <= 0.5 mSv/año.",
   },
   {
     codigo: "2.2",
@@ -203,11 +203,11 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "D",
     orden: 14,
     objetivo:
-      "Verificar que los cassettes y pantallas de imagen (CR) estan en buen estado y limpios, sin artefactos que afecten la calidad de imagen.",
-    instrumentacion: "Inspeccion visual, Exposicion uniforme de prueba.",
+      "Verificar que los cassettes y pantallas de imagen (CR) están en buen estado y limpios, sin artefactos que afecten la calidad de la imagen.",
+    instrumentacion: "Inspección visual, exposición uniforme de prueba.",
     metodologia:
-      "Se inspecciono visualmente cada cassette y se realizo una exposicion uniforme (flat field) con cada uno.",
-    criterio: "Sin artefactos visibles. Cassette sin danos fisicos.",
+      "Se inspeccionó visualmente cada cassette y se realizó una exposición uniforme (flat field) con cada uno.",
+    criterio: "Sin artefactos visibles. Cassette sin daños físicos.",
   },
   {
     codigo: "2.15",
@@ -216,34 +216,34 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     orden: 15,
     objetivo:
       "Verificar que la pantalla de imagen CR tiene sensibilidad uniforme en toda su superficie.",
-    instrumentacion: "Detector CR, Exposicion uniforme.",
+    instrumentacion: "Detector CR, exposición uniforme.",
     metodologia:
-      "Se realizo una exposicion uniforme que cubrio toda la pantalla y se analizo la uniformidad del EI entre cassettes.",
-    criterio: "Uniformidad segun fabricante.",
+      "Se realizó una exposición uniforme que cubrió toda la pantalla y se analizó la uniformidad del EI entre cassettes.",
+    criterio: "Uniformidad según fabricante.",
   },
   {
     codigo: "2.16",
-    nombre: "Funcion de transferencia de modulacion (MTF)",
+    nombre: "Función de transferencia de modulación (MTF)",
     grupo: "E",
     orden: 16,
     objetivo:
-      "Evaluar la capacidad del sistema para reproducir fielmente el contraste de objetos de diferente tamano.",
-    instrumentacion: "Patron MTF o borde recto (edge phantom), Software de analisis DICOM.",
+      "Evaluar la capacidad del sistema para reproducir fielmente el contraste de objetos de diferente tamaño.",
+    instrumentacion: "Patrón MTF o borde recto (edge phantom), software de análisis DICOM.",
     metodologia:
-      "Se coloco el patron MTF sobre el detector con una ligera inclinacion (2-5 grados), se realizo una exposicion, se exporto la imagen DICOM y se analizo con software especializado.",
+      "Se colocó el patrón MTF sobre el detector con una ligera inclinación (2–5 grados), se realizó una exposición, se exportó la imagen DICOM y se analizó con software especializado.",
     criterio: "MTF >= valor de referencia del sistema.",
   },
   {
     codigo: "2.17",
-    nombre: "Sensibilidad del control automatico de exposicion (CAE)",
+    nombre: "Sensibilidad del control automático de exposición (CAE)",
     grupo: "C",
     orden: 17,
     objetivo:
-      "Verificar que el CAE da valores similares a los de la visita anterior (valores base).",
+      "Verificar que el CAE entrega valores similares a los de la visita anterior (valores base).",
     instrumentacion: "Placas de cobre (1 mm), equipo con CAE activado.",
     metodologia:
-      "Se activo el CAE en modo automatico, se coloco 1 placa de cobre (1 mm) como atenuador y se compararon los valores medidos con los de la visita anterior.",
-    criterio: "Variacion de mAs, EI y D.I. respecto a base <= 50%.",
+      "Se activó el CAE en modo automático, se colocó 1 placa de cobre (1 mm) como atenuador y se compararon los valores medidos con los de la visita anterior.",
+    criterio: "Variación de mAs, EI y D.I. respecto a la base <= 50 %.",
   },
   {
     codigo: "2.18",
@@ -251,11 +251,11 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "C",
     orden: 18,
     objetivo:
-      "Verificar que los 3 sensores del CAE y sus combinaciones dan resultados similares entre si.",
+      "Verificar que los 3 sensores del CAE y sus combinaciones entregan resultados similares entre sí.",
     instrumentacion: "Placas de cobre (1 mm), equipo con CAE activado.",
     metodologia:
-      "Se mantuvieron las mismas condiciones (70 kVp, Cu 1mm) y se disparo con cada combinacion de sensores (7 mediciones).",
-    criterio: "Variacion (MAX-MIN)/promedio de mAs, EI y D.I. <= 30%.",
+      "Se mantuvieron las mismas condiciones (70 kVp, Cu 1 mm) y se disparó con cada combinación de sensores (7 mediciones).",
+    criterio: "Variación (MAX-MIN)/promedio de mAs, EI y D.I. <= 30 %.",
   },
   {
     codigo: "2.19",
@@ -263,23 +263,23 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "C",
     orden: 19,
     objetivo:
-      "Verificar que el CAE da resultados consistentes al repetir disparos con la misma configuracion.",
+      "Verificar que el CAE entrega resultados consistentes al repetir exposiciones con la misma configuración.",
     instrumentacion: "Placas de cobre (1 mm), equipo con CAE activado.",
     metodologia:
-      "Se mantuvieron las mismas condiciones (70 kVp, Cu 1mm, sensor Centro) y se disparo 4 veces.",
-    criterio: "CV de mAs, EI y D.I. <= 10%.",
+      "Se mantuvieron las mismas condiciones (70 kVp, Cu 1 mm, sensor Centro) y se disparó 4 veces.",
+    criterio: "CV de mAs, EI y D.I. <= 10 %.",
   },
   {
     codigo: "2.20",
-    nombre: "Compensacion del CAE para diferentes kVp y espesores",
+    nombre: "Compensación del CAE para diferentes kVp y espesores",
     grupo: "C",
     orden: 20,
     objetivo:
-      "Verificar que el CAE ajusta correctamente la exposicion cuando cambia el voltaje (kVp) o el espesor del paciente.",
+      "Verificar que el CAE ajusta correctamente la exposición cuando cambia el voltaje (kVp) o el espesor del paciente.",
     instrumentacion: "Placas de cobre: 1 mm, 2 mm, 3 mm. Equipo con CAE activado.",
     metodologia:
-      "Se disparo a diferentes kVp (60, 70, 81) con Cu 1mm y a diferentes espesores (Cu 1, 2, 3mm) a 81 kVp. Se compararon los valores con los de referencia.",
-    criterio: "Variacion por kVp y espesor de mAs, EI y D.I. <= 30%.",
+      "Se disparó a diferentes kVp (60, 70, 81) con Cu 1 mm y a diferentes espesores (Cu 1, 2, 3 mm) a 81 kVp. Se compararon los valores con los de referencia.",
+    criterio: "Variación por kVp y espesor de mAs, EI y D.I. <= 30 %.",
   },
   {
     codigo: "2.21",
@@ -287,11 +287,11 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "B",
     orden: 21,
     objetivo:
-      "Medir cuanta radiacion llega al detector de imagen usando los programas clinicos reales del equipo.",
-    instrumentacion: "Sensor RaySafe X2 RF, rejilla del equipo, cinta metrica.",
+      "Medir la dosis que llega al detector de imagen utilizando los programas clínicos reales del equipo.",
+    instrumentacion: "Sensor RaySafe X2 RF, rejilla del equipo, cinta métrica.",
     metodologia:
-      "Se hicieron 3 disparos CON rejilla y 3 SIN rejilla usando programas clinicos reales. Se registro la dosis al receptor corregida por distancia.",
-    criterio: "Diferencia con valor base <= 0.01 mGy.",
+      "Se realizaron 3 exposiciones con rejilla y 3 sin rejilla utilizando programas clínicos reales. Se registró la dosis al receptor corregida por distancia.",
+    criterio: "Diferencia con el valor base <= 0,01 mGy.",
   },
 ];
 

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -120,16 +120,19 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
   },
   {
     codigo: "2.8",
-    nombre: "Determinacion del factor de correccion del producto kerma-area (PKA)",
+    nombre: "Determinación del factor de corrección del producto kerma-área (PKA)",
     grupo: "B",
     orden: 8,
-    objetivo:
-      "Verificar si el medidor de dosis-area (DAP meter) del equipo esta calibrado correctamente, calculando un factor de correccion.",
-    instrumentacion: "Sensor RaySafe X2 RF, cinta metrica, regla para medir campo de irradiacion.",
+    objetivo: "Determinar el factor de corrección del sistema medidor de PKA.",
+    instrumentacion: "Analizador de rayos X RaySafe X2 con detector para radiodiagnóstico.",
     metodologia:
-      "Se usaron los mismos programas clinicos (Extremidad, Torax, Columna). Se midio el Kerma en aire con el sensor y el area del campo de irradiacion.",
+      "Se posicionó el detector del sistema dosimétrico en el centro del haz de radiación, manteniendo una distancia conocida entre el foco del tubo de rayos X y el detector.\n\n" +
+      "Se realizó una exposición con parámetros técnicos representativos de la práctica clínica y se registró el kerma en aire mediante el sistema dosimétrico.\n\n" +
+      "Posteriormente, se estimó el producto kerma-área (PkA) multiplicando el kerma en aire medido por el área del campo de irradiación corregida a la distancia del detector.\n\n" +
+      "Finalmente, el valor obtenido se comparó con el PkA reportado por el sistema del equipo, calculando el factor de corrección del indicador de PkA.",
     criterio:
-      "Se registra como referencia. Un factor muy diferente de 1.0 indica que el medidor DAP del equipo necesita recalibracion.",
+      "De acuerdo con el protocolo IAEA-TECDOC-1958, esta prueba tiene como objetivo determinar el factor de corrección del indicador de producto kerma-área (PKA) o DAP del equipo.\n" +
+      "Por lo tanto, no se establece un criterio de aceptación ni tolerancia para emitir concepto de conformidad o no conformidad. El resultado de esta prueba es el factor de corrección obtenido, el cual deberá aplicarse en las evaluaciones dosimétricas posteriores del equipo.",
   },
   {
     codigo: "2.9",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -189,12 +189,13 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     nombre: "Umbral de sensibilidad a bajo contraste",
     grupo: "E",
     orden: 13,
-    objetivo: "Evaluar la capacidad del sistema para detectar diferencias sutiles de contraste.",
+    objetivo: "Evaluar la sensibilidad del sistema para objetos de bajo contraste.",
     instrumentacion:
-      "Patron de bajo contraste (phantom con insertos de diferente densidad), Detector de imagen.",
+      "Objeto de prueba para resolución espacial de bajo contraste (patrón de pares de líneas), detector de imagen del sistema evaluado (CR o DR) y software de visualización y procesamiento de imágenes del sistema radiográfico.",
     metodologia:
-      "Se coloco el patron de bajo contraste sobre el detector, se realizo una exposicion y se identificaron los insertos de menor contraste visibles.",
-    criterio: "Segun especificaciones del fabricante y valor de referencia.",
+      "La prueba se realizó conforme al procedimiento descrito en el IAEA-TECDOC-1958, utilizando el módulo de bajo contraste del fantoma correspondiente. Se adquirió la imagen bajo condiciones representativas de operación y se evaluó visualmente la cantidad de detalles de bajo contraste visibles en la imagen.",
+    criterio:
+      "Debe observarse una cantidad mayor a tres masas o tener un porcentaje de contraste inferior a 4 %.",
   },
   {
     codigo: "2.14",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -140,11 +140,11 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "D",
     orden: 9,
     objetivo:
-      "Verificar que el indicador de dosis digital (DDI) y el indice de exposicion (EI) del sistema de imagen reportan valores correctos.",
-    instrumentacion: "Placas de cobre (1 mm), Detector de imagen (DR o CR).",
+      "Determinar la desviación de los índices de dosis para DR (DDI: detector dose index) y en los índices de exposición para CR (EI: exposure index), respecto a sus valores base.",
+    instrumentacion: "Cassette CR, lámina de cobre 1 mm Cu, software de procesamiento de imagen.",
     metodologia:
-      "Se configuro una tecnica estandar (70 kVp, Cu 1mm). Se realizo una exposicion con el detector de imagen en posicion y se comparo el EI/DI con los valores base.",
-    criterio: "Desviacion del EI y D.I. respecto a base <= 20%.",
+      "De acuerdo con el protocolo IAEA-TECDOC-1958, esta prueba consiste en registrar el valor del indicador de exposición (EI o DDI) del sistema bajo condiciones de exposición reproducibles y compararlo con el valor base definido por el fabricante o por el programa de control de calidad.",
+    criterio: "La desviación no debe exceder ± 20 % de los valores base.",
   },
   {
     codigo: "2.10",
@@ -152,11 +152,11 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "D",
     orden: 10,
     objetivo:
-      "Verificar que al repetir exposiciones con la misma tecnica, el DDI/EI reportado es consistente.",
-    instrumentacion: "Placas de cobre (1 mm), Detector de imagen.",
+      "Determinar la desviación de los índices de dosis para DR (DDI: detector dose index) y en los índices de exposición para CR (EI: exposure index), respecto a sus valores base.",
+    instrumentacion: "Cassette CR, lámina de cobre 1 mm Cu, software de procesamiento de imagen.",
     metodologia:
-      "Se repitio la misma exposicion 3 veces y se registro el EI y D.I. de cada exposicion.",
-    criterio: "CV del EI y D.I. <= 20%.",
+      "De acuerdo con el protocolo IAEA-TECDOC-1958, la repetibilidad del indicador de exposición se evalúa realizando varias exposiciones consecutivas bajo las mismas condiciones de irradiación y registrando el valor del indicador de exposición (DDI o EI) reportado por el sistema.",
+    criterio: "El valor del coeficiente de variación debe ser ≤ 20 %.",
   },
   {
     codigo: "2.11",

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -32,6 +32,7 @@ import {
   renderFotos29,
   renderFotos210,
   renderTablaChrRef,
+  renderTablaBaseRef29,
   type InformeCtx,
 } from "./secciones-convencional";
 
@@ -748,6 +749,11 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
       // Tabla de valores mínimos de referencia CHR (solo 2.6)
       if (codigo === "2.6" && aplica) {
         renderTablaChrRef(ctx);
+        y = ctx.y;
+      }
+      // Tabla de valores base de referencia DDI/EI (solo 2.9)
+      if (codigo === "2.9" && aplica) {
+        renderTablaBaseRef29(ctx, conv);
         y = ctx.y;
       }
       nextSub++;

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -303,7 +303,7 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
     doc.setFont("helvetica", "normal");
     doc.setFontSize(fontSize);
     doc.setTextColor(...COLOR_BLACK);
-    doc.text(lines, MARGIN + indent, y);
+    doc.text(lines, MARGIN + indent, y, { align: "justify", maxWidth: CONTENT_WIDTH - indent });
     y += lines.length * 4.2 + 2;
   }
 

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -25,6 +25,7 @@ import {
   renderFotos22,
   renderFotos23,
   renderFotos24,
+  renderFotos25,
   type InformeCtx,
 } from "./secciones-convencional";
 
@@ -765,6 +766,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         checkPage(20);
         addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
         renderFotos24(ctx, conv);
+        nextSub++;
+      }
+      if (codigo === "2.5" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos25(ctx, conv);
         nextSub++;
       }
 

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -451,8 +451,6 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
     y
   );
 
-  addFooter(doc, datos);
-
   // ═══════════════════════════════════════════════════════════
   //  PÁGINA 2 — INFORMACIÓN DE LA PRÁCTICA
   // ═══════════════════════════════════════════════════════════
@@ -1631,9 +1629,9 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
 
   // ─── Footers ───
   pageCount = doc.getNumberOfPages();
-  for (let i = 2; i <= pageCount; i++) {
+  for (let i = 1; i <= pageCount; i++) {
     doc.setPage(i);
-    addFooter(doc, datos);
+    addFooter(doc, datos, i, pageCount);
   }
 
   return doc.output("blob");
@@ -1687,9 +1685,7 @@ function addHeader(doc: jsPDF, datos: DatosInforme, logoBase64: string) {
   doc.line(MARGIN, MARGIN + HEADER_HEIGHT - 4, PAGE_WIDTH - MARGIN, MARGIN + HEADER_HEIGHT - 4);
 }
 
-function addFooter(doc: jsPDF, datos: DatosInforme) {
-  const pageNum = doc.getNumberOfPages();
-  doc.setPage(pageNum);
+function addFooter(doc: jsPDF, datos: DatosInforme, currentPage: number, totalPages: number) {
   doc.setFont("helvetica", "normal");
   doc.setFontSize(7);
   doc.setTextColor(...COLOR_GRAY);
@@ -1699,7 +1695,7 @@ function addFooter(doc: jsPDF, datos: DatosInforme) {
     ? new Date(datos.visita.fecha_visita).toLocaleDateString("es-CO")
     : "";
   doc.text(`${fechaCorta} — Pre-informe sujeto a revisión`, MARGIN, 292);
-  doc.text(`${pageNum}`, PAGE_WIDTH - MARGIN, 292, { align: "right" });
+  doc.text(`Página ${currentPage} de ${totalPages}`, PAGE_WIDTH - MARGIN, 292, { align: "right" });
 
   // Línea inferior púrpura
   doc.setFillColor(...COLOR_PRIMARY);

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -27,6 +27,7 @@ import {
   renderFotos24,
   renderFotos25,
   renderFotos26,
+  renderFotos27,
   renderTablaChrRef,
   type InformeCtx,
 } from "./secciones-convencional";
@@ -785,6 +786,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         checkPage(20);
         addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
         renderFotos26(ctx, conv);
+        nextSub++;
+      }
+      if (codigo === "2.7" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos27(ctx, conv);
         nextSub++;
       }
 

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -26,6 +26,7 @@ import {
   renderFotos23,
   renderFotos24,
   renderFotos25,
+  renderFotos26,
   type InformeCtx,
 } from "./secciones-convencional";
 
@@ -739,6 +740,20 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
       // Criterio de aceptación
       addSubsectionTitle(`${codigo}.${nextSub}.`, "Criterio de aceptación");
       addParagraph(cat.criterio);
+      // Tabla de valores mínimos de referencia CHR (solo 2.6)
+      if (codigo === "2.6" && aplica) {
+        checkPage(36);
+        autoTable(doc, {
+          startY: y,
+          head: [["Tensión (kV)", "CHR mínima (mm Al)"]],
+          body: [["60", "1,8"], ["70", "2,1"], ["80", "2,3"], ["90", "2,5"]],
+          styles: { fontSize: 8, cellPadding: 2, halign: "center" as const },
+          headStyles: { fillColor: [109, 40, 217] as [number, number, number], textColor: 255, fontStyle: "bold" as const },
+          columnStyles: { 0: { cellWidth: 40 }, 1: { cellWidth: 50 } },
+          margin: { left: MARGIN + (CONTENT_WIDTH - 90) / 2 },
+        });
+        y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+      }
       nextSub++;
 
       // Diagrama radiométrico (solo 2.1)
@@ -772,6 +787,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         checkPage(20);
         addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
         renderFotos25(ctx, conv);
+        nextSub++;
+      }
+      if (codigo === "2.6" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos26(ctx, conv);
         nextSub++;
       }
 

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -28,6 +28,7 @@ import {
   renderFotos25,
   renderFotos26,
   renderFotos27,
+  renderFotos28,
   renderTablaChrRef,
   type InformeCtx,
 } from "./secciones-convencional";
@@ -794,6 +795,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         renderFotos27(ctx, conv);
         nextSub++;
       }
+      if (codigo === "2.8" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos28(ctx, conv);
+        nextSub++;
+      }
 
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
@@ -1015,6 +1022,11 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
           conceptoParrafo = "La prueba de rendimiento del tubo de rayos X, repetibilidad y linealidad se considera conforme, ya que el coeficiente de variación obtenido para las exposiciones repetidas y las desviaciones observadas en la linealidad del rendimiento se encuentran dentro de los criterios de aceptación establecidos.";
           accionesTexto = "No se requieren acciones correctivas. Se recomienda mantener las condiciones actuales de operación del equipo y continuar con el seguimiento periódico dentro del programa de control de calidad.";
         }
+      } else if (codigo === "2.8" && aplica) {
+        conceptoLabel = "NO APLICA";
+        conceptoParrafo = "La prueba no define tolerancias, debido a que es de carácter descriptivo y de referencia técnica.";
+        accionesTexto = "No Aplica";
+        esNoConforme = false;
       } else if (!aplica) {
         conceptoLabel = "NO APLICA";
         esNoConforme = false;

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -27,6 +27,7 @@ import {
   renderFotos24,
   renderFotos25,
   renderFotos26,
+  renderTablaChrRef,
   type InformeCtx,
 } from "./secciones-convencional";
 
@@ -742,17 +743,8 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
       addParagraph(cat.criterio);
       // Tabla de valores mínimos de referencia CHR (solo 2.6)
       if (codigo === "2.6" && aplica) {
-        checkPage(36);
-        autoTable(doc, {
-          startY: y,
-          head: [["Tensión (kV)", "CHR mínima (mm Al)"]],
-          body: [["60", "1,8"], ["70", "2,1"], ["80", "2,3"], ["90", "2,5"]],
-          styles: { fontSize: 8, cellPadding: 2, halign: "center" as const },
-          headStyles: { fillColor: [109, 40, 217] as [number, number, number], textColor: 255, fontStyle: "bold" as const },
-          columnStyles: { 0: { cellWidth: 40 }, 1: { cellWidth: 50 } },
-          margin: { left: MARGIN + (CONTENT_WIDTH - 90) / 2 },
-        });
-        y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+        renderTablaChrRef(ctx);
+        y = ctx.y;
       }
       nextSub++;
 

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -32,6 +32,7 @@ import {
   renderFotos29,
   renderFotos210,
   renderFotos211,
+  renderFotos212,
   renderTablaChrRef,
   renderTablaBaseRef29,
   type InformeCtx,
@@ -835,6 +836,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         renderFotos211(ctx, conv);
         nextSub++;
       }
+      if (codigo === "2.12" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos212(ctx, conv);
+        nextSub++;
+      }
 
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
@@ -1118,6 +1125,27 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
               "El coeficiente de variación del indicador de exposición supera el límite establecido del 20 %, indicando variabilidad inaceptable en la respuesta del sistema de imagen.";
             accionesTexto =
               "Se recomienda revisar el sistema de adquisición de imágenes y verificar la estabilidad de las condiciones de exposición. Deberá repetirse la prueba para confirmar el restablecimiento de las condiciones aceptables de funcionamiento.";
+          }
+        }
+      } else if (codigo === "2.12" && aplica) {
+        const plmm = conv.resolucion?.pares_lineas_plmm;
+        if (plmm == null) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const conforme = plmm >= 2.4;
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "El valor medido de la resolución espacial cumple con el criterio de aceptación establecido.";
+            accionesTexto =
+              "No se requieren acciones correctivas. Se recomienda continuar con el programa de control de calidad establecido.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "El valor medido de la resolución espacial no cumple con el criterio de aceptación establecido.";
+            accionesTexto =
+              "Se recomienda repetir la prueba para descartar errores en la adquisición o visualización de la imagen. Si el resultado persiste fuera del criterio de aceptación, deberá notificarse al servicio de mantenimiento para la revisión del sistema.";
           }
         }
       } else if (codigo === "2.11" && aplica) {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -33,6 +33,7 @@ import {
   renderFotos210,
   renderFotos211,
   renderFotos212,
+  renderFotos213,
   renderTablaChrRef,
   renderTablaBaseRef29,
   type InformeCtx,
@@ -842,6 +843,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         renderFotos212(ctx, conv);
         nextSub++;
       }
+      if (codigo === "2.13" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos213(ctx, conv);
+        nextSub++;
+      }
 
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
@@ -1125,6 +1132,33 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
               "El coeficiente de variación del indicador de exposición supera el límite establecido del 20 %, indicando variabilidad inaceptable en la respuesta del sistema de imagen.";
             accionesTexto =
               "Se recomienda revisar el sistema de adquisición de imágenes y verificar la estabilidad de las condiciones de exposición. Deberá repetirse la prueba para confirmar el restablecimiento de las condiciones aceptables de funcionamiento.";
+          }
+        }
+      } else if (codigo === "2.13" && aplica) {
+        const bc = conv.bajoContraste;
+        if (!bc) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const KEYS_BC = [
+            "contraste_9_4", "contraste_8_0", "contraste_5_6", "contraste_4_0",
+            "contraste_2_8", "contraste_1_8", "contraste_1_3", "contraste_0_9",
+          ] as const;
+          const visibles = KEYS_BC.filter((k) => bc[k]).length;
+          const bajoUmb = bc.contraste_2_8 || bc.contraste_1_8 || bc.contraste_1_3 || bc.contraste_0_9;
+          const conforme = visibles > 3 || !!bajoUmb;
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "El sistema cuenta con el umbral de sensibilidad suficiente para el contexto de la práctica clínica.";
+            accionesTexto =
+              "No se requieren acciones correctivas. Se recomienda continuar con el programa de control de calidad establecido.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "El sistema no cuenta con el umbral de sensibilidad suficiente para el contexto de la práctica clínica.";
+            accionesTexto =
+              "Se deberá verificar el detector, el sistema de procesamiento de imagen y las condiciones de exposición, y repetir la prueba para confirmar el cumplimiento de los criterios establecidos.";
           }
         }
       } else if (codigo === "2.12" && aplica) {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -746,7 +746,14 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
 
       // Criterio de aceptación
       addSubsectionTitle(`${codigo}.${nextSub}.`, "Criterio de aceptación");
-      addParagraph(cat.criterio);
+      const criterioTexto =
+        codigo === "2.11"
+          ? cat.criterio.replace(
+              "[TOLERANCIA_PCT]",
+              String(conv.uniformidadDetector[0]?.tolerancia_pct ?? 15),
+            )
+          : cat.criterio;
+      addParagraph(criterioTexto);
       // Tabla de valores mínimos de referencia CHR (solo 2.6)
       if (codigo === "2.6" && aplica) {
         renderTablaChrRef(ctx);

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -29,6 +29,8 @@ import {
   renderFotos26,
   renderFotos27,
   renderFotos28,
+  renderFotos29,
+  renderFotos210,
   renderTablaChrRef,
   type InformeCtx,
 } from "./secciones-convencional";
@@ -801,6 +803,18 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         renderFotos28(ctx, conv);
         nextSub++;
       }
+      if (codigo === "2.9" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos29(ctx, conv);
+        nextSub++;
+      }
+      if (codigo === "2.10" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos210(ctx, conv);
+        nextSub++;
+      }
 
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
@@ -1027,6 +1041,65 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         conceptoParrafo = "La prueba no define tolerancias, debido a que es de carácter descriptivo y de referencia técnica.";
         accionesTexto = "No Aplica";
         esNoConforme = false;
+      } else if (codigo === "2.9" && aplica) {
+        const toma1 = conv.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
+        const ei = toma1?.ei ?? null;
+        const eiBase = toma1?.ei_base ?? null;
+        const di = toma1?.di ?? null;
+        const diBase = toma1?.di_base ?? null;
+        const hayDatos = ei != null;
+        const hayBase = eiBase != null;
+        if (!hayDatos || !hayBase) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const eiDev = eiBase > 0 ? Math.abs(ei - eiBase) / eiBase : Infinity;
+          const diDev =
+            di != null && diBase != null && diBase !== 0
+              ? Math.abs(di - diBase) / Math.abs(diBase)
+              : null;
+          const conforme = eiDev <= 0.2 && (diDev == null || diDev <= 0.2);
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "Los indicadores de exposición evaluados cumplen con el criterio de aceptación establecido, presentando desviaciones dentro del límite del ± 20 % respecto a los valores base.";
+            accionesTexto =
+              "No se requieren acciones correctivas. Se recomienda mantener las condiciones actuales de operación del equipo y continuar con el seguimiento periódico dentro del programa de control de calidad.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "Uno o más indicadores de exposición evaluados presentan desviaciones superiores al ± 20 % respecto a los valores base establecidos.";
+            accionesTexto =
+              "Se recomienda verificar las condiciones de exposición y los parámetros del sistema de imagen. Deberá repetirse la prueba tras cualquier intervención técnica para confirmar el restablecimiento de los valores dentro de las tolerancias.";
+          }
+        }
+      } else if (codigo === "2.10" && aplica) {
+        const grupo1 = conv.ddiMediciones.filter((m) => m.grupo === 1);
+        const eiVals = grupo1.map((m) => m.ei).filter((v): v is number => v != null);
+        if (eiVals.length < 2) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const eiAvg = eiVals.reduce((s, v) => s + v, 0) / eiVals.length;
+          const eiStd = Math.sqrt(
+            eiVals.reduce((s, v) => s + (v - eiAvg) ** 2, 0) / (eiVals.length - 1),
+          );
+          const eiCv = eiAvg > 0 ? eiStd / eiAvg : Infinity;
+          const conforme = eiCv <= 0.2;
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "El sistema presenta adecuada repetibilidad del indicador de exposición bajo condiciones de irradiación reproducibles, con un coeficiente de variación dentro del límite del 20 %.";
+            accionesTexto =
+              "No se requieren acciones correctivas. Se recomienda mantener las condiciones actuales de operación del equipo y continuar con el seguimiento periódico dentro del programa de control de calidad.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "El coeficiente de variación del indicador de exposición supera el límite establecido del 20 %, indicando variabilidad inaceptable en la respuesta del sistema de imagen.";
+            accionesTexto =
+              "Se recomienda revisar el sistema de adquisición de imágenes y verificar la estabilidad de las condiciones de exposición. Deberá repetirse la prueba para confirmar el restablecimiento de las condiciones aceptables de funcionamiento.";
+          }
+        }
       } else if (!aplica) {
         conceptoLabel = "NO APLICA";
         esNoConforme = false;

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -31,6 +31,7 @@ import {
   renderFotos28,
   renderFotos29,
   renderFotos210,
+  renderFotos211,
   renderTablaChrRef,
   renderTablaBaseRef29,
   type InformeCtx,
@@ -821,6 +822,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         renderFotos210(ctx, conv);
         nextSub++;
       }
+      if (codigo === "2.11" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos211(ctx, conv);
+        nextSub++;
+      }
 
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
@@ -1104,6 +1111,46 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
               "El coeficiente de variación del indicador de exposición supera el límite establecido del 20 %, indicando variabilidad inaceptable en la respuesta del sistema de imagen.";
             accionesTexto =
               "Se recomienda revisar el sistema de adquisición de imágenes y verificar la estabilidad de las condiciones de exposición. Deberá repetirse la prueba para confirmar el restablecimiento de las condiciones aceptables de funcionamiento.";
+          }
+        }
+      } else if (codigo === "2.11" && aplica) {
+        const dets = conv.uniformidadDetector ?? [];
+        if (dets.length === 0) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const calcMaxGlobal = (det: (typeof dets)[number]) => {
+            const tolPct = det.tolerancia_pct ?? 15;
+            let maxG = 0;
+            for (const orient of ["ac", "ca"] as const) {
+              const center = det[`roi_0_vmp_${orient}` as keyof typeof det] as number | undefined;
+              if (center == null) continue;
+              for (let i = 1; i <= 4; i++) {
+                const vmp = det[`roi_${i}_vmp_${orient}` as keyof typeof det] as number | undefined;
+                if (vmp != null) maxG = Math.max(maxG, Math.abs((vmp - center) / center) * 100);
+              }
+            }
+            return { maxG, tolPct };
+          };
+
+          const allConforme = dets.every((det) => {
+            const { maxG, tolPct } = calcMaxGlobal(det);
+            const tieneVmp = (det.roi_0_vmp_ac != null || det.roi_0_vmp_ca != null);
+            return tieneVmp && maxG <= tolPct && !det.pixeles_defectuosos && !det.artefactos;
+          });
+
+          esNoConforme = !allConforme;
+          if (allConforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "El detector no presenta píxeles defectuosos ni artefactos y el valor de uniformidad se encuentra dentro de la tolerancia establecida.";
+            accionesTexto =
+              "No se requieren acciones correctivas. Se recomienda continuar con el programa de control de calidad establecido.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "Se identificaron inconformidades en la evaluación de uniformidad y/o artefactos del detector, que exceden los criterios de aceptación establecidos.";
+            accionesTexto =
+              "Se recomienda realizar revisión técnica del detector, verificar la calibración del sistema y repetir la prueba. Si los problemas persisten, escalar al fabricante o servicio técnico autorizado.";
           }
         }
       } else if (!aplica) {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -196,7 +196,7 @@ function getTextoPrueba(codigo: string): TextoPrueba {
       metodologia:
         "Se ubicó el dispositivo de verificación de colimación sobre el receptor de imagen y se ajustó el campo luminoso de manera que coincidiera con las marcas de referencia del objeto de prueba. Posteriormente, se realizó una exposición radiográfica con una técnica adecuada para visualizar el campo irradiado y la posición del rayo central.",
       criterio:
-        "La desviación entre el campo luminoso y el campo de radiación no debe exceder el 2 % de la distancia foco-receptor en cada borde ni el 4 % en total. La perpendicularidad del rayo central debe presentar una desviación angular ≤ 3°.",
+        "La desviación entre el campo luminoso y el campo de radiación no debe exceder el 2 % de la distancia foco-receptor en cada borde ni el 4 % en total. La perpendicularidad del rayo central debe presentar una desviación angular <= 3°.",
     },
     TIE: {
       objetivo:
@@ -205,7 +205,7 @@ function getTextoPrueba(codigo: string): TextoPrueba {
       metodologia:
         "Se posicionó el medidor no invasivo sobre la mesa, en el centro del haz de radiación, ajustando el tamaño del campo al volumen sensible del instrumento. Se seleccionó una combinación representativa de tensión y corriente del generador y se realizaron al menos tres exposiciones para un tiempo de exposición determinado.",
       criterio:
-        "La desviación entre el tiempo de exposición seleccionado y el tiempo medido no debe exceder ±10 %. La repetibilidad de las mediciones debe presentar un coeficiente de variación (CV) ≤ 10 %.",
+        "La desviación entre el tiempo de exposición seleccionado y el tiempo medido no debe exceder ±10 %. La repetibilidad de las mediciones debe presentar un coeficiente de variación (CV) <= 10 %.",
     },
     KVP: {
       objetivo:
@@ -214,7 +214,7 @@ function getTextoPrueba(codigo: string): TextoPrueba {
       metodologia:
         "Se posicionó el medidor no invasivo sobre la mesa, en el centro del haz de radiación. Se seleccionaron al menos tres valores representativos de tensión del tubo de rayos X y se realizaron al menos tres exposiciones para cada valor seleccionado, registrando la tensión medida en cada irradiación.",
       criterio:
-        "La desviación entre la tensión seleccionada y la tensión medida no debe exceder ±10 %. La repetibilidad de las mediciones debe presentar un coeficiente de variación (CV) ≤ 5 %.",
+        "La desviación entre la tensión seleccionada y la tensión medida no debe exceder ±10 %. La repetibilidad de las mediciones debe presentar un coeficiente de variación (CV) <= 5 %.",
     },
     CHR: {
       objetivo:

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1148,10 +1148,10 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   let linMaxPct = 0;
   let prevRend: number | null = null;
 
+  ctx.checkPage(8);
   doc.setFont("helvetica", "bold");
   doc.setFontSize(9);
   doc.setTextColor(...COLOR_BLACK);
-  ctx.checkPage(8);
   doc.text("a) Evaluación del rendimiento del tubo de rayos X y linealidad", MARGIN, ctx.y);
   ctx.y += 6;
 
@@ -1207,10 +1207,10 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const conformeRep = kermasRep.length === 0 || cvRep <= 5;
   const conformeLin = gruposArr.length <= 1 || linMaxPct <= 10;
 
+  ctx.checkPage(8);
   doc.setFont("helvetica", "bold");
   doc.setFontSize(9);
   doc.setTextColor(...COLOR_BLACK);
-  ctx.checkPage(8);
   doc.text("b) Evaluación de la repetibilidad de la radiación de salida", MARGIN, ctx.y);
   ctx.y += 6;
 

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -80,6 +80,8 @@ export interface DatosConvencional {
   fotos24?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Fotografía de montaje RaySafe para la sección 2.5.7 (misma imagen que 2.4) */
   fotos25?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Fotografía de montaje RaySafe para la sección 2.6.7 (misma imagen que 2.4) */
+  fotos26?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Setup y mediciones del RaySafe (pruebas 2.4–2.8) */
   raysafeSetup?: ConvRaysafeSetup;
   raysafeMediciones: ConvRaysafeMedicion[];
@@ -178,6 +180,8 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   if (img24) fotos24.push({ label: "Fig. Implementación de instrumentación en la prueba", ...img24 });
   const fotos25: NonNullable<DatosConvencional["fotos25"]> = [];
   if (img24) fotos25.push({ label: "Fig 2.5.1. Implementación de instrumentación en la prueba", ...img24 });
+  const fotos26: NonNullable<DatosConvencional["fotos26"]> = [];
+  if (img24) fotos26.push({ label: "Fig 2.6.1 Implementación de instrumentación en la prueba", ...img24 });
 
   return {
     secciones: seccionesEfectivas,
@@ -192,6 +196,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     fotos23,
     fotos24,
     fotos25,
+    fotos26,
     raysafeSetup,
     raysafeMediciones,
   };
@@ -501,6 +506,37 @@ export function renderFotos24(ctx: InformeCtx, conv: DatosConvencional) {
     return;
   }
   const CWIDTH = 170; // ancho de contenido (mm)
+  for (const f of fotos) {
+    const maxW = CWIDTH * 0.5;
+    const maxH = 80;
+    const scale = Math.min(maxW / f.width, maxH / f.height, 1);
+    const w = f.width * scale;
+    const h = f.height * scale;
+    ctx.checkPage(h + 14);
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try {
+      doc.addImage(f.dataUrl, x, ctx.y, w, h);
+    } catch {
+      // imagen no renderizable
+    }
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7);
+    doc.setTextColor(...COLOR_GRAY);
+    const caption = doc.splitTextToSize(f.label, CWIDTH);
+    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
+    ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.6.7: fotografía del montaje con sensor RaySafe */
+export function renderFotos26(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos26 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
+    return;
+  }
+  const CWIDTH = 170;
   for (const f of fotos) {
     const maxW = CWIDTH * 0.5;
     const maxH = 80;
@@ -1041,6 +1077,10 @@ function render26(ctx: InformeCtx, conv: DatosConvencional): number {
     didParseCell: colorearConcepto(3),
   });
   ctx.y = finalY(doc) + 4;
+
+  ctx.addParagraph(
+    "Para la evaluación del cumplimiento se compararon los valores medidos con los valores mínimos de referencia de capa hemirreductora correspondientes a cada nivel de tensión.",
+  );
 
   ctx.addSubsectionTitle("2.6.5.", "Análisis");
   const todosConformes = rows.every((r) => r[3] === "Conforme");

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1761,31 +1761,23 @@ function render211(ctx: InformeCtx, conv: DatosConvencional): number {
           i === 0 || center == null || vmp == null
             ? "—"
             : `${(Math.abs((vmp - center) / center) * 100).toFixed(2)} %`;
-        const conceptoCell =
-          i === 0 || center == null || vmp == null
-            ? "—"
-            : Math.abs((vmp - center) / center) * 100 <= tolerancia
-              ? "Conforme"
-              : "No conforme";
         return [
           label,
           vmp != null ? vmp.toFixed(2) : "—",
           desv != null ? desv.toFixed(2) : "—",
           uniformidad,
-          conceptoCell,
         ];
       });
 
       ctx.checkPage(40);
       autoTable(doc, {
+        ...TABLE_STYLE,
         startY: ctx.y,
-        head: [["ROI", "VMP", "Desviación", "Uniformidad (%)", "Concepto"]],
+        head: [["ROI", "VMP", "Desviación", "Uniformidad (%)"]],
         body: rows,
-        theme: "grid",
-        styles: { fontSize: 7.5, cellPadding: 2, font: "helvetica", halign: "center" },
-        headStyles: { fillColor: [37, 99, 235], textColor: 255, fontStyle: "bold" },
-        columnStyles: { 0: { halign: "left" } },
-        margin: { left: MARGIN, right: MARGIN },
+        headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
+        bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" as const },
+        columnStyles: { 0: { halign: "left" as const } },
       });
       ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 5;
     }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -15,6 +15,7 @@ import type {
   ConvRaysafeMedicion,
   ConvDdiMedicion,
   ConvUniformidadDetector,
+  ConvResolucion,
 } from "@/lib/equipos/convencional/db/types";
 import {
   ITEMS_INSPECCION_EQUIPO,
@@ -101,6 +102,10 @@ export interface DatosConvencional {
   ddiMediciones: ConvDdiMedicion[];
   /** Mediciones de uniformidad del detector (prueba 2.11) */
   uniformidadDetector: ConvUniformidadDetector[];
+  /** Fotografía del patrón de resolución para la sección 2.12.7 */
+  fotos212?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Medición de resolución espacial (prueba 2.12) */
+  resolucion?: ConvResolucion;
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -126,7 +131,7 @@ async function cargarImagen(
 }
 
 export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector] =
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion] =
     await Promise.all([
       db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
@@ -140,6 +145,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
       db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
       db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
       db.conv_uniformidad_detector.where("visita_id").equals(visitaId).sortBy("item_numero"),
+      db.conv_resolucion.where("visita_id").equals(visitaId).first(),
     ]);
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
@@ -213,6 +219,12 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   const fotos210: NonNullable<DatosConvencional["fotos210"]> = [];
   if (img29) fotos210.push({ label: "Fig. 2.10.1 Montaje experimental para la prueba de repetibilidad DDI/EI", ...img29 });
 
+  // Fotografía patrón resolución para 2.12.7
+  const ev212 = evidencias.find((e) => e.prueba_codigo === "2.12" && e.slot === "montaje_resolucion");
+  const img212 = await cargarImagen(ev212);
+  const fotos212: NonNullable<DatosConvencional["fotos212"]> = [];
+  if (img212) fotos212.push({ label: "Fig. 2.12.1 Patrón de resolución espacial", ...img212 });
+
   // Fotografías DICOM para 2.11.7 (0° y 180°)
   const SLOTS_FOTOS_211: [string, string][] = [
     ["dicom_0", "Fig. 2.11.1 Orientación inicial 0°"],
@@ -244,10 +256,12 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     fotos29,
     fotos210,
     fotos211,
+    fotos212,
     raysafeSetup,
     raysafeMediciones,
     ddiMediciones,
     uniformidadDetector,
+    resolucion,
   };
 }
 
@@ -630,6 +644,32 @@ export function renderFotos29(ctx: InformeCtx, conv: DatosConvencional) {
     } catch {
       // imagen no renderizable
     }
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7);
+    doc.setTextColor(...COLOR_GRAY);
+    const caption = doc.splitTextToSize(f.label, CWIDTH);
+    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
+    ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.12.7: fotografía del patrón de resolución espacial */
+export function renderFotos212(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos212 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del patrón de resolución.");
+    return;
+  }
+  const CWIDTH = 170;
+  for (const f of fotos) {
+    const maxW = CWIDTH * 0.7;
+    const scale = Math.min(maxW / f.width, 100 / f.height, 1);
+    const w = f.width * scale;
+    const h = f.height * scale;
+    ctx.checkPage(h + 16);
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try { doc.addImage(f.dataUrl, x, ctx.y, w, h); } catch { /* no renderizable */ }
     doc.setFont("helvetica", "italic");
     doc.setFontSize(7);
     doc.setTextColor(...COLOR_GRAY);
@@ -1722,6 +1762,66 @@ function render210(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+// ─── Sección 2.12: Resolución espacial de alto contraste ───
+
+function render212(ctx: InformeCtx, conv: DatosConvencional): number {
+  const resol = conv.resolucion;
+  const plmm = resol?.pares_lineas_plmm;
+
+  // ── 2.12.4 Resultados ──
+  ctx.addSubsectionTitle("2.12.4.", "Resultados");
+  ctx.addParagraph("La prueba se llevó a cabo bajo las siguientes condiciones de medición:");
+
+  ctx.checkPage(18);
+  const { doc, autoTable } = ctx;
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    body: [
+      ["Distancia foco-receptor, SID (cm):", fmt(resol?.sid_cm, 0), "Tensión (kVp):", fmt(resol?.tecnica_kv, 0)],
+    ],
+    headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
+    bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" as const },
+    columnStyles: { 0: { halign: "left" as const }, 2: { halign: "left" as const } },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 5;
+
+  ctx.addParagraph(
+    "Se registró el grupo máximo de pares de líneas por milímetro visible de forma distinguible en la imagen obtenida.",
+  );
+
+  ctx.checkPage(14);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Parámetro", "Valor"]],
+    body: [["Cantidad de pares de líneas visibles (pl/mm)", plmm != null ? `${plmm.toFixed(1)} pl/mm` : "—"]],
+    headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
+    bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" as const },
+    columnStyles: { 0: { halign: "left" as const } },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 5;
+
+  // ── 2.12.5 Análisis ──
+  ctx.addSubsectionTitle("2.12.5.", "Análisis");
+  ctx.addParagraph(
+    "El valor de resolución espacial obtenido fue comparado con el criterio de aceptación establecido en el protocolo de control de calidad aplicable.",
+  );
+  if (plmm == null) {
+    ctx.addParagraph("No se registró el valor de resolución espacial para esta prueba.");
+  } else if (plmm >= 2.4) {
+    ctx.addParagraph(
+      "Se observa que la resolución espacial observada corresponde a un valor que se encuentra por encima del mínimo requerido.",
+    );
+  } else {
+    ctx.addParagraph(
+      "Se observa que la resolución espacial observada corresponde a un valor que se encuentra por debajo del mínimo requerido.",
+    );
+  }
+
+  return 6;
+}
+
 // ─── Sección 2.11: Uniformidad y artefactos del detector ───
 
 function render211(ctx: InformeCtx, conv: DatosConvencional): number {
@@ -1902,6 +2002,8 @@ export function renderResultadosSeccion(
       return render210(ctx, conv);
     case "2.11":
       return render211(ctx, conv);
+    case "2.12":
+      return render212(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1327,94 +1327,44 @@ function render28(ctx: InformeCtx, conv: DatosConvencional): number {
 
   const d1 = conv.raysafeSetup?.distancia_foco_sensor_cm ?? 100;
   const d2 = conv.raysafeSetup?.distancia_foco_detector_d2_cm ?? d1;
-  const factorDist = (d2 / d1) ** 2; // factor de corrección geométrica
+  const factorDist = (d2 / d1) ** 2;
 
-  ctx.addParagraph(
-    `Las mediciones se realizaron con el sensor ubicado a ${d1} cm del foco. ` +
-      (d2 !== d1
-        ? `La distancia foco-detector de imagen es ${d2} cm. Las mediciones de kerma y área se corrigen al plano del detector mediante el factor (${d2}/${d1})² = ${factorDist.toFixed(4)}.`
-        : "No se aplicó corrección de distancia (sensor en el plano del detector)."),
-  );
+  ctx.addParagraph("La prueba se llevó a cabo bajo las siguientes condiciones de medición:");
 
   const rows = mediciones.map((m) => {
     const kerma = m.dosis_medida_mgy!;
     const ancho = m.ancho_irradiacion_cm ?? 0;
     const largo = m.largo_irradiacion_cm ?? 0;
-    const areaMed = ancho * largo;
-    const areaCorr = areaMed * factorDist;
+    const areaCorr = ancho * largo * factorDist;
     const kermaCorr = kerma * factorDist;
-    const dapEst = kermaCorr * areaCorr; // mGy·cm²
+    const dapEst = kermaCorr * areaCorr;
     const dapNom = m.dap_nominal;
     const fc = dapNom != null && dapNom > 0 ? dapEst / dapNom : null;
-
     return {
-      toma: m.toma_numero,
-      kv: m.kv_nominal ?? "—",
+      kv: m.kv_nominal != null ? m.kv_nominal.toFixed(1) : "—",
       mas: m.mas_nominal != null ? m.mas_nominal.toFixed(1) : "—",
       dapNom: dapNom != null ? dapNom.toFixed(0) : "—",
-      ancho: ancho > 0 ? ancho.toFixed(1) : "—",
-      largo: largo > 0 ? largo.toFixed(1) : "—",
-      areaCorr: areaCorr > 0 ? areaCorr.toFixed(0) : "—",
-      kermaCorr: kermaCorr.toFixed(5),
       dapEst: dapEst > 0 ? dapEst.toFixed(2) : "—",
-      fc: fc != null ? fc.toFixed(2) : "—",
+      fc: fc != null ? fc.toFixed(1) : "—",
     };
   });
 
-  ctx.checkPage(50);
-  addCaption(ctx, "Tabla 2.8.1. Estimación del DAP y factor de corrección del medidor PKA");
+  ctx.checkPage(40);
+  addCaption(ctx, "Tabla 2.8.1 Determinación del factor de corrección del PKA");
   autoTable(doc, {
     ...TABLE_STYLE,
     startY: ctx.y,
-    head: [
-      [
-        "Toma",
-        "Tensión (kV)",
-        "Exp. (mAs)",
-        "DAP nominal (mGy·cm²)",
-        "Ancho (cm)",
-        "Largo (cm)",
-        "Área corregida (cm²)",
-        "Kerma corregido (mGy)",
-        "DAP estimado (mGy·cm²)",
-        "Factor de corrección",
-      ],
-    ],
-    body: rows.map((r) => [
-      r.toma,
-      r.kv,
-      r.mas,
-      r.dapNom,
-      r.ancho,
-      r.largo,
-      r.areaCorr,
-      r.kermaCorr,
-      r.dapEst,
-      r.fc,
-    ]),
-    styles: { fontSize: 6.5, cellPadding: 1.5 },
-    headStyles: { fillColor: COLOR_PRIMARY, textColor: [255, 255, 255] as [number, number, number], fontStyle: "bold", fontSize: 6 },
+    head: [["Tensión (kV)", "Carga (mAs)", "DAP nominal (mGy·cm²)", "DAP estimado (mGy·cm²)", "Factor de corrección"]],
+    body: rows.map((r) => [r.kv, r.mas, r.dapNom, r.dapEst, r.fc]),
+    columnStyles: { 4: { cellWidth: 32 } },
   });
   ctx.y = finalY(doc) + 4;
 
   // ── 2.8.5 Análisis ──
   ctx.addSubsectionTitle("2.8.5.", "Análisis");
-
-  const fcs = rows.map((r) => parseFloat(r.fc)).filter((v) => !isNaN(v));
-  if (fcs.length === 0) {
-    ctx.addParagraph("No se registraron datos suficientes para calcular el factor de corrección.");
-    return 6;
-  }
-  const fcMean = mean(fcs);
-  const fcMin = Math.min(...fcs);
-  const fcMax = Math.max(...fcs);
-  const lejos = fcs.some((f) => Math.abs(f - 1.0) > 0.2);
-
   ctx.addParagraph(
-    `Los factores de corrección del medidor PKA calculados para las técnicas evaluadas presentan valores entre ${fcMin.toFixed(2)} y ${fcMax.toFixed(2)}, con un promedio de ${fcMean.toFixed(2)}. ` +
-      (lejos
-        ? "Se observa una desviación significativa con respecto a la unidad, lo que sugiere que el medidor de producto kerma-área del equipo requiere revisión de su calibración."
-        : "Los valores obtenidos son cercanos a la unidad, lo que indica que el medidor de producto kerma-área del equipo presenta una respuesta adecuada bajo las condiciones evaluadas."),
+    "Se evidencian diferencias entre los valores estimados de PkA o DAP y los reportados por el equipo, " +
+      "lo que permite determinar un factor de corrección aplicable en evaluaciones dosimétricas posteriores.",
   );
 
   return 6;

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1119,76 +1119,81 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   );
 
   ctx.addSubsectionTitle("2.7.4.", "Resultados");
+  const distancia = conv.raysafeSetup?.distancia_foco_sensor_cm ?? 100;
   ctx.addParagraph(
     "La prueba se llevó a cabo bajo las siguientes condiciones de medición:\n" +
-      `Tensión de referencia: 80 kVp\nDistancia foco-detector: ${conv.raysafeSetup?.distancia_foco_sensor_cm ?? 100} cm`,
+      `Tensión de referencia: 80 kVp\n` +
+      `Distancia foco-detector: ${distancia} cm\n` +
+      "Estimación del rendimiento: normalizado a 100 centímetros\n" +
+      "Factor de corrección por presión y temperatura del analizador: 1,0",
+  );
+  ctx.addParagraph(
+    "Las mediciones obtenidas se utilizaron para evaluar el valor del rendimiento del tubo de rayos X, " +
+      "la repetibilidad de la radiación de salida y la linealidad del rendimiento con respecto al mAs.",
   );
 
   if (shots80.length === 0) return SIN_DATOS(ctx);
 
-  // ── Tabla 2.7.1: Rendimiento y linealidad (agrupado por grupo_numero) ──
+  // ── Tabla 2.7.1: Rendimiento y linealidad (grupos 2-5 a 80 kV) ──
+  // Solo grupos 2–5 (variación de mAs a 80 kV); grupos 7–8 van a repetibilidad
+  const GRUPOS_LIN = new Set([2, 3, 4, 5]);
   const gruposNum = new Map<number, typeof shots80>();
   for (const m of shots80) {
-    if (m.grupo_numero == null || m.mas_nominal == null) continue;
+    if (m.grupo_numero == null || !GRUPOS_LIN.has(m.grupo_numero) || m.mas_nominal == null) continue;
     if (!gruposNum.has(m.grupo_numero)) gruposNum.set(m.grupo_numero, []);
     gruposNum.get(m.grupo_numero)!.push(m);
   }
-
-  // Para el análisis posterior también mantenemos el map por grupo
   const gruposArr = [...gruposNum.entries()].sort(([a], [b]) => a - b);
 
-  let rendRef: number | null = null;
   let linMaxPct = 0;
+  let prevRend: number | null = null;
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(9);
+  doc.setTextColor(...COLOR_BLACK);
+  ctx.checkPage(8);
+  doc.text("a) Evaluación del rendimiento del tubo de rayos X y linealidad", MARGIN, ctx.y);
+  ctx.y += 6;
 
   if (gruposArr.length > 0) {
-    const rowsLin = gruposArr.map(([grp, ms], idx) => {
+    const rowsLin = gruposArr.map(([, ms]) => {
       const mas = ms[0].mas_nominal!;
       const kermaProm = mean(ms.map((m) => m.dosis_medida_mgy!));
-      const chrProm = ms.some((m) => m.chr_medido_mmal != null)
-        ? mean(ms.filter((m) => m.chr_medido_mmal != null).map((m) => m.chr_medido_mmal!))
-        : null;
-      const rend = mas > 0 ? (kermaProm / mas) * 1000 : 0; // µGy/mAs
-      if (idx === 0) rendRef = rend;
+      const rend = mas > 0 ? (kermaProm / mas) * 1000 : 0;
+      // Linealidad: comparación con el grupo anterior (fórmula |a-b|/(a+b)*100)
       const linPct =
-        rendRef != null && rendRef > 0 && idx > 0
-          ? Math.abs((rend - rendRef) / rendRef) * 100
+        prevRend != null && prevRend > 0
+          ? (Math.abs(rend - prevRend) / (rend + prevRend)) * 100
           : null;
       if (linPct != null && linPct > linMaxPct) linMaxPct = linPct;
-      const concepto =
-        linPct == null ? "—" : linPct <= 10 ? "Conforme" : "No conforme";
+      prevRend = rend;
       return [
-        String(grp),
-        chrProm != null ? chrProm.toFixed(2) : "—",
         mas.toFixed(1),
-        kermaProm.toFixed(4),
-        rend.toFixed(2),
-        linPct != null ? linPct.toFixed(2) + " %" : "—",
-        concepto,
+        kermaProm.toFixed(3),
+        rend.toFixed(1),
+        linPct != null ? linPct.toFixed(2) + " %" : "-%",
       ];
     });
 
     ctx.checkPage(40);
-    addCaption(ctx, "Tabla 2.7.1. Reproducibilidad de la radiación de salida — rendimiento y linealidad");
+    addCaption(ctx, "Tabla 2.7.1. Rendimiento del tubo de rayos X y linealidad");
     autoTable(doc, {
       ...TABLE_STYLE,
       startY: ctx.y,
       head: [
-        [
-          "Grupo",
-          "CHR (mm Al)",
-          "Exposición nominal (mAs)",
-          "Kerma en aire promedio (mGy)",
-          "Rendimiento (µGy/mAs)",
-          "Linealidad (%)",
-          "Concepto",
-        ],
+        ["Exposición nominal (mAs)", "Kerma en aire promedio (mGy)", "Rendimiento (µGy/mAs)", "Linealidad (%)"],
       ],
       body: rowsLin,
-      columnStyles: { 6: { cellWidth: 24 } },
-      didParseCell: colorearConcepto(6),
+      columnStyles: { 0: { cellWidth: 38 } },
     });
     ctx.y = finalY(doc) + 4;
   }
+
+  ctx.addParagraph(
+    "El rendimiento del tubo se calculó como el cociente entre el kerma en aire medido y la carga " +
+      "utilizada (mAs). La linealidad se evaluó mediante la comparación del rendimiento obtenido " +
+      "para los diferentes valores de carga.",
+  );
 
   // ── Tabla 2.7.2: Repetibilidad (grupo 3 — 80kV/200mA/0.05s) ──
   const repShots = shots80
@@ -1202,24 +1207,39 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const conformeRep = kermasRep.length === 0 || cvRep <= 5;
   const conformeLin = gruposArr.length <= 1 || linMaxPct <= 10;
 
-  ctx.checkPage(28);
-  addCaption(ctx, "Tabla 2.7.2. Repetibilidad de la radiación de salida");
-  autoTable(doc, {
-    ...TABLE_STYLE,
-    startY: ctx.y,
-    head: [["Kerma en aire promedio (mGy)", "Desviación estándar (mGy)", "CV (%)", "Concepto"]],
-    body: [
-      [
-        promRep.toFixed(4),
-        stdRep.toFixed(4),
-        cvRep.toFixed(2) + " %",
-        conformeRep ? "Conforme" : "No conforme",
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(9);
+  doc.setTextColor(...COLOR_BLACK);
+  ctx.checkPage(8);
+  doc.text("b) Evaluación de la repetibilidad de la radiación de salida", MARGIN, ctx.y);
+  ctx.y += 6;
+
+  ctx.addParagraph(
+    "La repetibilidad se evaluó a partir de exposiciones repetidas bajo las mismas condiciones " +
+      "de irradiación (80 kV y aproximadamente 10 mAs).",
+  );
+
+  if (repShots.length > 0) {
+    const rowsIndiv: string[][] = repShots.map((m, i) => [String(i + 1), m.dosis_medida_mgy!.toFixed(4)]);
+
+    ctx.checkPage(40);
+    addCaption(ctx, "Tabla 2.7.2. Repetibilidad de la radiación de salida");
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      startY: ctx.y,
+      head: [["Medición", "Kerma en aire medido (mGy)"]],
+      body: [
+        ...rowsIndiv,
+        ["Promedio", promRep.toFixed(4)],
+        ["Desviación estándar (mGy)", stdRep.toFixed(4)],
+        ["CV(%)", cvRep.toFixed(2) + " %"],
       ],
-    ],
-    columnStyles: { 3: { cellWidth: 24 } },
-    didParseCell: colorearConcepto(3),
-  });
-  ctx.y = finalY(doc) + 4;
+      columnStyles: {
+        0: { cellWidth: 60, fontStyle: "bold", fillColor: COLOR_ALT_ROW },
+      },
+    });
+    ctx.y = finalY(doc) + 4;
+  }
 
   // ── 2.7.5 Análisis ──
   ctx.addSubsectionTitle("2.7.5.", "Análisis");
@@ -1229,28 +1249,16 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
     return 6;
   }
 
-  const rendMin =
-    gruposArr.length > 0
-      ? Math.min(
-          ...gruposArr.map(([, ms]) => {
-            const mas = ms[0].mas_nominal!;
-            return mas > 0 ? (mean(ms.map((m) => m.dosis_medida_mgy!)) / mas) * 1000 : 0;
-          }),
-        )
-      : 0;
-  const rendMax =
-    gruposArr.length > 0
-      ? Math.max(
-          ...gruposArr.map(([, ms]) => {
-            const mas = ms[0].mas_nominal!;
-            return mas > 0 ? (mean(ms.map((m) => m.dosis_medida_mgy!)) / mas) * 1000 : 0;
-          }),
-        )
-      : 0;
+  const allRends = gruposArr.map(([, ms]) => {
+    const mas = ms[0].mas_nominal!;
+    return mas > 0 ? (mean(ms.map((m) => m.dosis_medida_mgy!)) / mas) * 1000 : 0;
+  });
+  const rendMin = allRends.length > 0 ? Math.min(...allRends) : 0;
+  const rendMax = allRends.length > 0 ? Math.max(...allRends) : 0;
 
   if (conformeRep && conformeLin) {
     ctx.addParagraph(
-      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rendMin.toFixed(2)} y ${rendMax.toFixed(2)} µGy/mAs para los diferentes valores de carga evaluados a 80 kV. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvRep.toFixed(2)} % y la linealidad del rendimiento presenta una desviación máxima de ${linMaxPct.toFixed(2)} %, ambos dentro de los criterios de aceptación establecidos.`,
+      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rendMin.toFixed(1)} y ${rendMax.toFixed(1)} µGy/mAs para los diferentes valores de carga evaluados a 80 kV. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvRep.toFixed(2)} % y la linealidad del rendimiento presenta una desviación máxima de ${linMaxPct.toFixed(2)} %, ambos dentro de los criterios de aceptación establecidos.`,
     );
   } else {
     ctx.addParagraph(

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -16,6 +16,7 @@ import type {
   ConvDdiMedicion,
   ConvUniformidadDetector,
   ConvResolucion,
+  ConvBajoContraste,
 } from "@/lib/equipos/convencional/db/types";
 import {
   ITEMS_INSPECCION_EQUIPO,
@@ -106,6 +107,10 @@ export interface DatosConvencional {
   fotos212?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Medición de resolución espacial (prueba 2.12) */
   resolucion?: ConvResolucion;
+  /** Fotografía del patrón de bajo contraste para la sección 2.13.7 */
+  fotos213?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Medición de bajo contraste (prueba 2.13) */
+  bajoContraste?: ConvBajoContraste;
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -131,7 +136,7 @@ async function cargarImagen(
 }
 
 export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion] =
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste] =
     await Promise.all([
       db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
@@ -146,6 +151,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
       db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
       db.conv_uniformidad_detector.where("visita_id").equals(visitaId).sortBy("item_numero"),
       db.conv_resolucion.where("visita_id").equals(visitaId).first(),
+      db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
     ]);
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
@@ -219,6 +225,12 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   const fotos210: NonNullable<DatosConvencional["fotos210"]> = [];
   if (img29) fotos210.push({ label: "Fig. 2.10.1 Montaje experimental para la prueba de repetibilidad DDI/EI", ...img29 });
 
+  // Fotografía patrón bajo contraste para 2.13.7
+  const ev213 = evidencias.find((e) => e.prueba_codigo === "2.13" && e.slot === "montaje_bajo_contraste");
+  const img213 = await cargarImagen(ev213);
+  const fotos213: NonNullable<DatosConvencional["fotos213"]> = [];
+  if (img213) fotos213.push({ label: "Fig. 2.13.1 Patrón de bajo contraste", ...img213 });
+
   // Fotografías patrón resolución para 2.12.7 (montaje + DICOM)
   const SLOTS_FOTOS_212: [string, string][] = [
     ["montaje_resolucion", "Fig. 2.12.1 Foto montaje experimental"],
@@ -263,11 +275,13 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     fotos210,
     fotos211,
     fotos212,
+    fotos213,
     raysafeSetup,
     raysafeMediciones,
     ddiMediciones,
     uniformidadDetector,
     resolucion,
+    bajoContraste,
   };
 }
 
@@ -650,6 +664,32 @@ export function renderFotos29(ctx: InformeCtx, conv: DatosConvencional) {
     } catch {
       // imagen no renderizable
     }
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7);
+    doc.setTextColor(...COLOR_GRAY);
+    const caption = doc.splitTextToSize(f.label, CWIDTH);
+    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
+    ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.13.7: fotografía del patrón de bajo contraste */
+export function renderFotos213(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos213 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del patrón de bajo contraste.");
+    return;
+  }
+  const CWIDTH = 170;
+  for (const f of fotos) {
+    const maxW = CWIDTH * 0.7;
+    const scale = Math.min(maxW / f.width, 100 / f.height, 1);
+    const w = f.width * scale;
+    const h = f.height * scale;
+    ctx.checkPage(h + 16);
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try { doc.addImage(f.dataUrl, x, ctx.y, w, h); } catch { /* no renderizable */ }
     doc.setFont("helvetica", "italic");
     doc.setFontSize(7);
     doc.setTextColor(...COLOR_GRAY);
@@ -1775,6 +1815,80 @@ function render210(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+// ─── Sección 2.13: Umbral de sensibilidad a bajo contraste ───
+
+const NIVELES_BC = [
+  { key: "contraste_9_4" as const, label: "9,4 %" },
+  { key: "contraste_8_0" as const, label: "8,0 %" },
+  { key: "contraste_5_6" as const, label: "5,6 %" },
+  { key: "contraste_4_0" as const, label: "4,0 %" },
+  { key: "contraste_2_8" as const, label: "2,8 %" },
+  { key: "contraste_1_8" as const, label: "1,8 %" },
+  { key: "contraste_1_3" as const, label: "1,3 %" },
+  { key: "contraste_0_9" as const, label: "0,9 %" },
+];
+
+function render213(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { doc, autoTable } = ctx;
+  const bc = conv.bajoContraste;
+
+  // ── 2.13.4 Resultados ──
+  ctx.addSubsectionTitle("2.13.4.", "Resultados");
+  ctx.addParagraph("La prueba se llevó a cabo bajo las siguientes condiciones de medición:");
+
+  ctx.checkPage(18);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    body: [
+      ["Distancia foco-receptor, SID (cm):", fmt(bc?.sid_cm, 0), "Tensión (kVp):", fmt(bc?.tecnica_kv, 0)],
+    ],
+    headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
+    bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" as const },
+    columnStyles: { 0: { halign: "left" as const }, 2: { halign: "left" as const } },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 5;
+
+  ctx.checkPage(24);
+  addCaption(ctx, "Tabla 2.13.1. Evaluación del umbral de sensibilidad a bajo contraste");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["% Contraste", ...NIVELES_BC.map((n) => n.label)]],
+    body: [["¿Visible?", ...NIVELES_BC.map((n) => (bc?.[n.key] ? "SI" : "NO"))]],
+    headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
+    bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" as const },
+    columnStyles: { 0: { halign: "left" as const } },
+    didParseCell: (data) => {
+      if (data.section === "body" && data.column.index > 0) {
+        const val = data.cell.raw as string;
+        data.cell.styles.textColor = val === "SI" ? [16, 150, 80] : [220, 50, 50];
+        data.cell.styles.fontStyle = "bold";
+      }
+    },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 5;
+
+  // ── 2.13.5 Análisis ──
+  ctx.addSubsectionTitle("2.13.5.", "Análisis");
+
+  const visibles = bc ? NIVELES_BC.filter((n) => bc[n.key]).length : null;
+  const bajoUmb = bc && (bc.contraste_2_8 || bc.contraste_1_8 || bc.contraste_1_3 || bc.contraste_0_9);
+  const conforme = visibles != null && (visibles > 3 || bajoUmb);
+
+  if (visibles == null) {
+    ctx.addParagraph("No se registraron datos para esta prueba.");
+  } else if (conforme) {
+    ctx.addParagraph("Se observa una cantidad de masas superiores a las requeridas por el sistema.");
+  } else {
+    ctx.addParagraph(
+      `Se observa una cantidad de masas visible de ${visibles}, que no supera el mínimo requerido, y ninguno de los niveles de contraste evaluados alcanza valores por debajo del 4 %.`,
+    );
+  }
+
+  return 6;
+}
+
 // ─── Sección 2.12: Resolución espacial de alto contraste ───
 
 function render212(ctx: InformeCtx, conv: DatosConvencional): number {
@@ -2017,6 +2131,8 @@ export function renderResultadosSeccion(
       return render211(ctx, conv);
     case "2.12":
       return render212(ctx, conv);
+    case "2.13":
+      return render213(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -14,6 +14,7 @@ import type {
   ConvRaysafeSetup,
   ConvRaysafeMedicion,
   ConvDdiMedicion,
+  ConvUniformidadDetector,
 } from "@/lib/equipos/convencional/db/types";
 import {
   ITEMS_INSPECCION_EQUIPO,
@@ -91,11 +92,15 @@ export interface DatosConvencional {
   fotos29?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Fotografía de montaje DDI para la sección 2.10.7 (misma imagen que 2.9) */
   fotos210?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Fotografías de imágenes DICOM para la sección 2.11.7 (0° y 180°) */
+  fotos211?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Setup y mediciones del RaySafe (pruebas 2.4–2.8) */
   raysafeSetup?: ConvRaysafeSetup;
   raysafeMediciones: ConvRaysafeMedicion[];
   /** Mediciones DDI/EI (pruebas 2.9 y 2.10) */
   ddiMediciones: ConvDdiMedicion[];
+  /** Mediciones de uniformidad del detector (prueba 2.11) */
+  uniformidadDetector: ConvUniformidadDetector[];
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -121,7 +126,7 @@ async function cargarImagen(
 }
 
 export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones] =
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector] =
     await Promise.all([
       db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
@@ -134,6 +139,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
       db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
       db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
       db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
+      db.conv_uniformidad_detector.where("visita_id").equals(visitaId).sortBy("item_numero"),
     ]);
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
@@ -207,6 +213,18 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   const fotos210: NonNullable<DatosConvencional["fotos210"]> = [];
   if (img29) fotos210.push({ label: "Fig. 2.10.1 Montaje experimental para la prueba de repetibilidad DDI/EI", ...img29 });
 
+  // Fotografías DICOM para 2.11.7 (0° y 180°)
+  const SLOTS_FOTOS_211: [string, string][] = [
+    ["dicom_0", "Fig. 2.11.1 Orientación inicial 0°"],
+    ["dicom_180", "Fig. 2.11.2 Orientación final 180°"],
+  ];
+  const fotos211: NonNullable<DatosConvencional["fotos211"]> = [];
+  for (const [slot, label] of SLOTS_FOTOS_211) {
+    const ev = evidencias.find((e) => e.prueba_codigo === "2.11" && e.slot === slot);
+    const img = await cargarImagen(ev);
+    if (img) fotos211.push({ label, ...img });
+  }
+
   return {
     secciones: seccionesEfectivas,
     setup,
@@ -225,9 +243,11 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     fotos28,
     fotos29,
     fotos210,
+    fotos211,
     raysafeSetup,
     raysafeMediciones,
     ddiMediciones,
+    uniformidadDetector,
   };
 }
 
@@ -616,6 +636,39 @@ export function renderFotos29(ctx: InformeCtx, conv: DatosConvencional) {
     const caption = doc.splitTextToSize(f.label, CWIDTH);
     doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
     ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.11.7: imágenes DICOM de uniformidad (0° y 180°) */
+export function renderFotos211(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos211 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntaron imágenes DICOM de la prueba de uniformidad.");
+    return;
+  }
+  const CWIDTH = 170;
+  const fotosPerRow = 2;
+  const colW = CWIDTH / fotosPerRow;
+  for (let i = 0; i < fotos.length; i += fotosPerRow) {
+    const grupo = fotos.slice(i, i + fotosPerRow);
+    const maxH = 80;
+    const scales = grupo.map((f) => Math.min((colW * 0.9) / f.width, maxH / f.height, 1));
+    const rowH = Math.max(...grupo.map((f, j) => f.height * scales[j]));
+    ctx.checkPage(rowH + 16);
+    grupo.forEach((f, j) => {
+      const scale = scales[j];
+      const w = f.width * scale;
+      const h = f.height * scale;
+      const x = MARGIN + j * colW + (colW - w) / 2;
+      try { doc.addImage(f.dataUrl, x, ctx.y, w, h); } catch { /* no renderizable */ }
+      doc.setFont("helvetica", "italic");
+      doc.setFontSize(7);
+      doc.setTextColor(...COLOR_GRAY);
+      const caption = doc.splitTextToSize(f.label, colW - 4);
+      doc.text(caption, MARGIN + j * colW + colW / 2, ctx.y + rowH + 4, { align: "center" });
+    });
+    ctx.y += rowH + 12;
   }
 }
 
@@ -1669,6 +1722,128 @@ function render210(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+// ─── Sección 2.11: Uniformidad y artefactos del detector ───
+
+function render211(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { doc, autoTable } = ctx;
+  const dets = conv.uniformidadDetector ?? [];
+
+  // ── 2.11.4 Resultados ──
+  ctx.addSubsectionTitle("2.11.4.", "Resultados");
+
+  if (dets.length === 0) {
+    ctx.addParagraph("Sin datos registrados para esta prueba.");
+    return 5;
+  }
+
+  ctx.addParagraph(
+    "Se obtuvieron imágenes uniformes con el detector orientado en las direcciones ánodo–cátodo (AC, posición inicial) " +
+      "y cátodo–ánodo (CA, rotación de 180°). En cada imagen se evaluaron cinco regiones de interés (ROI) distribuidas sobre el detector.",
+  );
+
+  const roiLabels = ["ROIc (central)", "ROI 1", "ROI 2", "ROI 3", "ROI 4"];
+
+  for (const [detIdx, det] of dets.entries()) {
+    const detLabel = det.serie_detector ? ` — ${det.serie_detector}` : ` ${detIdx + 1}`;
+    const tolerancia = det.tolerancia_pct ?? 15;
+
+    for (const orient of ["ac", "ca"] as const) {
+      const orientLabel = orient === "ac" ? "Orientación AC 0°" : "Orientación CA 180°";
+      const tableNum = detIdx * 2 + (orient === "ac" ? 1 : 2);
+      ctx.addSubsectionTitle(`Tabla 2.11.${tableNum}.`, `${orientLabel}${detLabel}`);
+
+      const center = det[`roi_0_vmp_${orient}` as keyof typeof det] as number | undefined;
+
+      const rows: (string | number)[][] = roiLabels.map((label, i) => {
+        const vmp = det[`roi_${i}_vmp_${orient}` as keyof typeof det] as number | undefined;
+        const desv = det[`roi_${i}_desv_${orient}` as keyof typeof det] as number | undefined;
+        const uniformidad =
+          i === 0 || center == null || vmp == null
+            ? "—"
+            : `${(Math.abs((vmp - center) / center) * 100).toFixed(2)} %`;
+        const conceptoCell =
+          i === 0 || center == null || vmp == null
+            ? "—"
+            : Math.abs((vmp - center) / center) * 100 <= tolerancia
+              ? "Conforme"
+              : "No conforme";
+        return [
+          label,
+          vmp != null ? vmp.toFixed(2) : "—",
+          desv != null ? desv.toFixed(2) : "—",
+          uniformidad,
+          conceptoCell,
+        ];
+      });
+
+      ctx.checkPage(40);
+      autoTable(doc, {
+        startY: ctx.y,
+        head: [["ROI", "VMP", "Desviación", "Uniformidad (%)", "Concepto"]],
+        body: rows,
+        theme: "grid",
+        styles: { fontSize: 7.5, cellPadding: 2, font: "helvetica", halign: "center" },
+        headStyles: { fillColor: [37, 99, 235], textColor: 255, fontStyle: "bold" },
+        columnStyles: { 0: { halign: "left" } },
+        margin: { left: MARGIN, right: MARGIN },
+      });
+      ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 5;
+    }
+  }
+
+  // ── 2.11.5 Análisis ──
+  ctx.addSubsectionTitle("2.11.5.", "Análisis");
+
+  for (const det of dets) {
+    const tolerancia = det.tolerancia_pct ?? 15;
+
+    const calcMax = (orient: "ac" | "ca") => {
+      const center = det[`roi_0_vmp_${orient}` as keyof typeof det] as number | undefined;
+      if (center == null) return null;
+      let max = 0;
+      for (let i = 1; i <= 4; i++) {
+        const vmp = det[`roi_${i}_vmp_${orient}` as keyof typeof det] as number | undefined;
+        if (vmp != null) max = Math.max(max, Math.abs((vmp - center) / center) * 100);
+      }
+      return max;
+    };
+
+    const maxAc = calcMax("ac");
+    const maxCa = calcMax("ca");
+    const maxGlobal =
+      maxAc != null && maxCa != null
+        ? Math.max(maxAc, maxCa)
+        : (maxAc ?? maxCa ?? null);
+
+    const unifConforme = maxGlobal == null || maxGlobal <= tolerancia;
+    const conforme = unifConforme && !det.pixeles_defectuosos && !det.artefactos;
+
+    let parrafo: string;
+    if (conforme) {
+      parrafo =
+        `En la evaluación de uniformidad y artefactos del detector no se evidencian píxeles defectuosos en el detector ` +
+        `ni artefactos en la imagen. El valor máximo de desviación de uniformidad obtenido fue de ` +
+        `${maxGlobal != null ? maxGlobal.toFixed(2) : "—"} %, el cual se encuentra dentro de la tolerancia establecida de ${tolerancia} %. ` +
+        `En consecuencia, la prueba cumple con el criterio de aceptación.`;
+    } else {
+      const partes: string[] = [];
+      if (det.pixeles_defectuosos) partes.push("se identificaron píxeles defectuosos en el detector");
+      if (det.artefactos) partes.push("se observaron artefactos en la imagen");
+      if (!unifConforme && maxGlobal != null)
+        partes.push(
+          `el valor máximo de desviación de uniformidad obtenido fue de ${maxGlobal.toFixed(2)} %, superior a la tolerancia establecida de ${tolerancia} %`,
+        );
+      parrafo =
+        `En la evaluación de uniformidad y artefactos del detector, ` +
+        partes.join("; ") +
+        `. La prueba no cumple con el criterio de aceptación establecido.`;
+    }
+    ctx.addParagraph(parrafo);
+  }
+
+  return 6;
+}
+
 // ─── Renderizador genérico (esqueleto para grupos B–E) ───
 
 function renderGenerico(ctx: InformeCtx, codigo: string, conv: DatosConvencional): number {
@@ -1733,6 +1908,8 @@ export function renderResultadosSeccion(
       return render29(ctx, conv);
     case "2.10":
       return render210(ctx, conv);
+    case "2.11":
+      return render211(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -13,6 +13,7 @@ import type {
   ConvColimacion,
   ConvRaysafeSetup,
   ConvRaysafeMedicion,
+  ConvDdiMedicion,
 } from "@/lib/equipos/convencional/db/types";
 import {
   ITEMS_INSPECCION_EQUIPO,
@@ -86,9 +87,15 @@ export interface DatosConvencional {
   fotos27?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Fotografía de montaje RaySafe para la sección 2.8.7 (misma imagen que 2.4) */
   fotos28?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Fotografía de montaje DDI para la sección 2.9.7 */
+  fotos29?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Fotografía de montaje DDI para la sección 2.10.7 (misma imagen que 2.9) */
+  fotos210?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Setup y mediciones del RaySafe (pruebas 2.4–2.8) */
   raysafeSetup?: ConvRaysafeSetup;
   raysafeMediciones: ConvRaysafeMedicion[];
+  /** Mediciones DDI/EI (pruebas 2.9 y 2.10) */
+  ddiMediciones: ConvDdiMedicion[];
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -114,7 +121,7 @@ async function cargarImagen(
 }
 
 export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones] =
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones] =
     await Promise.all([
       db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
@@ -126,6 +133,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
       db.conv_colimacion.where("visita_id").equals(visitaId).first(),
       db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
       db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
+      db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
     ]);
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
@@ -191,6 +199,14 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   const fotos28: NonNullable<DatosConvencional["fotos28"]> = [];
   if (img24) fotos28.push({ label: "Fig 2.1.8 Implementación de instrumentación en la prueba", ...img24 });
 
+  // Fotografía de montaje DDI (secciones 2.9.7 y 2.10.7)
+  const ev29 = evidencias.find((e) => e.prueba_codigo === "2.9" && e.slot === "montaje_ddi");
+  const img29 = await cargarImagen(ev29);
+  const fotos29: NonNullable<DatosConvencional["fotos29"]> = [];
+  if (img29) fotos29.push({ label: "Fig. 2.9.1 Montaje experimental para la prueba DDI/EI", ...img29 });
+  const fotos210: NonNullable<DatosConvencional["fotos210"]> = [];
+  if (img29) fotos210.push({ label: "Fig. 2.10.1 Montaje experimental para la prueba de repetibilidad DDI/EI", ...img29 });
+
   return {
     secciones: seccionesEfectivas,
     setup,
@@ -207,8 +223,11 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     fotos26,
     fotos27,
     fotos28,
+    fotos29,
+    fotos210,
     raysafeSetup,
     raysafeMediciones,
+    ddiMediciones,
   };
 }
 
@@ -542,6 +561,68 @@ export function renderFotos24(ctx: InformeCtx, conv: DatosConvencional) {
 export function renderFotos28(ctx: InformeCtx, conv: DatosConvencional) {
   const { doc } = ctx;
   const fotos = conv.fotos28 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
+    return;
+  }
+  const CWIDTH = 170;
+  for (const f of fotos) {
+    const maxW = CWIDTH * 0.5;
+    const maxH = 80;
+    const scale = Math.min(maxW / f.width, maxH / f.height, 1);
+    const w = f.width * scale;
+    const h = f.height * scale;
+    ctx.checkPage(h + 14);
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try {
+      doc.addImage(f.dataUrl, x, ctx.y, w, h);
+    } catch {
+      // imagen no renderizable
+    }
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7);
+    doc.setTextColor(...COLOR_GRAY);
+    const caption = doc.splitTextToSize(f.label, CWIDTH);
+    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
+    ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.9.7: fotografía del montaje DDI/EI */
+export function renderFotos29(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos29 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
+    return;
+  }
+  const CWIDTH = 170;
+  for (const f of fotos) {
+    const maxW = CWIDTH * 0.5;
+    const maxH = 80;
+    const scale = Math.min(maxW / f.width, maxH / f.height, 1);
+    const w = f.width * scale;
+    const h = f.height * scale;
+    ctx.checkPage(h + 14);
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try {
+      doc.addImage(f.dataUrl, x, ctx.y, w, h);
+    } catch {
+      // imagen no renderizable
+    }
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7);
+    doc.setTextColor(...COLOR_GRAY);
+    const caption = doc.splitTextToSize(f.label, CWIDTH);
+    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
+    ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.10.7: fotografía del montaje DDI/EI (repetibilidad) */
+export function renderFotos210(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos210 ?? [];
   if (fotos.length === 0) {
     ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
     return;
@@ -1410,6 +1491,151 @@ function render28(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+function render29(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { doc, autoTable } = ctx;
+
+  const grupo1 = conv.ddiMediciones
+    .filter((m) => m.grupo === 1)
+    .sort((a, b) => a.toma_numero - b.toma_numero);
+  const toma1 = grupo1.find((m) => m.toma_numero === 1);
+
+  ctx.addSubsectionTitle("2.9.4.", "Resultados");
+
+  if (!toma1) return SIN_DATOS(ctx);
+
+  const kv = toma1.kv_nominal ?? 0;
+  const mas = toma1.carga_mas ?? 0;
+  const ei = toma1.ei ?? null;
+  const di = toma1.di ?? null;
+
+  ctx.checkPage(40);
+  addCaption(ctx, "Tabla 2.9.1. Resultado de la medición del indicador de exposición.");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Tensión (kVp)", "Carga (mAs)", "EI"]],
+    body: [[kv ? String(kv) : "—", mas ? String(mas) : "—", ei != null ? String(ei) : "—"]],
+  });
+  ctx.y = finalY(doc) + 4;
+
+  const eiBase = toma1.ei_base ?? null;
+  const diBase = toma1.di_base ?? null;
+  const eiDev =
+    eiBase != null && eiBase > 0 && ei != null
+      ? (Math.abs(ei - eiBase) / eiBase) * 100
+      : null;
+  const diDev =
+    diBase != null && diBase !== 0 && di != null
+      ? (Math.abs(di - diBase) / Math.abs(diBase)) * 100
+      : null;
+  const eiConf = eiDev != null ? (eiDev <= 20 ? "Conforme" : "No conforme") : "—";
+  const diConf = diDev != null ? (diDev <= 20 ? "Conforme" : "No conforme") : "—";
+
+  addCaption(ctx, "Tabla 2.9.2. Análisis del indicador de exposición.");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Parámetro", "Valor medido", "Valor Base", "Desviación (%)", "Concepto"]],
+    body: [
+      [
+        "EI",
+        ei != null ? String(ei) : "—",
+        eiBase != null ? String(eiBase) : "—",
+        eiDev != null ? eiDev.toFixed(1) : "—",
+        eiConf,
+      ],
+      [
+        "D.I.",
+        di != null ? di.toFixed(2) : "—",
+        diBase != null ? diBase.toFixed(2) : "—",
+        diDev != null ? diDev.toFixed(1) : "—",
+        diConf,
+      ],
+    ],
+    didParseCell: colorearConcepto(4),
+  });
+  ctx.y = finalY(doc) + 4;
+
+  ctx.addSubsectionTitle("2.9.5.", "Análisis");
+  ctx.addParagraph(
+    "Se evaluó la desviación del indicador de exposición (EI) y del índice de dosis (D.I.) respecto a los valores base de referencia. " +
+      "Los resultados se consideran conformes cuando la desviación no supera el ± 20 % del valor base establecido.",
+  );
+
+  return 6;
+}
+
+function render210(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { doc, autoTable } = ctx;
+
+  const grupo1 = conv.ddiMediciones
+    .filter((m) => m.grupo === 1)
+    .sort((a, b) => a.toma_numero - b.toma_numero);
+
+  ctx.addSubsectionTitle("2.10.4.", "Resultados");
+
+  if (grupo1.length === 0) return SIN_DATOS(ctx);
+
+  const eiVals = grupo1.map((m) => m.ei).filter((v): v is number => v != null);
+  const diVals = grupo1.map((m) => m.di).filter((v): v is number => v != null);
+
+  function ddiAvg(arr: number[]): number | null {
+    return arr.length > 0 ? arr.reduce((s, v) => s + v, 0) / arr.length : null;
+  }
+  function ddiStd(arr: number[]): number | null {
+    if (arr.length < 2) return null;
+    const m = ddiAvg(arr)!;
+    return Math.sqrt(arr.reduce((s, v) => s + (v - m) ** 2, 0) / (arr.length - 1));
+  }
+
+  const eiAvg = ddiAvg(eiVals);
+  const eiStd = ddiStd(eiVals);
+  const eiCv = eiAvg != null && eiAvg > 0 && eiStd != null ? (eiStd / eiAvg) * 100 : null;
+  const diAvg = ddiAvg(diVals);
+  const diStd = ddiStd(diVals);
+  const diCv =
+    diAvg != null && diAvg !== 0 && diStd != null
+      ? (diStd / Math.abs(diAvg)) * 100
+      : null;
+
+  const eiConf = eiCv != null ? (eiCv <= 20 ? "Conforme" : "No conforme") : "—";
+  const diConf = diCv != null ? (diCv <= 20 ? "Conforme" : "No conforme") : "—";
+
+  ctx.checkPage(40);
+  addCaption(ctx, "Tabla 2.10.1. Análisis de la repetibilidad del indicador de exposición.");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Parámetro", "Valor Promedio", "Desviación estándar", "CV (%)", "Concepto"]],
+    body: [
+      [
+        "EI",
+        eiAvg != null ? eiAvg.toFixed(1) : "—",
+        eiStd != null ? eiStd.toFixed(2) : "—",
+        eiCv != null ? eiCv.toFixed(1) : "—",
+        eiConf,
+      ],
+      [
+        "D.I.",
+        diAvg != null ? diAvg.toFixed(2) : "—",
+        diStd != null ? diStd.toFixed(2) : "—",
+        diCv != null ? diCv.toFixed(1) : "—",
+        diConf,
+      ],
+    ],
+    didParseCell: colorearConcepto(4),
+  });
+  ctx.y = finalY(doc) + 4;
+
+  ctx.addSubsectionTitle("2.10.5.", "Análisis");
+  ctx.addParagraph(
+    "Se evaluó la repetibilidad del indicador de exposición (EI) y del índice de dosis (D.I.) mediante el cálculo del coeficiente de variación (CV) " +
+      "sobre las exposiciones consecutivas realizadas bajo las mismas condiciones. Los resultados se consideran conformes cuando el CV es ≤ 20 %.",
+  );
+
+  return 6;
+}
+
 // ─── Renderizador genérico (esqueleto para grupos B–E) ───
 
 function renderGenerico(ctx: InformeCtx, codigo: string, conv: DatosConvencional): number {
@@ -1470,6 +1696,10 @@ export function renderResultadosSeccion(
       return render27(ctx, conv);
     case "2.8":
       return render28(ctx, conv);
+    case "2.9":
+      return render29(ctx, conv);
+    case "2.10":
+      return render210(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1507,7 +1507,10 @@ function render29(ctx: InformeCtx, conv: DatosConvencional): number {
   const mas = toma1.carga_mas ?? 0;
   const ei = toma1.ei ?? null;
   const di = toma1.di ?? null;
+  const eiBase = toma1.ei_base ?? null;
+  const diBase = toma1.di_base ?? null;
 
+  // Tabla 2.9.1 — medición
   ctx.checkPage(40);
   addCaption(ctx, "Tabla 2.9.1. Resultado de la medición del indicador de exposición.");
   autoTable(doc, {
@@ -1518,8 +1521,7 @@ function render29(ctx: InformeCtx, conv: DatosConvencional): number {
   });
   ctx.y = finalY(doc) + 4;
 
-  const eiBase = toma1.ei_base ?? null;
-  const diBase = toma1.di_base ?? null;
+  // Cálculo de desviaciones
   const eiDev =
     eiBase != null && eiBase > 0 && ei != null
       ? (Math.abs(ei - eiBase) / eiBase) * 100
@@ -1529,26 +1531,35 @@ function render29(ctx: InformeCtx, conv: DatosConvencional): number {
       ? (Math.abs(di - diBase) / Math.abs(diBase)) * 100
       : null;
   const eiConf = eiDev != null ? (eiDev <= 20 ? "Conforme" : "No conforme") : "—";
-  const diConf = diDev != null ? (diDev <= 20 ? "Conforme" : "No conforme") : "—";
+  const diConf = diDev != null ? (diDev <= 20 ? "Conforme" : "No conforme") : "NA";
+  const conforme = eiDev == null || eiDev <= 20;
 
-  addCaption(ctx, "Tabla 2.9.2. Análisis del indicador de exposición.");
+  // 2.9.5 Análisis — párrafo dinámico + Tabla 2.9.2
+  ctx.addSubsectionTitle("2.9.5.", "Análisis");
+  ctx.addParagraph(
+    conforme
+      ? "Los valores del indicador de exposición (EI) y de la desviación del indicador (D.I.) presentan variaciones dentro del rango de tolerancia establecido (± 20 %), evidenciando una adecuada consistencia en la respuesta del sistema de adquisición de imagen bajo condiciones de exposición reproducibles."
+      : "Se evidencian desviaciones en el indicador de exposición (EI) y/o en la desviación del indicador (D.I.) fuera del rango de tolerancia establecido, lo que indica inconsistencias en la respuesta del sistema.",
+  );
+
+  addCaption(ctx, "Tabla 2.9.2: Análisis de los indicadores de exposición");
   autoTable(doc, {
     ...TABLE_STYLE,
     startY: ctx.y,
-    head: [["Parámetro", "Valor medido", "Valor Base", "Desviación (%)", "Concepto"]],
+    head: [["Parámetro", "Valor", "Valor Base", "Desviación (%)", "Concepto"]],
     body: [
       [
         "EI",
         ei != null ? String(ei) : "—",
         eiBase != null ? String(eiBase) : "—",
-        eiDev != null ? eiDev.toFixed(1) : "—",
+        eiDev != null ? `${eiDev.toFixed(1)}%` : "—",
         eiConf,
       ],
       [
         "D.I.",
-        di != null ? di.toFixed(2) : "—",
-        diBase != null ? diBase.toFixed(2) : "—",
-        diDev != null ? diDev.toFixed(1) : "—",
+        di != null ? di.toFixed(2) : "NA",
+        diBase != null ? diBase.toFixed(2) : "NA",
+        diDev != null ? `${diDev.toFixed(1)}%` : "NA",
         diConf,
       ],
     ],
@@ -1556,13 +1567,25 @@ function render29(ctx: InformeCtx, conv: DatosConvencional): number {
   });
   ctx.y = finalY(doc) + 4;
 
-  ctx.addSubsectionTitle("2.9.5.", "Análisis");
-  ctx.addParagraph(
-    "Se evaluó la desviación del indicador de exposición (EI) y del índice de dosis (D.I.) respecto a los valores base de referencia. " +
-      "Los resultados se consideran conformes cuando la desviación no supera el ± 20 % del valor base establecido.",
-  );
+  // 2.9.6 Valores base de referencia
+  ctx.addSubsectionTitle("2.9.6.", "Valores base de referencia");
+  addCaption(ctx, "Tabla 2.9.3. Valores base de referencia establecidos para la prueba DDI/EI.");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Tensión (kVp)", "Carga (mAs)", "EI base", "D.I. base"]],
+    body: [
+      [
+        kv ? String(kv) : "—",
+        mas ? String(mas) : "—",
+        eiBase != null ? String(eiBase) : "—",
+        diBase != null ? diBase.toFixed(2) : "—",
+      ],
+    ],
+  });
+  ctx.y = finalY(doc) + 4;
 
-  return 6;
+  return 7; // 2.9.4, 2.9.5, 2.9.6 renderizados; caller inicia en 7 (Criterio)
 }
 
 function render210(ctx: InformeCtx, conv: DatosConvencional): number {

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -84,6 +84,8 @@ export interface DatosConvencional {
   fotos26?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Fotografía de montaje RaySafe para la sección 2.7.7 (misma imagen que 2.4) */
   fotos27?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Fotografía de montaje RaySafe para la sección 2.8.7 (misma imagen que 2.4) */
+  fotos28?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Setup y mediciones del RaySafe (pruebas 2.4–2.8) */
   raysafeSetup?: ConvRaysafeSetup;
   raysafeMediciones: ConvRaysafeMedicion[];
@@ -186,6 +188,8 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   if (img24) fotos26.push({ label: "Fig 2.6.1 Implementación de instrumentación en la prueba", ...img24 });
   const fotos27: NonNullable<DatosConvencional["fotos27"]> = [];
   if (img24) fotos27.push({ label: "Fig 2.7.1 Implementación de instrumentación en la prueba", ...img24 });
+  const fotos28: NonNullable<DatosConvencional["fotos28"]> = [];
+  if (img24) fotos28.push({ label: "Fig 2.1.8 Implementación de instrumentación en la prueba", ...img24 });
 
   return {
     secciones: seccionesEfectivas,
@@ -202,6 +206,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     fotos25,
     fotos26,
     fotos27,
+    fotos28,
     raysafeSetup,
     raysafeMediciones,
   };
@@ -511,6 +516,37 @@ export function renderFotos24(ctx: InformeCtx, conv: DatosConvencional) {
     return;
   }
   const CWIDTH = 170; // ancho de contenido (mm)
+  for (const f of fotos) {
+    const maxW = CWIDTH * 0.5;
+    const maxH = 80;
+    const scale = Math.min(maxW / f.width, maxH / f.height, 1);
+    const w = f.width * scale;
+    const h = f.height * scale;
+    ctx.checkPage(h + 14);
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try {
+      doc.addImage(f.dataUrl, x, ctx.y, w, h);
+    } catch {
+      // imagen no renderizable
+    }
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7);
+    doc.setTextColor(...COLOR_GRAY);
+    const caption = doc.splitTextToSize(f.label, CWIDTH);
+    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
+    ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.8.7: fotografía del montaje con sensor RaySafe */
+export function renderFotos28(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos28 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
+    return;
+  }
+  const CWIDTH = 170;
   for (const f of fotos) {
     const maxW = CWIDTH * 0.5;
     const maxH = 80;
@@ -1325,26 +1361,20 @@ function render28(ctx: InformeCtx, conv: DatosConvencional): number {
 
   if (mediciones.length === 0) return SIN_DATOS(ctx);
 
-  const d1 = conv.raysafeSetup?.distancia_foco_sensor_cm ?? 100;
-  const d2 = conv.raysafeSetup?.distancia_foco_detector_d2_cm ?? d1;
-  const factorDist = (d2 / d1) ** 2;
+  const d1Setup = conv.raysafeSetup?.distancia_foco_sensor_cm ?? 100;
+  const d2Setup = conv.raysafeSetup?.distancia_foco_detector_d2_cm ?? d1Setup;
 
   ctx.addParagraph("La prueba se llevó a cabo bajo las siguientes condiciones de medición:");
 
-  // kv_nominal/mas_nominal no se almacenan en kerma; se buscan en con_rejilla del mismo programa
-  const conRejillaMap = new Map(
-    conv.raysafeMediciones
-      .filter((m) => m.tipo_medicion === "con_rejilla" && m.programa_clinico)
-      .map((m) => [m.programa_clinico!, m]),
-  );
-
   const rows = mediciones.map((m) => {
-    const ref = m.programa_clinico ? conRejillaMap.get(m.programa_clinico) : undefined;
-    const kvNom = m.kv_nominal ?? ref?.kv_nominal;
-    const masNom = m.mas_nominal ?? ref?.mas_nominal;
+    const kvNom = m.kv_nominal;
+    const masNom = m.mas_nominal;
     const kerma = m.dosis_medida_mgy!;
     const ancho = m.ancho_irradiacion_cm ?? 0;
     const largo = m.largo_irradiacion_cm ?? 0;
+    const d1 = m.distancia_foco_sensor_cm ?? d1Setup;
+    const d2 = m.distancia_foco_detector_cm ?? d2Setup;
+    const factorDist = (d2 / d1) ** 2;
     const areaCorr = ancho * largo * factorDist;
     const kermaCorr = kerma * factorDist;
     const dapEst = kermaCorr * areaCorr;

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1097,6 +1097,21 @@ function render26(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+/** Tabla de valores mínimos de referencia CHR para sección 2.6.6 */
+export function renderTablaChrRef(ctx: InformeCtx) {
+  const { doc, autoTable } = ctx;
+  ctx.checkPage(36);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Tensión (kV)", "CHR mínima (mm Al)"]],
+    body: [["60", "1,8"], ["70", "2,1"], ["80", "2,3"], ["90", "2,5"]],
+    columnStyles: { 0: { halign: "center" as const, cellWidth: 45 }, 1: { halign: "center" as const, cellWidth: 45 } },
+    margin: { left: MARGIN + (170 - 90) / 2 },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+}
+
 function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const { doc, autoTable } = ctx;
   const shots80 = conv.raysafeMediciones.filter(

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1115,122 +1115,149 @@ export function renderTablaChrRef(ctx: InformeCtx) {
 function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const { doc, autoTable } = ctx;
   const shots80 = conv.raysafeMediciones.filter(
-    (m) => m.tipo_medicion === "principal" && m.kv_nominal === 80 && m.dosis_medida_mgy != null
+    (m) => m.tipo_medicion === "principal" && m.kv_nominal === 80 && m.dosis_medida_mgy != null,
   );
 
   ctx.addSubsectionTitle("2.7.4.", "Resultados");
   ctx.addParagraph(
     "La prueba se llevó a cabo bajo las siguientes condiciones de medición:\n" +
-    "Tensión de referencia: 80 kVp\n" +
-    `Distancia foco-detector: ${conv.raysafeSetup?.distancia_foco_sensor_cm ?? 100} cm\n` +
-    "Estimación del rendimiento: normalizado a 100 centímetros"
+      `Tensión de referencia: 80 kVp\nDistancia foco-detector: ${conv.raysafeSetup?.distancia_foco_sensor_cm ?? 100} cm`,
   );
 
   if (shots80.length === 0) return SIN_DATOS(ctx);
 
-  // ── Tabla 2.7.1: Linealidad ──
-  const gruposMas = new Map<number, typeof shots80>();
+  // ── Tabla 2.7.1: Rendimiento y linealidad (agrupado por grupo_numero) ──
+  const gruposNum = new Map<number, typeof shots80>();
   for (const m of shots80) {
-    if (m.mas_nominal == null) continue;
-    if (!gruposMas.has(m.mas_nominal)) gruposMas.set(m.mas_nominal, []);
-    gruposMas.get(m.mas_nominal)!.push(m);
+    if (m.grupo_numero == null || m.mas_nominal == null) continue;
+    if (!gruposNum.has(m.grupo_numero)) gruposNum.set(m.grupo_numero, []);
+    gruposNum.get(m.grupo_numero)!.push(m);
   }
 
-  if (gruposMas.size > 0) {
-    const entradasOrdenadas = [...gruposMas.entries()].sort(([a], [b]) => a - b);
-    let rendRef: number | null = null;
-    const rowsLin = entradasOrdenadas.map(([mas, ms], idx) => {
+  // Para el análisis posterior también mantenemos el map por grupo
+  const gruposArr = [...gruposNum.entries()].sort(([a], [b]) => a - b);
+
+  let rendRef: number | null = null;
+  let linMaxPct = 0;
+
+  if (gruposArr.length > 0) {
+    const rowsLin = gruposArr.map(([grp, ms], idx) => {
+      const mas = ms[0].mas_nominal!;
       const kermaProm = mean(ms.map((m) => m.dosis_medida_mgy!));
+      const chrProm = ms.some((m) => m.chr_medido_mmal != null)
+        ? mean(ms.filter((m) => m.chr_medido_mmal != null).map((m) => m.chr_medido_mmal!))
+        : null;
       const rend = mas > 0 ? (kermaProm / mas) * 1000 : 0; // µGy/mAs
       if (idx === 0) rendRef = rend;
       const linPct =
-        rendRef && rendRef > 0 && idx > 0
-          ? ((rend - rendRef) / rendRef) * 100
+        rendRef != null && rendRef > 0 && idx > 0
+          ? Math.abs((rend - rendRef) / rendRef) * 100
           : null;
+      if (linPct != null && linPct > linMaxPct) linMaxPct = linPct;
+      const concepto =
+        linPct == null ? "—" : linPct <= 10 ? "Conforme" : "No conforme";
       return [
+        String(grp),
+        chrProm != null ? chrProm.toFixed(2) : "—",
         mas.toFixed(1),
-        kermaProm.toFixed(3),
-        rend.toFixed(1),
+        kermaProm.toFixed(4),
+        rend.toFixed(2),
         linPct != null ? linPct.toFixed(2) + " %" : "—",
+        concepto,
       ];
     });
 
     ctx.checkPage(40);
-    addCaption(ctx, "Tabla 2.7.1. Rendimiento del tubo de rayos X y linealidad");
+    addCaption(ctx, "Tabla 2.7.1. Reproducibilidad de la radiación de salida — rendimiento y linealidad");
     autoTable(doc, {
       ...TABLE_STYLE,
       startY: ctx.y,
-      head: [["Exposición nominal (mAs)", "Kerma en aire promedio (mGy)", "Rendimiento (µGy/mAs)", "Linealidad (%)"]],
+      head: [
+        [
+          "Grupo",
+          "CHR (mm Al)",
+          "Exposición nominal (mAs)",
+          "Kerma en aire promedio (mGy)",
+          "Rendimiento (µGy/mAs)",
+          "Linealidad (%)",
+          "Concepto",
+        ],
+      ],
       body: rowsLin,
-      columnStyles: { 0: { cellWidth: 36 } },
+      columnStyles: { 6: { cellWidth: 24 } },
+      didParseCell: colorearConcepto(6),
     });
     ctx.y = finalY(doc) + 4;
   }
 
-  // ── Tabla 2.7.2: Repetibilidad (grupo 3 — 80kV/10mAs) ──
+  // ── Tabla 2.7.2: Repetibilidad (grupo 3 — 80kV/200mA/0.05s) ──
   const repShots = shots80
     .filter((m) => m.grupo_numero === 3)
     .sort((a, b) => a.toma_numero - b.toma_numero);
 
-  if (repShots.length > 0) {
-    const kermas = repShots.map((m) => m.dosis_medida_mgy!);
-    const prom = mean(kermas);
-    const std = stdDev(kermas);
-    const cv = prom > 0 ? (std / prom) * 100 : 0;
+  const kermasRep = repShots.map((m) => m.dosis_medida_mgy!);
+  const promRep = kermasRep.length > 0 ? mean(kermasRep) : 0;
+  const stdRep = kermasRep.length > 0 ? stdDev(kermasRep) : 0;
+  const cvRep = promRep > 0 ? (stdRep / promRep) * 100 : 0;
+  const conformeRep = kermasRep.length === 0 || cvRep <= 5;
+  const conformeLin = gruposArr.length <= 1 || linMaxPct <= 10;
 
-    const rowsRep: string[][] = repShots.map((m, i) => [String(i + 1), m.dosis_medida_mgy!.toFixed(4)]);
-
-    ctx.checkPage(40);
-    addCaption(ctx, "Tabla 2.7.2. Repetibilidad de la radiación de salida");
-    autoTable(doc, {
-      ...TABLE_STYLE,
-      startY: ctx.y,
-      head: [["Medición", "Kerma en aire medido (mGy)"]],
-      body: [
-        ...rowsRep,
-        ["Promedio", prom.toFixed(4)],
-        ["Desviación estándar (mGy)", std.toFixed(4)],
-        ["CV (%)", cv.toFixed(2) + " %"],
+  ctx.checkPage(28);
+  addCaption(ctx, "Tabla 2.7.2. Repetibilidad de la radiación de salida");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Kerma en aire promedio (mGy)", "Desviación estándar (mGy)", "CV (%)", "Concepto"]],
+    body: [
+      [
+        promRep.toFixed(4),
+        stdRep.toFixed(4),
+        cvRep.toFixed(2) + " %",
+        conformeRep ? "Conforme" : "No conforme",
       ],
-      columnStyles: {
-        0: { cellWidth: 60, fontStyle: "bold", fillColor: COLOR_ALT_ROW },
-      },
-    });
-    ctx.y = finalY(doc) + 4;
+    ],
+    columnStyles: { 3: { cellWidth: 24 } },
+    didParseCell: colorearConcepto(3),
+  });
+  ctx.y = finalY(doc) + 4;
 
-    ctx.addSubsectionTitle("2.7.5.", "Análisis");
-    const gruposMasArr = [...gruposMas.entries()].sort(([a], [b]) => a - b);
-    const rendMin = gruposMasArr.length > 0
-      ? Math.min(...gruposMasArr.map(([mas, ms]) => (mean(ms.map((m) => m.dosis_medida_mgy!)) / mas) * 1000))
+  // ── 2.7.5 Análisis ──
+  ctx.addSubsectionTitle("2.7.5.", "Análisis");
+
+  if (kermasRep.length === 0 && gruposArr.length === 0) {
+    ctx.addParagraph("Sin datos registrados para esta prueba.");
+    return 6;
+  }
+
+  const rendMin =
+    gruposArr.length > 0
+      ? Math.min(
+          ...gruposArr.map(([, ms]) => {
+            const mas = ms[0].mas_nominal!;
+            return mas > 0 ? (mean(ms.map((m) => m.dosis_medida_mgy!)) / mas) * 1000 : 0;
+          }),
+        )
       : 0;
-    const rendMax = gruposMasArr.length > 0
-      ? Math.max(...gruposMasArr.map(([mas, ms]) => (mean(ms.map((m) => m.dosis_medida_mgy!)) / mas) * 1000))
+  const rendMax =
+    gruposArr.length > 0
+      ? Math.max(
+          ...gruposArr.map(([, ms]) => {
+            const mas = ms[0].mas_nominal!;
+            return mas > 0 ? (mean(ms.map((m) => m.dosis_medida_mgy!)) / mas) * 1000 : 0;
+          }),
+        )
       : 0;
-    const linMax = gruposMasArr.length > 1
-      ? (() => {
-          const ref = (mean(gruposMasArr[0][1].map((m) => m.dosis_medida_mgy!)) / gruposMasArr[0][0]) * 1000;
-          return Math.max(...gruposMasArr.slice(1).map(([mas, ms]) => {
-            const r = (mean(ms.map((m) => m.dosis_medida_mgy!)) / mas) * 1000;
-            return Math.abs((r - ref) / ref) * 100;
-          }));
-        })()
-      : 0;
-    const conformeRep = cv <= 5;
-    const conformeLin = linMax <= 10;
-    if (conformeRep && conformeLin) {
-      ctx.addParagraph(
-        `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rendMin.toFixed(1)} y ${rendMax.toFixed(1)} µGy/mAs para los diferentes valores de carga evaluados a 80 kV. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cv.toFixed(2)} % y la linealidad del rendimiento presenta una desviación máxima de ${linMax.toFixed(2)} %, ambos dentro de los criterios de aceptación establecidos.`
-      );
-    } else {
-      ctx.addParagraph(
-        `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta un CV de repetibilidad de ${cv.toFixed(2)} % y una linealidad máxima de ${linMax.toFixed(2)} %. ` +
-        (!conformeRep ? "La repetibilidad supera el criterio de aceptación del 5 %. " : "") +
-        (!conformeLin ? "La linealidad supera el criterio de aceptación del 10 %. " : "")
-      );
-    }
+
+  if (conformeRep && conformeLin) {
+    ctx.addParagraph(
+      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rendMin.toFixed(2)} y ${rendMax.toFixed(2)} µGy/mAs para los diferentes valores de carga evaluados a 80 kV. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvRep.toFixed(2)} % y la linealidad del rendimiento presenta una desviación máxima de ${linMaxPct.toFixed(2)} %, ambos dentro de los criterios de aceptación establecidos.`,
+    );
   } else {
-    ctx.addSubsectionTitle("2.7.5.", "Análisis");
-    ctx.addParagraph("Sin datos de repetibilidad registrados.");
+    ctx.addParagraph(
+      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta un CV de repetibilidad de ${cvRep.toFixed(2)} % y una linealidad máxima de ${linMaxPct.toFixed(2)} %. ` +
+        (!conformeRep ? "La repetibilidad supera el criterio de aceptación del 5 %. " : "") +
+        (!conformeLin ? "La linealidad supera el criterio de aceptación del 10 %. " : ""),
+    );
   }
 
   return 6;

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -82,6 +82,8 @@ export interface DatosConvencional {
   fotos25?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Fotografía de montaje RaySafe para la sección 2.6.7 (misma imagen que 2.4) */
   fotos26?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Fotografía de montaje RaySafe para la sección 2.7.7 (misma imagen que 2.4) */
+  fotos27?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Setup y mediciones del RaySafe (pruebas 2.4–2.8) */
   raysafeSetup?: ConvRaysafeSetup;
   raysafeMediciones: ConvRaysafeMedicion[];
@@ -182,6 +184,8 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   if (img24) fotos25.push({ label: "Fig 2.5.1. Implementación de instrumentación en la prueba", ...img24 });
   const fotos26: NonNullable<DatosConvencional["fotos26"]> = [];
   if (img24) fotos26.push({ label: "Fig 2.6.1 Implementación de instrumentación en la prueba", ...img24 });
+  const fotos27: NonNullable<DatosConvencional["fotos27"]> = [];
+  if (img24) fotos27.push({ label: "Fig 2.7.1 Implementación de instrumentación en la prueba", ...img24 });
 
   return {
     secciones: seccionesEfectivas,
@@ -197,6 +201,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     fotos24,
     fotos25,
     fotos26,
+    fotos27,
     raysafeSetup,
     raysafeMediciones,
   };
@@ -506,6 +511,37 @@ export function renderFotos24(ctx: InformeCtx, conv: DatosConvencional) {
     return;
   }
   const CWIDTH = 170; // ancho de contenido (mm)
+  for (const f of fotos) {
+    const maxW = CWIDTH * 0.5;
+    const maxH = 80;
+    const scale = Math.min(maxW / f.width, maxH / f.height, 1);
+    const w = f.width * scale;
+    const h = f.height * scale;
+    ctx.checkPage(h + 14);
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try {
+      doc.addImage(f.dataUrl, x, ctx.y, w, h);
+    } catch {
+      // imagen no renderizable
+    }
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7);
+    doc.setTextColor(...COLOR_GRAY);
+    const caption = doc.splitTextToSize(f.label, CWIDTH);
+    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
+    ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.7.7: fotografía del montaje con sensor RaySafe */
+export function renderFotos27(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos27 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
+    return;
+  }
+  const CWIDTH = 170;
   for (const f of fotos) {
     const maxW = CWIDTH * 0.5;
     const maxH = 80;
@@ -1256,15 +1292,20 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const rendMin = allRends.length > 0 ? Math.min(...allRends) : 0;
   const rendMax = allRends.length > 0 ? Math.max(...allRends) : 0;
 
+  const cvStr = cvRep.toFixed(2).replace(".", ",");
+  const linStr = linMaxPct.toFixed(2).replace(".", ",");
+  const rMinStr = rendMin.toFixed(1).replace(".", ",");
+  const rMaxStr = rendMax.toFixed(1).replace(".", ",");
+
   if (conformeRep && conformeLin) {
     ctx.addParagraph(
-      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rendMin.toFixed(1)} y ${rendMax.toFixed(1)} µGy/mAs para los diferentes valores de carga evaluados a 80 kV. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvRep.toFixed(2)} % y la linealidad del rendimiento presenta una desviación máxima de ${linMaxPct.toFixed(2)} %, ambos dentro de los criterios de aceptación establecidos.`,
+      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rMinStr} y ${rMaxStr} µGy/mAs para los diferentes valores de carga evaluados a 80 kV, lo que indica un comportamiento consistente del sistema de generación de radiación. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvStr} %, valor inferior al límite establecido. Asimismo, la linealidad del rendimiento con respecto al mAs presenta una desviación máxima de ${linStr} %, lo que indica un comportamiento proporcional entre la radiación de salida y la carga seleccionada. En conjunto, los resultados indican que el generador de rayos X presenta un comportamiento estable, reproducible y lineal bajo las condiciones de irradiación evaluadas.`,
     );
   } else {
     ctx.addParagraph(
-      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta un CV de repetibilidad de ${cvRep.toFixed(2)} % y una linealidad máxima de ${linMaxPct.toFixed(2)} %. ` +
-        (!conformeRep ? "La repetibilidad supera el criterio de aceptación del 5 %. " : "") +
-        (!conformeLin ? "La linealidad supera el criterio de aceptación del 10 %. " : ""),
+      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rMinStr} y ${rMaxStr} µGy/mAs para los diferentes valores de carga evaluados a 80 kV. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvStr} % y la linealidad del rendimiento con respecto al mAs presenta una desviación máxima de ${linStr} %.` +
+        (!conformeRep ? ` La repetibilidad supera el criterio de aceptación del 5 %.` : "") +
+        (!conformeLin ? ` La linealidad supera el criterio de aceptación del 10 %.` : ""),
     );
   }
 

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1312,6 +1312,114 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+// ─── Renderizador 2.8: Factor de corrección PKA ───
+
+function render28(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { doc, autoTable } = ctx;
+
+  const mediciones = conv.raysafeMediciones
+    .filter((m) => m.tipo_medicion === "kerma" && m.dosis_medida_mgy != null)
+    .sort((a, b) => a.toma_numero - b.toma_numero);
+
+  ctx.addSubsectionTitle("2.8.4.", "Resultados");
+
+  if (mediciones.length === 0) return SIN_DATOS(ctx);
+
+  const d1 = conv.raysafeSetup?.distancia_foco_sensor_cm ?? 100;
+  const d2 = conv.raysafeSetup?.distancia_foco_detector_d2_cm ?? d1;
+  const factorDist = (d2 / d1) ** 2; // factor de corrección geométrica
+
+  ctx.addParagraph(
+    `Las mediciones se realizaron con el sensor ubicado a ${d1} cm del foco. ` +
+      (d2 !== d1
+        ? `La distancia foco-detector de imagen es ${d2} cm. Las mediciones de kerma y área se corrigen al plano del detector mediante el factor (${d2}/${d1})² = ${factorDist.toFixed(4)}.`
+        : "No se aplicó corrección de distancia (sensor en el plano del detector)."),
+  );
+
+  const rows = mediciones.map((m) => {
+    const kerma = m.dosis_medida_mgy!;
+    const ancho = m.ancho_irradiacion_cm ?? 0;
+    const largo = m.largo_irradiacion_cm ?? 0;
+    const areaMed = ancho * largo;
+    const areaCorr = areaMed * factorDist;
+    const kermaCorr = kerma * factorDist;
+    const dapEst = kermaCorr * areaCorr; // mGy·cm²
+    const dapNom = m.dap_nominal;
+    const fc = dapNom != null && dapNom > 0 ? dapEst / dapNom : null;
+
+    return {
+      toma: m.toma_numero,
+      kv: m.kv_nominal ?? "—",
+      mas: m.mas_nominal != null ? m.mas_nominal.toFixed(1) : "—",
+      dapNom: dapNom != null ? dapNom.toFixed(0) : "—",
+      ancho: ancho > 0 ? ancho.toFixed(1) : "—",
+      largo: largo > 0 ? largo.toFixed(1) : "—",
+      areaCorr: areaCorr > 0 ? areaCorr.toFixed(0) : "—",
+      kermaCorr: kermaCorr.toFixed(5),
+      dapEst: dapEst > 0 ? dapEst.toFixed(2) : "—",
+      fc: fc != null ? fc.toFixed(2) : "—",
+    };
+  });
+
+  ctx.checkPage(50);
+  addCaption(ctx, "Tabla 2.8.1. Estimación del DAP y factor de corrección del medidor PKA");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [
+      [
+        "Toma",
+        "Tensión (kV)",
+        "Exp. (mAs)",
+        "DAP nominal (mGy·cm²)",
+        "Ancho (cm)",
+        "Largo (cm)",
+        "Área corregida (cm²)",
+        "Kerma corregido (mGy)",
+        "DAP estimado (mGy·cm²)",
+        "Factor de corrección",
+      ],
+    ],
+    body: rows.map((r) => [
+      r.toma,
+      r.kv,
+      r.mas,
+      r.dapNom,
+      r.ancho,
+      r.largo,
+      r.areaCorr,
+      r.kermaCorr,
+      r.dapEst,
+      r.fc,
+    ]),
+    styles: { fontSize: 6.5, cellPadding: 1.5 },
+    headStyles: { fillColor: COLOR_PRIMARY, textColor: [255, 255, 255] as [number, number, number], fontStyle: "bold", fontSize: 6 },
+  });
+  ctx.y = finalY(doc) + 4;
+
+  // ── 2.8.5 Análisis ──
+  ctx.addSubsectionTitle("2.8.5.", "Análisis");
+
+  const fcs = rows.map((r) => parseFloat(r.fc)).filter((v) => !isNaN(v));
+  if (fcs.length === 0) {
+    ctx.addParagraph("No se registraron datos suficientes para calcular el factor de corrección.");
+    return 6;
+  }
+  const fcMean = mean(fcs);
+  const fcMin = Math.min(...fcs);
+  const fcMax = Math.max(...fcs);
+  const lejos = fcs.some((f) => Math.abs(f - 1.0) > 0.2);
+
+  ctx.addParagraph(
+    `Los factores de corrección del medidor PKA calculados para las técnicas evaluadas presentan valores entre ${fcMin.toFixed(2)} y ${fcMax.toFixed(2)}, con un promedio de ${fcMean.toFixed(2)}. ` +
+      (lejos
+        ? "Se observa una desviación significativa con respecto a la unidad, lo que sugiere que el medidor de producto kerma-área del equipo requiere revisión de su calibración."
+        : "Los valores obtenidos son cercanos a la unidad, lo que indica que el medidor de producto kerma-área del equipo presenta una respuesta adecuada bajo las condiciones evaluadas."),
+  );
+
+  return 6;
+}
+
 // ─── Renderizador genérico (esqueleto para grupos B–E) ───
 
 function renderGenerico(ctx: InformeCtx, codigo: string, conv: DatosConvencional): number {
@@ -1370,6 +1478,8 @@ export function renderResultadosSeccion(
       return render26(ctx, conv);
     case "2.7":
       return render27(ctx, conv);
+    case "2.8":
+      return render28(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -78,6 +78,8 @@ export interface DatosConvencional {
   fotos23?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Fotografía de montaje RaySafe para la sección 2.4.7 */
   fotos24?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Fotografía de montaje RaySafe para la sección 2.5.7 (misma imagen que 2.4) */
+  fotos25?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Setup y mediciones del RaySafe (pruebas 2.4–2.8) */
   raysafeSetup?: ConvRaysafeSetup;
   raysafeMediciones: ConvRaysafeMedicion[];
@@ -169,11 +171,13 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     if (img) fotos23.push({ label, ...img });
   }
 
-  // Fotografía de montaje RaySafe (sección 2.4.7)
-  const fotos24: NonNullable<DatosConvencional["fotos24"]> = [];
+  // Fotografía de montaje RaySafe (secciones 2.4.7 y 2.5.7 — misma imagen)
   const ev24 = evidencias.find((e) => e.prueba_codigo === "2.4" && e.slot === "montaje_raysafe");
   const img24 = await cargarImagen(ev24);
+  const fotos24: NonNullable<DatosConvencional["fotos24"]> = [];
   if (img24) fotos24.push({ label: "Fig. Implementación de instrumentación en la prueba", ...img24 });
+  const fotos25: NonNullable<DatosConvencional["fotos25"]> = [];
+  if (img24) fotos25.push({ label: "Fig 2.5.1. Implementación de instrumentación en la prueba", ...img24 });
 
   return {
     secciones: seccionesEfectivas,
@@ -187,6 +191,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     fotos22,
     fotos23,
     fotos24,
+    fotos25,
     raysafeSetup,
     raysafeMediciones,
   };
@@ -496,6 +501,37 @@ export function renderFotos24(ctx: InformeCtx, conv: DatosConvencional) {
     return;
   }
   const CWIDTH = 170; // ancho de contenido (mm)
+  for (const f of fotos) {
+    const maxW = CWIDTH * 0.5;
+    const maxH = 80;
+    const scale = Math.min(maxW / f.width, maxH / f.height, 1);
+    const w = f.width * scale;
+    const h = f.height * scale;
+    ctx.checkPage(h + 14);
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try {
+      doc.addImage(f.dataUrl, x, ctx.y, w, h);
+    } catch {
+      // imagen no renderizable
+    }
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7);
+    doc.setTextColor(...COLOR_GRAY);
+    const caption = doc.splitTextToSize(f.label, CWIDTH);
+    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
+    ctx.y += h + 12;
+  }
+}
+
+/** Subsección 2.5.7: fotografía del montaje con sensor RaySafe */
+export function renderFotos25(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc } = ctx;
+  const fotos = conv.fotos25 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
+    return;
+  }
+  const CWIDTH = 170;
   for (const f of fotos) {
     const maxW = CWIDTH * 0.5;
     const maxH = 80;
@@ -942,6 +978,13 @@ function render25(ctx: InformeCtx, conv: DatosConvencional): number {
     didParseCell: colorearConcepto(5),
   });
   ctx.y = finalY(doc) + 4;
+
+  ctx.addParagraph(
+    "La exactitud de la tensión del tubo se evaluó mediante la desviación máxima porcentual entre la tensión nominal seleccionada y la tensión medida con mayor desviación.",
+  );
+  ctx.addParagraph(
+    "La repetibilidad del sistema de generación de alta tensión se evaluó mediante el coeficiente de variación (CV) calculado a partir de las mediciones repetidas para cada valor de tensión nominal.",
+  );
 
   ctx.addSubsectionTitle("2.5.5.", "Análisis");
   const todosConformes = rows.every((r) => r[5] === "Conforme");

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1657,10 +1657,13 @@ function render210(ctx: InformeCtx, conv: DatosConvencional): number {
   });
   ctx.y = finalY(doc) + 4;
 
+  const conforme210 = eiCv == null || eiCv <= 20;
+
   ctx.addSubsectionTitle("2.10.5.", "Análisis");
   ctx.addParagraph(
-    "Se evaluó la repetibilidad del indicador de exposición (EI) y del índice de dosis (D.I.) mediante el cálculo del coeficiente de variación (CV) " +
-      "sobre las exposiciones consecutivas realizadas bajo las mismas condiciones. Los resultados se consideran conformes cuando el CV es ≤ 20 %.",
+    conforme210
+      ? "Los valores del indicador de exposición presentan baja dispersión bajo condiciones de exposición reproducibles. Los coeficientes de variación obtenidos se encuentran dentro del criterio de aceptación establecido, evidenciando una adecuada repetibilidad del sistema de adquisición de imagen."
+      : "Se evidencian variaciones en los indicadores evaluados superiores al criterio de aceptación establecido, lo que indica inestabilidad en la repetibilidad del sistema de adquisición de imagen.",
   );
 
   return 6;

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1331,7 +1331,17 @@ function render28(ctx: InformeCtx, conv: DatosConvencional): number {
 
   ctx.addParagraph("La prueba se llevó a cabo bajo las siguientes condiciones de medición:");
 
+  // kv_nominal/mas_nominal no se almacenan en kerma; se buscan en con_rejilla del mismo programa
+  const conRejillaMap = new Map(
+    conv.raysafeMediciones
+      .filter((m) => m.tipo_medicion === "con_rejilla" && m.programa_clinico)
+      .map((m) => [m.programa_clinico!, m]),
+  );
+
   const rows = mediciones.map((m) => {
+    const ref = m.programa_clinico ? conRejillaMap.get(m.programa_clinico) : undefined;
+    const kvNom = m.kv_nominal ?? ref?.kv_nominal;
+    const masNom = m.mas_nominal ?? ref?.mas_nominal;
     const kerma = m.dosis_medida_mgy!;
     const ancho = m.ancho_irradiacion_cm ?? 0;
     const largo = m.largo_irradiacion_cm ?? 0;
@@ -1341,8 +1351,8 @@ function render28(ctx: InformeCtx, conv: DatosConvencional): number {
     const dapNom = m.dap_nominal;
     const fc = dapNom != null && dapNom > 0 ? dapEst / dapNom : null;
     return {
-      kv: m.kv_nominal != null ? m.kv_nominal.toFixed(1) : "—",
-      mas: m.mas_nominal != null ? m.mas_nominal.toFixed(1) : "—",
+      kv: kvNom != null ? kvNom.toFixed(1) : "—",
+      mas: masNom != null ? masNom.toFixed(1) : "—",
       dapNom: dapNom != null ? dapNom.toFixed(0) : "—",
       dapEst: dapEst > 0 ? dapEst.toFixed(2) : "—",
       fc: fc != null ? fc.toFixed(1) : "—",

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -222,7 +222,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   // Fotografías patrón resolución para 2.12.7 (montaje + DICOM)
   const SLOTS_FOTOS_212: [string, string][] = [
     ["montaje_resolucion", "Fig. 2.12.1 Foto montaje experimental"],
-    ["dicom_resolucion", "Fig. 2.12.2 Imagen DICOM patrón de resolución espacial"],
+    ["dicom_resolucion", "Fig. 2.12.2 Radiografía del patrón de resolución espacial"],
   ];
   const fotos212: NonNullable<DatosConvencional["fotos212"]> = [];
   for (const [slot, label] of SLOTS_FOTOS_212) {
@@ -668,20 +668,27 @@ export function renderFotos212(ctx: InformeCtx, conv: DatosConvencional) {
     return;
   }
   const CWIDTH = 170;
-  for (const f of fotos) {
-    const maxW = CWIDTH * 0.7;
-    const scale = Math.min(maxW / f.width, 100 / f.height, 1);
-    const w = f.width * scale;
-    const h = f.height * scale;
-    ctx.checkPage(h + 16);
-    const x = MARGIN + (CWIDTH - w) / 2;
-    try { doc.addImage(f.dataUrl, x, ctx.y, w, h); } catch { /* no renderizable */ }
-    doc.setFont("helvetica", "italic");
-    doc.setFontSize(7);
-    doc.setTextColor(...COLOR_GRAY);
-    const caption = doc.splitTextToSize(f.label, CWIDTH);
-    doc.text(caption, MARGIN + CWIDTH / 2, ctx.y + h + 4, { align: "center" });
-    ctx.y += h + 12;
+  const fotosPerRow = 2;
+  const colW = CWIDTH / fotosPerRow;
+  for (let i = 0; i < fotos.length; i += fotosPerRow) {
+    const grupo = fotos.slice(i, i + fotosPerRow);
+    const maxH = 80;
+    const scales = grupo.map((f) => Math.min((colW * 0.9) / f.width, maxH / f.height, 1));
+    const rowH = Math.max(...grupo.map((f, j) => f.height * scales[j]));
+    ctx.checkPage(rowH + 16);
+    grupo.forEach((f, j) => {
+      const scale = scales[j];
+      const w = f.width * scale;
+      const h = f.height * scale;
+      const x = MARGIN + j * colW + (colW - w) / 2;
+      try { doc.addImage(f.dataUrl, x, ctx.y, w, h); } catch { /* no renderizable */ }
+      doc.setFont("helvetica", "italic");
+      doc.setFontSize(7);
+      doc.setTextColor(...COLOR_GRAY);
+      const caption = doc.splitTextToSize(f.label, colW - 4);
+      doc.text(caption, MARGIN + j * colW + colW / 2, ctx.y + rowH + 4, { align: "center" });
+    });
+    ctx.y += rowH + 12;
   }
 }
 

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -219,11 +219,17 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   const fotos210: NonNullable<DatosConvencional["fotos210"]> = [];
   if (img29) fotos210.push({ label: "Fig. 2.10.1 Montaje experimental para la prueba de repetibilidad DDI/EI", ...img29 });
 
-  // Fotografía patrón resolución para 2.12.7
-  const ev212 = evidencias.find((e) => e.prueba_codigo === "2.12" && e.slot === "montaje_resolucion");
-  const img212 = await cargarImagen(ev212);
+  // Fotografías patrón resolución para 2.12.7 (montaje + DICOM)
+  const SLOTS_FOTOS_212: [string, string][] = [
+    ["montaje_resolucion", "Fig. 2.12.1 Foto montaje experimental"],
+    ["dicom_resolucion", "Fig. 2.12.2 Imagen DICOM patrón de resolución espacial"],
+  ];
   const fotos212: NonNullable<DatosConvencional["fotos212"]> = [];
-  if (img212) fotos212.push({ label: "Fig. 2.12.1 Patrón de resolución espacial", ...img212 });
+  for (const [slot, label] of SLOTS_FOTOS_212) {
+    const ev = evidencias.find((e) => e.prueba_codigo === "2.12" && e.slot === slot);
+    const img = await cargarImagen(ev);
+    if (img) fotos212.push({ label, ...img });
+  }
 
   // Fotografías DICOM para 2.11.7 (0° y 180°)
   const SLOTS_FOTOS_211: [string, string][] = [

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1265,6 +1265,31 @@ export function renderTablaChrRef(ctx: InformeCtx) {
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 }
 
+export function renderTablaBaseRef29(ctx: InformeCtx, conv: DatosConvencional) {
+  const { doc, autoTable } = ctx;
+  const toma1 = conv.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
+  const kv = toma1?.kv_nominal ?? null;
+  const mas = toma1?.carga_mas ?? null;
+  const eiBase = toma1?.ei_base ?? null;
+  const diBase = toma1?.di_base ?? null;
+  ctx.checkPage(30);
+  addCaption(ctx, "Valores base de referencia");
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    startY: ctx.y,
+    head: [["Tensión (kVp)", "Carga (mAs)", "EI", "D.I."]],
+    body: [
+      [
+        kv != null ? kv.toFixed(1) : "—",
+        mas != null ? mas.toFixed(1) : "—",
+        eiBase != null ? String(eiBase) : "—",
+        diBase != null ? diBase.toFixed(2) : "NA",
+      ],
+    ],
+  });
+  ctx.y = finalY(doc) + 4;
+}
+
 function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const { doc, autoTable } = ctx;
   const shots80 = conv.raysafeMediciones.filter(
@@ -1567,25 +1592,7 @@ function render29(ctx: InformeCtx, conv: DatosConvencional): number {
   });
   ctx.y = finalY(doc) + 4;
 
-  // 2.9.6 Valores base de referencia
-  ctx.addSubsectionTitle("2.9.6.", "Valores base de referencia");
-  addCaption(ctx, "Tabla 2.9.3. Valores base de referencia establecidos para la prueba DDI/EI.");
-  autoTable(doc, {
-    ...TABLE_STYLE,
-    startY: ctx.y,
-    head: [["Tensión (kVp)", "Carga (mAs)", "EI base", "D.I. base"]],
-    body: [
-      [
-        kv ? String(kv) : "—",
-        mas ? String(mas) : "—",
-        eiBase != null ? String(eiBase) : "—",
-        diBase != null ? diBase.toFixed(2) : "—",
-      ],
-    ],
-  });
-  ctx.y = finalY(doc) + 4;
-
-  return 7; // 2.9.4, 2.9.5, 2.9.6 renderizados; caller inicia en 7 (Criterio)
+  return 6; // 2.9.4 y 2.9.5 renderizados; caller inicia en 6 (Criterio)
 }
 
 function render210(ctx: InformeCtx, conv: DatosConvencional): number {


### PR DESCRIPTION
## Summary

- Implementación completa de pruebas 2.8 (PKA), 2.9/2.10 (DDI/EI), 2.11 (Uniformidad detector), 2.12 (Resolución espacial), 2.13 (Bajo contraste) en el PDF del informe convencional
- UI para ingreso de datos grupos D y E: tolerancia dinámica, selector pl/mm, concepto FAVORABLE/NO FAVORABLE inline
- Carga de plantilla RaySafe con valores nominales precargados para grupos B y C
- Corrección ortográfica completa de textos en secciones 2.1, 2.14–2.21 (tildes, conjugaciones verbales)
- Justificación de todos los párrafos del PDF via `addParagraph`

## Test plan

- [x] Generar PDF de una visita con datos en 2.8–2.13 y verificar que las tablas, análisis y concepto aparecen correctamente
- [x] Verificar que los párrafos de objetivo, metodología y análisis se muestran justificados
- [x] Verificar ortografía en secciones 2.1 y 2.14–2.21 del PDF generado
- [x] Confirmar que el porcentaje de tolerancia en el criterio 2.11 refleja el valor configurado en la UI
- [x] Confirmar que el concepto 2.12 es FAVORABLE cuando pl/mm >= 2,4

🤖 Generated with [Claude Code](https://claude.com/claude-code)