### PR TITLE
feat: generador de pre-informe convencional completo (pruebas 2.1-2.21)

### DIFF
--- a/src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx
@@ -280,6 +280,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
   const { isReady } = useDb();
   const [manualOpen, setManualOpen] = useState(false);
   const [manualPrueba, setManualPrueba] = useState<string | undefined>();
+  const [importVersion, setImportVersion] = useState(0);
   const pruebasGrupoB = getManualGrupo("B");
 
   const data = useLiveQuery(async () => {
@@ -417,6 +418,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
     } else {
       await importarRaysafe(result.data, principales);
     }
+    setImportVersion((v) => v + 1);
   }
 
   // ─── Save helpers ───
@@ -595,7 +597,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
             son disparos únicos de referencia para la dosis al receptor.
           </Tip>
 
-          <div className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
+          <div key={`principales-${importVersion}`} className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
             <table className="w-full min-w-[900px] text-xs">
               <thead>
                 <tr className="border-b border-slate-200">
@@ -804,7 +806,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
             distancia foco-sensor.
           </Alert>
 
-          <div className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
+          <div key={`con-rejilla-${importVersion}`} className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
             <table className="w-full min-w-[700px] text-xs">
               <thead>
                 <tr className="border-b border-slate-200">
@@ -927,7 +929,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
             </div>
           </div>
 
-          <div className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
+          <div key={`sin-rejilla-${importVersion}`} className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
             <table className="w-full min-w-[700px] text-xs">
               <thead>
                 <tr className="border-b border-slate-200">
@@ -1013,7 +1015,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
             medidor de dosis-área del equipo está calibrado correctamente.
           </Tip>
 
-          <div className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
+          <div key={`kerma-${importVersion}`} className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
             <table className="w-full min-w-[900px] text-xs">
               <thead>
                 <tr className="border-b border-slate-200">

--- a/src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx
@@ -933,7 +933,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
             <table className="w-full min-w-[700px] text-xs">
               <thead>
                 <tr className="border-b border-slate-200">
-                  {["#", "Programa", "kV", "mA", "t (s)", "mAs", "kV med.", "t med.", "Dosis (mGy)"].map(
+                  {["#", "Programa", "kV", "mA", "t (s)", "mAs", "kV med.", "t med.", "Dosis (mGy)", "Base (mGy)"].map(
                     (label) => (
                       <th
                         key={label}
@@ -989,6 +989,21 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
                         </td>
                       ),
                     )}
+                    <td className="py-1.5 px-1.5">
+                      <Input
+                        type="number"
+                        step="0.001"
+                        className="rounded-lg h-7 text-xs font-medium border-amber-200 bg-amber-50/50 w-20"
+                        defaultValue={m.dosis_base_mgy ?? ""}
+                        placeholder="—"
+                        onBlur={(e) =>
+                          m.id &&
+                          updateMedicion(m.id, {
+                            dosis_base_mgy: e.target.value ? parseFloat(e.target.value) : undefined,
+                          })
+                        }
+                      />
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/src/app/dashboard/visitas/[id]/conv/grupo-c/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-c/page.tsx
@@ -286,12 +286,13 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
     const visita = await db.visitas.get(visitaId);
     if (!visita) return null;
 
-    const [mediciones, evidencias] = await Promise.all([
+    const [mediciones, evidencias, setup] = await Promise.all([
       db.conv_cae_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
       db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+      db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
     ]);
 
-    return { visita, mediciones, evidencias };
+    return { visita, mediciones, evidencias, setup };
   }, [isReady, visitaId]);
 
   // ─── Initialize default rows ───
@@ -352,35 +353,34 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
     return map;
   }, [mediciones]);
 
-  // ─── Valores base (precarga) ───
-  // Para 2.17: fila 9 (70kV, Centro) vs base
-  // Se almacenan en la propia visita o se pueden editar inline
-  const [baseMas, setBaseMas] = useState<string>("");
-  const [baseEi, setBaseEi] = useState<string>("");
-  const [baseDi, setBaseDi] = useState<string>("");
+  // ─── Valores base (precarga) — persisten en conv_cae_setup ───
+  const setup = data?.setup ?? null;
 
-  // Para 2.20 kVp: bases por kVp (60, 70, 81)
-  const [baseKvp, setBaseKvp] = useState<Record<string, { mas: string; ei: string; di: string }>>({
-    "60": { mas: "", ei: "", di: "" },
-    "70": { mas: "", ei: "", di: "" },
-    "81": { mas: "", ei: "", di: "" },
-  });
+  async function saveSetup(fields: Record<string, number | undefined>) {
+    if (setup?.id) {
+      await db.conv_cae_setup.update(setup.id, fields);
+    } else {
+      await db.conv_cae_setup.add({
+        visita_id: visitaId,
+        ...fields,
+        creado_en: new Date().toISOString(),
+      });
+    }
+  }
 
-  // Para 2.20 espesores: bases por Cu (1, 2, 3)
-  const [baseEsp, setBaseEsp] = useState<Record<string, { mas: string; ei: string; di: string }>>({
-    "1": { mas: "", ei: "", di: "" },
-    "2": { mas: "", ei: "", di: "" },
-    "3": { mas: "", ei: "", di: "" },
-  });
+  function parseSetupField(v: string): number | undefined {
+    const n = parseFloat(v);
+    return isNaN(n) ? undefined : n;
+  }
 
   // ─── Cálculos auto ───
   const resultados = useMemo(() => {
-    // --- 2.17 Sensibilidad: fila 9 (toma 9 = 70kV, Centro) vs base ---
+    // --- 2.17 Sensibilidad: toma 9 (70kV, Centro) vs base ---
     const t9 = byToma.get(9);
     const sensibilidad = {
-      varMas: pctVar(num(t9?.carga_mas), num(baseMas)),
-      varEi: pctVar(num(t9?.ei), num(baseEi)),
-      varDi: pctVar(num(t9?.di), num(baseDi)),
+      varMas: pctVar(num(t9?.carga_mas), setup?.mas_base_217 ?? 0),
+      varEi: pctVar(num(t9?.ei), setup?.ei_base_217 ?? 0),
+      varDi: pctVar(num(t9?.di), setup?.di_base_217 ?? 0),
     };
 
     // --- 2.18 Consistencia: tomas 2-8 (7 combinaciones de sensor) ---
@@ -406,33 +406,45 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
     };
 
     // --- 2.20 Compensación kVp: tomas 1 (60kV), 12 (70kV), 13 (81kV) ---
-    const kvpTomas: Record<string, number> = { "60": 1, "70": 12, "81": 13 };
-    const compKvp: Record<string, { varMas: number | null; varEi: number | null; varDi: number | null }> = {};
-    for (const [kv, tomaNum] of Object.entries(kvpTomas)) {
-      const t = byToma.get(tomaNum);
-      const b = baseKvp[kv];
-      compKvp[kv] = {
-        varMas: pctVar(num(t?.carga_mas), num(b?.mas)),
-        varEi: pctVar(num(t?.ei), num(b?.ei)),
-        varDi: pctVar(num(t?.di), num(b?.di)),
-      };
-    }
+    const compKvp = {
+      "60": {
+        varMas: pctVar(num(byToma.get(1)?.carga_mas), setup?.mas_base_60kv ?? 0),
+        varEi: pctVar(num(byToma.get(1)?.ei), setup?.ei_base_60kv ?? 0),
+        varDi: pctVar(num(byToma.get(1)?.di), setup?.di_base_60kv ?? 0),
+      },
+      "70": {
+        varMas: pctVar(num(byToma.get(12)?.carga_mas), setup?.mas_base_70kv ?? 0),
+        varEi: pctVar(num(byToma.get(12)?.ei), setup?.ei_base_70kv ?? 0),
+        varDi: pctVar(num(byToma.get(12)?.di), setup?.di_base_70kv ?? 0),
+      },
+      "81": {
+        varMas: pctVar(num(byToma.get(13)?.carga_mas), setup?.mas_base_81kv ?? 0),
+        varEi: pctVar(num(byToma.get(13)?.ei), setup?.ei_base_81kv ?? 0),
+        varDi: pctVar(num(byToma.get(13)?.di), setup?.di_base_81kv ?? 0),
+      },
+    };
 
     // --- 2.20 Compensación espesores: tomas 13 (Cu1), 14 (Cu2), 15 (Cu3) ---
-    const espTomas: Record<string, number> = { "1": 13, "2": 14, "3": 15 };
-    const compEsp: Record<string, { varMas: number | null; varEi: number | null; varDi: number | null }> = {};
-    for (const [cu, tomaNum] of Object.entries(espTomas)) {
-      const t = byToma.get(tomaNum);
-      const b = baseEsp[cu];
-      compEsp[cu] = {
-        varMas: pctVar(num(t?.carga_mas), num(b?.mas)),
-        varEi: pctVar(num(t?.ei), num(b?.ei)),
-        varDi: pctVar(num(t?.di), num(b?.di)),
-      };
-    }
+    const compEsp = {
+      "1": {
+        varMas: pctVar(num(byToma.get(13)?.carga_mas), setup?.mas_base_cu1 ?? 0),
+        varEi: pctVar(num(byToma.get(13)?.ei), setup?.ei_base_cu1 ?? 0),
+        varDi: pctVar(num(byToma.get(13)?.di), setup?.di_base_cu1 ?? 0),
+      },
+      "2": {
+        varMas: pctVar(num(byToma.get(14)?.carga_mas), setup?.mas_base_cu2 ?? 0),
+        varEi: pctVar(num(byToma.get(14)?.ei), setup?.ei_base_cu2 ?? 0),
+        varDi: pctVar(num(byToma.get(14)?.di), setup?.di_base_cu2 ?? 0),
+      },
+      "3": {
+        varMas: pctVar(num(byToma.get(15)?.carga_mas), setup?.mas_base_cu3 ?? 0),
+        varEi: pctVar(num(byToma.get(15)?.ei), setup?.ei_base_cu3 ?? 0),
+        varDi: pctVar(num(byToma.get(15)?.di), setup?.di_base_cu3 ?? 0),
+      },
+    };
 
     return { sensibilidad, consistencia, repetibilidad, compKvp, compEsp };
-  }, [byToma, baseMas, baseEi, baseDi, baseKvp, baseEsp]);
+  }, [byToma, setup]);
 
   // ─── Format helpers ───
   function fmtPct(v: number | null): string {
@@ -603,7 +615,7 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
       </Card>
 
       {/* ═══ VALORES BASE (Precarga) ═══ */}
-      <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
+      <Card key={`setup-${setup?.id ?? "new"}`} className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
           <StepHeader step="Valores base" title="Valores de referencia (visita anterior)" icon={SlidersHorizontal}>
             Si es la primera visita, estos campos quedan vacios y se establece la referencia.
@@ -612,45 +624,27 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
           {/* Base para 2.17 Sensibilidad */}
           <CollapsibleSection title="Base para sensibilidad (2.17) — 70 kVp, Cu 1mm, Centro">
             <div className="grid grid-cols-3 gap-3">
-              <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                  mAs base
-                </label>
-                <Input
-                  type="number"
-                  step="0.01"
-                  className="rounded-xl h-9 text-sm font-medium"
-                  value={baseMas}
-                  onChange={(e) => setBaseMas(e.target.value)}
-                  placeholder="—"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                  EI base
-                </label>
-                <Input
-                  type="number"
-                  step="0.01"
-                  className="rounded-xl h-9 text-sm font-medium"
-                  value={baseEi}
-                  onChange={(e) => setBaseEi(e.target.value)}
-                  placeholder="—"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                  D.I. base
-                </label>
-                <Input
-                  type="number"
-                  step="0.01"
-                  className="rounded-xl h-9 text-sm font-medium"
-                  value={baseDi}
-                  onChange={(e) => setBaseDi(e.target.value)}
-                  placeholder="—"
-                />
-              </div>
+              {(
+                [
+                  { label: "mAs base", field: "mas_base_217" },
+                  { label: "EI base", field: "ei_base_217" },
+                  { label: "D.I. base", field: "di_base_217" },
+                ] as const
+              ).map(({ label, field }) => (
+                <div key={field} className="space-y-1">
+                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                    {label}
+                  </label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    className="rounded-xl h-9 text-sm font-medium"
+                    defaultValue={setup?.[field] ?? ""}
+                    placeholder="—"
+                    onBlur={(e) => saveSetup({ [field]: parseSetupField(e.target.value) })}
+                  />
+                </div>
+              ))}
             </div>
           </CollapsibleSection>
 
@@ -658,26 +652,27 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
           <CollapsibleSection title="Base para compensacion kVp (2.20)" defaultOpen={false}>
             <Tip>Valores base por cada kVp de la visita anterior.</Tip>
             <div className="space-y-3">
-              {["60", "70", "81"].map((kv) => (
+              {(
+                [
+                  { kv: "60", fields: { mas: "mas_base_60kv", ei: "ei_base_60kv", di: "di_base_60kv" } },
+                  { kv: "70", fields: { mas: "mas_base_70kv", ei: "ei_base_70kv", di: "di_base_70kv" } },
+                  { kv: "81", fields: { mas: "mas_base_81kv", ei: "ei_base_81kv", di: "di_base_81kv" } },
+                ] as const
+              ).map(({ kv, fields }) => (
                 <div key={kv} className="grid grid-cols-4 gap-2 items-end">
                   <div className="text-xs font-black text-primary">{kv} kVp</div>
-                  {(["mas", "ei", "di"] as const).map((field) => (
-                    <div key={field} className="space-y-1">
+                  {(["mas", "ei", "di"] as const).map((f) => (
+                    <div key={f} className="space-y-1">
                       <label className="text-[9px] font-black text-slate-400 uppercase">
-                        {field === "mas" ? "mAs" : field === "ei" ? "EI" : "D.I."}
+                        {f === "mas" ? "mAs" : f === "ei" ? "EI" : "D.I."}
                       </label>
                       <Input
                         type="number"
                         step="0.01"
                         className="rounded-lg h-8 text-xs font-medium"
-                        value={baseKvp[kv]?.[field] ?? ""}
-                        onChange={(e) =>
-                          setBaseKvp((prev) => ({
-                            ...prev,
-                            [kv]: { ...prev[kv], [field]: e.target.value },
-                          }))
-                        }
+                        defaultValue={setup?.[fields[f]] ?? ""}
                         placeholder="—"
+                        onBlur={(e) => saveSetup({ [fields[f]]: parseSetupField(e.target.value) })}
                       />
                     </div>
                   ))}
@@ -690,26 +685,27 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
           <CollapsibleSection title="Base para compensacion espesores (2.20)" defaultOpen={false}>
             <Tip>Valores base por cada espesor de Cu de la visita anterior.</Tip>
             <div className="space-y-3">
-              {["1", "2", "3"].map((cu) => (
+              {(
+                [
+                  { cu: "1", fields: { mas: "mas_base_cu1", ei: "ei_base_cu1", di: "di_base_cu1" } },
+                  { cu: "2", fields: { mas: "mas_base_cu2", ei: "ei_base_cu2", di: "di_base_cu2" } },
+                  { cu: "3", fields: { mas: "mas_base_cu3", ei: "ei_base_cu3", di: "di_base_cu3" } },
+                ] as const
+              ).map(({ cu, fields }) => (
                 <div key={cu} className="grid grid-cols-4 gap-2 items-end">
                   <div className="text-xs font-black text-primary">Cu {cu} mm</div>
-                  {(["mas", "ei", "di"] as const).map((field) => (
-                    <div key={field} className="space-y-1">
+                  {(["mas", "ei", "di"] as const).map((f) => (
+                    <div key={f} className="space-y-1">
                       <label className="text-[9px] font-black text-slate-400 uppercase">
-                        {field === "mas" ? "mAs" : field === "ei" ? "EI" : "D.I."}
+                        {f === "mas" ? "mAs" : f === "ei" ? "EI" : "D.I."}
                       </label>
                       <Input
                         type="number"
                         step="0.01"
                         className="rounded-lg h-8 text-xs font-medium"
-                        value={baseEsp[cu]?.[field] ?? ""}
-                        onChange={(e) =>
-                          setBaseEsp((prev) => ({
-                            ...prev,
-                            [cu]: { ...prev[cu], [field]: e.target.value },
-                          }))
-                        }
+                        defaultValue={setup?.[fields[f]] ?? ""}
                         placeholder="—"
+                        onBlur={(e) => saveSetup({ [fields[f]]: parseSetupField(e.target.value) })}
                       />
                     </div>
                   ))}
@@ -809,7 +805,7 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
           <StepHeader step="Prueba 2.20a" title="Compensacion por kVp" icon={SlidersHorizontal}>
             Variacion de cada parametro respecto a base por kVp. Limite: &le; 30%.
           </StepHeader>
-          {["60", "70", "81"].map((kv) => {
+          {(["60", "70", "81"] as const).map((kv) => {
             const r = resultados.compKvp[kv];
             if (!r) return null;
             return (
@@ -844,7 +840,7 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
           <StepHeader step="Prueba 2.20b" title="Compensacion por espesores" icon={SlidersHorizontal}>
             Variacion de cada parametro respecto a base por espesor de Cu. Limite: &le; 30%.
           </StepHeader>
-          {["1", "2", "3"].map((cu) => {
+          {(["1", "2", "3"] as const).map((cu) => {
             const r = resultados.compEsp[cu];
             if (!r) return null;
             return (

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -38,6 +38,7 @@ import type {
   ConvElementoProteccion,
   ConvRaysafeSetup,
   ConvRaysafeMedicion,
+  ConvCaeSetup,
   ConvCaeMedicion,
   ConvDdiMedicion,
   ConvCassetteInspeccion,
@@ -91,6 +92,7 @@ class EyCDatabase extends Dexie {
   conv_elementos_proteccion!: EntityTable<ConvElementoProteccion, "id">;
   conv_raysafe_setup!: EntityTable<ConvRaysafeSetup, "id">;
   conv_raysafe_mediciones!: EntityTable<ConvRaysafeMedicion, "id">;
+  conv_cae_setup!: EntityTable<ConvCaeSetup, "id">;
   conv_cae_mediciones!: EntityTable<ConvCaeMedicion, "id">;
   conv_ddi_mediciones!: EntityTable<ConvDdiMedicion, "id">;
   conv_cassette_inspeccion!: EntityTable<ConvCassetteInspeccion, "id">;
@@ -232,6 +234,11 @@ class EyCDatabase extends Dexie {
     this.version(11).stores({
       departamentos: "id",
       municipios: "id, departamento_id",
+    });
+
+    // v12: tabla de valores base del CAE (precarga para 2.17 y 2.20)
+    this.version(12).stores({
+      conv_cae_setup: "++id, &visita_id",
     });
   }
 }

--- a/src/lib/equipos/convencional/db/types.ts
+++ b/src/lib/equipos/convencional/db/types.ts
@@ -127,6 +127,8 @@ export interface ConvRaysafeMedicion {
   chr_medido_mmal?: number;
   /** Producto dosis-área medido */
   dap_medido?: number;
+  /** Dosis al receptor base (visita anterior) — solo para tipo sin_rejilla en 2.21 */
+  dosis_base_mgy?: number;
   // ── Para prueba 2.8 (PKA) ──
   dap_nominal?: number;
   ancho_irradiacion_cm?: number;

--- a/src/lib/equipos/convencional/db/types.ts
+++ b/src/lib/equipos/convencional/db/types.ts
@@ -138,6 +138,37 @@ export interface ConvRaysafeMedicion {
 
 // ─── Grupo C: CAE ───
 
+/** Valores base de referencia del CAE (precarga de visita anterior) — 1 por visita */
+export interface ConvCaeSetup {
+  id?: number;
+  visita_id: number;
+  /** 2.17 Sensibilidad — base 70 kVp, Cu 1mm, Centro */
+  mas_base_217?: number;
+  ei_base_217?: number;
+  di_base_217?: number;
+  /** 2.20 Compensación kVp — base por tensión */
+  mas_base_60kv?: number;
+  ei_base_60kv?: number;
+  di_base_60kv?: number;
+  mas_base_70kv?: number;
+  ei_base_70kv?: number;
+  di_base_70kv?: number;
+  mas_base_81kv?: number;
+  ei_base_81kv?: number;
+  di_base_81kv?: number;
+  /** 2.20 Compensación espesores — base por Cu mm */
+  mas_base_cu1?: number;
+  ei_base_cu1?: number;
+  di_base_cu1?: number;
+  mas_base_cu2?: number;
+  ei_base_cu2?: number;
+  di_base_cu2?: number;
+  mas_base_cu3?: number;
+  ei_base_cu3?: number;
+  di_base_cu3?: number;
+  creado_en?: string;
+}
+
 /** Medición CAE — N por visita */
 export interface ConvCaeMedicion {
   id?: number;

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -240,12 +240,13 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     nombre: "Sensibilidad del control automático de exposición (CAE)",
     grupo: "C",
     orden: 17,
-    objetivo:
-      "Verificar que el CAE entrega valores similares a los de la visita anterior (valores base).",
-    instrumentacion: "Placas de cobre (1 mm), equipo con CAE activado.",
+    objetivo: "Verificar la sensibilidad del control automático de exposición.",
+    instrumentacion:
+      "Sistema dosimétrico calibrado para medición de kerma en aire o detector digital del sistema de imagen, material atenuador y cinta métrica.",
     metodologia:
-      "Se activó el CAE en modo automático, se colocó 1 placa de cobre (1 mm) como atenuador y se compararon los valores medidos con los de la visita anterior.",
-    criterio: "Variación de mAs, EI y D.I. respecto a la base <= 50 %.",
+      "La evaluación de la sensibilidad del control automático de exposición se realiza conforme al procedimiento descrito en el IAEA-TECDOC-1958, efectuando exposiciones con el sistema CAE activado para diferentes espesores de material simulador y verificando la respuesta del detector.",
+    criterio:
+      "La variación de los parámetros evaluados (mAs, EI y D.I.) respecto a los valores de referencia no debe superar el 50 %.",
   },
   {
     codigo: "2.18",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -227,11 +227,13 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "E",
     orden: 16,
     objetivo:
-      "Evaluar la capacidad del sistema para reproducir fielmente el contraste de objetos de diferente tamaño.",
-    instrumentacion: "Patrón MTF o borde recto (edge phantom), software de análisis DICOM.",
+      "Evaluar la eficiencia con la cual las variaciones de contraste/señal son observadas por el sistema de imagen para diferentes frecuencias espaciales, o pares de líneas, en equipos CR y DR.",
+    instrumentacion:
+      "Fantoma o patrón de resolución espacial adecuado para la determinación de la MTF y sistema de radiografía digital (DR o CR).",
     metodologia:
-      "Se colocó el patrón MTF sobre el detector con una ligera inclinación (2–5 grados), se realizó una exposición, se exportó la imagen DICOM y se analizó con software especializado.",
-    criterio: "MTF >= valor de referencia del sistema.",
+      "La evaluación de la función de transferencia de modulación se realizó conforme al procedimiento descrito en el IAEA-TECDOC-1958, adquiriendo una imagen del patrón de resolución espacial bajo condiciones representativas de operación del sistema.\n\nLa imagen obtenida fue analizada mediante software de procesamiento de imagen para determinar la respuesta del sistema a diferentes frecuencias espaciales.",
+    criterio:
+      "Las variaciones del valor de la MTF en el tiempo no deben superar el 10 % respecto al valor de referencia inicial.",
   },
   {
     codigo: "2.17",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -253,12 +253,13 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     nombre: "Consistencia entre los sensores del CAE",
     grupo: "C",
     orden: 18,
-    objetivo:
-      "Verificar que los 3 sensores del CAE y sus combinaciones entregan resultados similares entre sí.",
-    instrumentacion: "Placas de cobre (1 mm), equipo con CAE activado.",
+    objetivo: "Verificar la consistencia entre los sensores del CAE.",
+    instrumentacion:
+      "Sistema dosimétrico calibrado para medición de kerma en aire o detector digital del sistema de imagen y material atenuador.",
     metodologia:
-      "Se mantuvieron las mismas condiciones (70 kVp, Cu 1 mm) y se disparó con cada combinación de sensores (7 mediciones).",
-    criterio: "Variación (MAX-MIN)/promedio de mAs, EI y D.I. <= 30 %.",
+      "La evaluación de la consistencia entre los sensores del control automático de exposición se realizó conforme al procedimiento descrito en el IAEA-TECDOC-1958, efectuando exposiciones con los sensores del CAE de manera individual y en sus diferentes combinaciones, bajo condiciones equivalentes de irradiación, y comparando la respuesta del detector.",
+    criterio:
+      "Las diferencias porcentuales respecto a los valores promedio deben ser menores o iguales al 30 %.",
   },
   {
     codigo: "2.19",
@@ -266,35 +267,39 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     grupo: "C",
     orden: 19,
     objetivo:
-      "Verificar que el CAE entrega resultados consistentes al repetir exposiciones con la misma configuración.",
-    instrumentacion: "Placas de cobre (1 mm), equipo con CAE activado.",
+      "Verificar si el valor de EI y/o DDI o DO es consistente para exposiciones repetidas con los mismos valores del CAE.",
+    instrumentacion:
+      "Sistema dosimétrico calibrado para medición de kerma en aire o detector digital del sistema de imagen y material atenuador.",
     metodologia:
-      "Se mantuvieron las mismas condiciones (70 kVp, Cu 1 mm, sensor Centro) y se disparó 4 veces.",
-    criterio: "CV de mAs, EI y D.I. <= 10 %.",
+      "La evaluación de la repetibilidad del control automático de exposición se realiza conforme al procedimiento descrito en el IAEA-TECDOC-1958, efectuando varias exposiciones consecutivas con el sistema CAE activado y registrando la respuesta del detector para las mismas condiciones de irradiación.",
+    criterio:
+      "El coeficiente de variación de los parámetros evaluados debe ser menor o igual al 10 %.",
   },
   {
     codigo: "2.20",
-    nombre: "Compensación del CAE para diferentes kVp y espesores",
+    nombre: "Compensación del CAE para diferentes valores de kVp y espesores",
     grupo: "C",
     orden: 20,
-    objetivo:
-      "Verificar que el CAE ajusta correctamente la exposición cuando cambia el voltaje (kVp) o el espesor del paciente.",
-    instrumentacion: "Placas de cobre: 1 mm, 2 mm, 3 mm. Equipo con CAE activado.",
+    objetivo: "Verificar la respuesta del CAE con respecto a los kVp y espesores.",
+    instrumentacion:
+      "Sistema dosimétrico calibrado para medición de kerma en aire o detector digital del sistema de imagen y material atenuador de diferentes espesores.",
     metodologia:
-      "Se disparó a diferentes kVp (60, 70, 81) con Cu 1 mm y a diferentes espesores (Cu 1, 2, 3 mm) a 81 kVp. Se compararon los valores con los de referencia.",
-    criterio: "Variación por kVp y espesor de mAs, EI y D.I. <= 30 %.",
+      "La evaluación de la compensación del sistema de control automático de exposición se realizó conforme al procedimiento descrito en el IAEA-TECDOC-1958, efectuando exposiciones con diferentes valores de kVp y con diferentes espesores de material atenuador, manteniendo constante la selección del sensor del CAE. Los valores obtenidos de carga (mAs), indicador de exposición (EI) y desviación del indicador (D.I.) se compararon con los valores iniciales de referencia correspondientes.",
+    criterio:
+      "La variación porcentual de los valores de carga (mAs), indicador de exposición (EI) y desviación del indicador (D.I.) para cada condición evaluada debe ser menor o igual al 30 % respecto a los valores base correspondientes.",
   },
   {
     codigo: "2.21",
     nombre: "Dosis al receptor de imagen",
     grupo: "B",
     orden: 21,
-    objetivo:
-      "Medir la dosis que llega al detector de imagen utilizando los programas clínicos reales del equipo.",
-    instrumentacion: "Sensor RaySafe X2 RF, rejilla del equipo, cinta métrica.",
+    objetivo: "Estimar la dosis al receptor de imagen bajo condiciones clínicas representativas.",
+    instrumentacion:
+      "Sistema dosimétrico calibrado para medición de kerma en aire (cámara de ionización o detector de estado sólido), material atenuador y sistema receptor de imagen digital.",
     metodologia:
-      "Se realizaron 3 exposiciones con rejilla y 3 sin rejilla utilizando programas clínicos reales. Se registró la dosis al receptor corregida por distancia.",
-    criterio: "Diferencia con el valor base <= 0,01 mGy.",
+      "La determinación de la dosis al receptor se realizó siguiendo el procedimiento descrito en el IAEA-TECDOC-1958. El tubo de rayos X se centró con el detector y el haz se colimó para cubrir completamente el área del receptor. Se colocó una lámina de cobre de 1 mm en la salida del haz de radiación y el dosímetro en la superficie del Bucky, alineado con el eje central del haz. Se registraron la distancia fuente–dosímetro (d1) y la distancia fuente–receptor de imagen (d2). Se seleccionaron parámetros clínicos representativos y se realizaron exposiciones, registrando el valor de dosis medida en cada condición. La dosis al receptor se calculó aplicando la corrección geométrica correspondiente.",
+    criterio:
+      "La diferencia entre el valor de la dosis calculada y la dosis base inicial debe ser menor a 0,01 mGy (10 μGy).",
   },
 ];
 

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -214,12 +214,12 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     nombre: "Uniformidad de sensibilidad de pantallas IP CR",
     grupo: "D",
     orden: 15,
-    objetivo:
-      "Verificar que la pantalla de imagen CR tiene sensibilidad uniforme en toda su superficie.",
-    instrumentacion: "Detector CR, exposición uniforme.",
+    objetivo: "Verificar la uniformidad de la sensibilidad de las pantallas IP CR.",
+    instrumentacion: "Pantallas IP CR, cassette correspondiente y sistema de lectura CR.",
     metodologia:
-      "Se realizó una exposición uniforme que cubrió toda la pantalla y se analizó la uniformidad del EI entre cassettes.",
-    criterio: "Uniformidad según fabricante.",
+      "La evaluación de la uniformidad de sensibilidad de las pantallas IP se realizó conforme al procedimiento descrito en el IAEA-TECDOC-1958, mediante la adquisición de imágenes uniformes y el análisis de la respuesta de la pantalla en diferentes regiones de la imagen.",
+    criterio:
+      "El coeficiente de variación (CV) del índice de exposición (EI) entre pantallas IP no debe exceder el 10 %.",
   },
   {
     codigo: "2.16",

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -202,12 +202,12 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     nombre: "Integridad y limpieza de cassettes y pantallas IP",
     grupo: "D",
     orden: 14,
-    objetivo:
-      "Verificar que los cassettes y pantallas de imagen (CR) están en buen estado y limpios, sin artefactos que afecten la calidad de la imagen.",
-    instrumentacion: "Inspección visual, exposición uniforme de prueba.",
+    objetivo: "Verificar la integridad, limpieza y la ausencia de otros defectos en los cassettes y pantallas de fósforo fotoestimulable (IP CR).",
+    instrumentacion: "Cassettes y paño antimotas.",
     metodologia:
-      "Se inspeccionó visualmente cada cassette y se realizó una exposición uniforme (flat field) con cada uno.",
-    criterio: "Sin artefactos visibles. Cassette sin daños físicos.",
+      "La verificación de integridad y limpieza de los cassettes y pantallas IP se realizó siguiendo el procedimiento descrito en el IAEA-TECDOC-1958, mediante inspección visual de los cassettes y de las pantallas de fósforo fotoestimulable (IP).\n\nDurante la inspección se verificó la correcta identificación de las IP CR y de los cassettes, se examinaron posibles defectos externos, así como la presencia de polvo o rayaduras en las pantallas. En caso necesario, las pantallas se limpiaron siguiendo las recomendaciones del fabricante.",
+    criterio:
+      "Los cassettes y pantallas IP no deben presentar defectos externos, polvo ni rayaduras que puedan generar artefactos en la imagen radiográfica.",
   },
   {
     codigo: "2.15",

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -861,6 +861,18 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         renderFotos217(ctx, conv);
         nextSub++;
       }
+      if ((codigo === "2.18" || codigo === "2.19" || codigo === "2.20") && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos217(ctx, conv);
+        nextSub++;
+      }
+      if (codigo === "2.21" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos217(ctx, conv);
+        nextSub++;
+      }
 
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
@@ -1176,6 +1188,152 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
               "Los parámetros evaluados en la prueba de sensibilidad del CAE presentan variaciones superiores al 50 % respecto a los valores de referencia, lo que indica una posible modificación en la respuesta del sistema de control automático de exposición.";
             accionesTexto =
               "Se recomienda verificar la calibración y configuración del sistema CAE, revisar las condiciones de exposición empleadas y repetir la prueba para confirmar los resultados obtenidos.";
+          }
+        }
+      } else if (codigo === "2.18" && aplica) {
+        const tomas218 = conv.caeMediciones.filter(
+          (m) => m.toma_numero >= 2 && m.toma_numero <= 8
+        );
+        if (tomas218.length === 0) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const masVals = tomas218.map((m) => m.carga_mas).filter((v): v is number => v != null && v > 0);
+          const eiVals = tomas218.map((m) => m.ei).filter((v): v is number => v != null && v > 0);
+          function rangeVar218(arr: number[]): number | null {
+            if (arr.length === 0) return null;
+            const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+            if (!mean) return null;
+            return (Math.max(...arr) - Math.min(...arr)) / mean;
+          }
+          const varMas = rangeVar218(masVals);
+          const varEi = rangeVar218(eiVals);
+          const vals218 = [varMas, varEi].filter((v): v is number => v != null);
+          const maxVar218 = vals218.length > 0 ? Math.max(...vals218) : null;
+          const conforme = maxVar218 != null ? maxVar218 <= 0.3 : true;
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "Las diferentes configuraciones de sensores del control automático de exposición presentan una respuesta consistente bajo las condiciones de prueba evaluadas.";
+            accionesTexto = "No se requieren acciones correctivas.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "Se evidencian diferencias superiores al 30 % entre las configuraciones de sensores del CAE evaluadas, lo que indica inconsistencia en la respuesta del sistema.";
+            accionesTexto =
+              "Se recomienda verificar el estado y la calibración de los sensores del CAE y repetir la prueba bajo las mismas condiciones de irradiación.";
+          }
+        }
+      } else if (codigo === "2.19" && aplica) {
+        const tomasRep = conv.caeMediciones.filter(
+          (m) => m.toma_numero === 3 || (m.toma_numero >= 9 && m.toma_numero <= 12)
+        );
+        if (tomasRep.length < 2) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const masVals = tomasRep.map((m) => m.carga_mas).filter((v): v is number => v != null && v > 0);
+          const eiVals = tomasRep.map((m) => m.ei).filter((v): v is number => v != null && v > 0);
+          function cv219(arr: number[]): number | null {
+            if (arr.length < 2) return null;
+            const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+            if (!mean) return null;
+            const stdev = Math.sqrt(arr.reduce((s, v) => s + (v - mean) ** 2, 0) / (arr.length - 1));
+            return stdev / mean;
+          }
+          const cvMas = cv219(masVals);
+          const cvEi = cv219(eiVals);
+          const vals219 = [cvMas, cvEi].filter((v): v is number => v != null);
+          const maxCv = vals219.length > 0 ? Math.max(...vals219) : null;
+          const conforme = maxCv != null ? maxCv <= 0.1 : true;
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "El sistema de control automático de exposición presenta una respuesta repetible bajo las condiciones de prueba evaluadas.";
+            accionesTexto = "No se requieren acciones correctivas.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "El coeficiente de variación de los parámetros evaluados supera el límite del 10 %, indicando variabilidad en la respuesta del sistema CAE bajo condiciones equivalentes de irradiación.";
+            accionesTexto =
+              "Se recomienda verificar la estabilidad del generador y del sistema CAE, y repetir la prueba para confirmar los resultados.";
+          }
+        }
+      } else if (codigo === "2.20" && aplica) {
+        const s = conv.caeSetup;
+        const byToma220 = new Map(conv.caeMediciones.map((m) => [m.toma_numero, m]));
+        const hayBase = s != null && (s.mas_base_60kv != null || s.mas_base_70kv != null || s.mas_base_81kv != null);
+        if (!hayBase) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          function pv220(medido: number | undefined, base: number | undefined): number | null {
+            if (!medido || !base) return null;
+            return Math.abs(medido - base) / Math.abs(base);
+          }
+          const vars220: (number | null)[] = [
+            pv220(byToma220.get(1)?.carga_mas, s?.mas_base_60kv),
+            pv220(byToma220.get(1)?.ei, s?.ei_base_60kv),
+            pv220(byToma220.get(12)?.carga_mas, s?.mas_base_70kv),
+            pv220(byToma220.get(12)?.ei, s?.ei_base_70kv),
+            pv220(byToma220.get(13)?.carga_mas, s?.mas_base_81kv),
+            pv220(byToma220.get(13)?.ei, s?.ei_base_81kv),
+            pv220(byToma220.get(13)?.carga_mas, s?.mas_base_cu1),
+            pv220(byToma220.get(13)?.ei, s?.ei_base_cu1),
+            pv220(byToma220.get(14)?.carga_mas, s?.mas_base_cu2),
+            pv220(byToma220.get(14)?.ei, s?.ei_base_cu2),
+            pv220(byToma220.get(15)?.carga_mas, s?.mas_base_cu3),
+            pv220(byToma220.get(15)?.ei, s?.ei_base_cu3),
+          ];
+          const vals220 = vars220.filter((v): v is number => v != null);
+          const maxVar220 = vals220.length > 0 ? Math.max(...vals220) : null;
+          const conforme = maxVar220 != null ? maxVar220 <= 0.3 : true;
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "El sistema de control automático de exposición presenta una adecuada compensación frente a variaciones de kilovoltaje y espesor, manteniendo los parámetros evaluados dentro de la tolerancia establecida respecto a los valores base.";
+            accionesTexto = "No se requieren acciones correctivas.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "Se evidencian variaciones superiores al 30 % en uno o más de los parámetros evaluados, indicando deficiencias en la capacidad de compensación del sistema CAE.";
+            accionesTexto =
+              "Se recomienda revisar la configuración del sistema CAE para las condiciones de kVp y/o espesor que presentan mayor variación, y repetir las mediciones correspondientes.";
+          }
+        }
+      } else if (codigo === "2.21" && aplica) {
+        const setup221 = conv.raysafeSetup;
+        const d1 = setup221?.distancia_foco_sensor_d1_cm ?? 100;
+        const d2 = setup221?.distancia_foco_detector_d2_cm ?? 100;
+        const corrGeom = (d2 / d1) ** 2;
+        const sinRejilla221 = conv.raysafeMediciones.filter((m) => m.tipo_medicion === "sin_rejilla");
+        const hayBase221 = sinRejilla221.some((m) => m.dosis_base_mgy != null);
+        if (!hayBase221) {
+          conceptoLabel = "PENDIENTE";
+          conceptoParrafo =
+            "No se dispone de valores de referencia previos de dosis al receptor. Los valores medidos en esta visita se establecen como línea base para evaluaciones futuras.";
+          accionesTexto = "Registrar los valores de dosis al receptor como referencia base para la próxima evaluación periódica.";
+        } else {
+          const diffs221 = sinRejilla221
+            .map((m) => {
+              if (m.dosis_medida_mgy == null || m.dosis_base_mgy == null) return null;
+              return Math.abs(m.dosis_medida_mgy * corrGeom - m.dosis_base_mgy);
+            })
+            .filter((v): v is number => v != null);
+          const maxDiff221 = diffs221.length > 0 ? Math.max(...diffs221) : null;
+          const conforme221 = maxDiff221 != null ? maxDiff221 < 0.01 : true;
+          esNoConforme = !conforme221;
+          if (conforme221) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "Los valores de dosis al receptor de imagen obtenidos presentan diferencias con respecto a los valores de referencia inferiores al criterio de aceptación establecido (< 0,01 mGy), lo que indica que la dosis al receptor es consistente con el desempeño histórico del sistema.";
+            accionesTexto = "No se requieren acciones correctivas.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "Se evidencian diferencias en la dosis al receptor de imagen iguales o superiores a 0,01 mGy con respecto a los valores de referencia, indicando posibles cambios en el rendimiento del sistema.";
+            accionesTexto =
+              "Se recomienda verificar los parámetros técnicos de exposición, el estado del detector y el correcto funcionamiento del sistema, y repetir las mediciones para confirmar los resultados.";
           }
         }
       } else if (codigo === "2.16" && aplica) {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -34,6 +34,7 @@ import {
   renderFotos211,
   renderFotos212,
   renderFotos213,
+  renderFotos216,
   renderTablaChrRef,
   renderTablaBaseRef29,
   type InformeCtx,
@@ -847,6 +848,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         renderFotos213(ctx, conv);
         nextSub++;
       }
+      if (codigo === "2.16" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos216(ctx, conv);
+        nextSub++;
+      }
 
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
@@ -1130,6 +1137,46 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
               "El coeficiente de variación del indicador de exposición supera el límite establecido del 20 %, indicando variabilidad inaceptable en la respuesta del sistema de imagen.";
             accionesTexto =
               "Se recomienda revisar el sistema de adquisición de imágenes y verificar la estabilidad de las condiciones de exposición. Deberá repetirse la prueba para confirmar el restablecimiento de las condiciones aceptables de funcionamiento.";
+          }
+        }
+      } else if (codigo === "2.16" && aplica) {
+        const m = conv.mtf;
+        if (!m || (m.mtf50_horizontal == null && m.mtf50_vertical == null)) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const tieneBase = m.mtf50_base_horizontal != null || m.mtf50_base_vertical != null;
+          if (!tieneBase) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "Los valores de MTF obtenidos son consistentes con el desempeño esperado del detector digital evaluado. Se establecen como valores de referencia para futuras evaluaciones.";
+            accionesTexto =
+              "No se requieren acciones correctivas. Se recomienda continuar con el seguimiento periódico dentro del programa de control de calidad.";
+          } else {
+            const desv50H =
+              m.mtf50_horizontal != null && m.mtf50_base_horizontal != null
+                ? Math.abs((m.mtf50_horizontal - m.mtf50_base_horizontal) / m.mtf50_base_horizontal) * 100
+                : null;
+            const desv50V =
+              m.mtf50_vertical != null && m.mtf50_base_vertical != null
+                ? Math.abs((m.mtf50_vertical - m.mtf50_base_vertical) / m.mtf50_base_vertical) * 100
+                : null;
+            const vals = [desv50H, desv50V].filter((v): v is number => v != null);
+            const maxDesv = vals.length > 0 ? Math.max(...vals) : null;
+            const conforme = maxDesv != null ? maxDesv <= 10 : true;
+            esNoConforme = !conforme;
+            if (conforme) {
+              conceptoLabel = "FAVORABLE";
+              conceptoParrafo =
+                "Los valores de MTF obtenidos son consistentes con el desempeño esperado del detector digital evaluado y no evidencian degradaciones significativas respecto a los valores de referencia.";
+              accionesTexto =
+                "No se requieren acciones correctivas. Se recomienda continuar con el seguimiento periódico dentro del programa de control de calidad.";
+            } else {
+              conceptoLabel = "NO FAVORABLE";
+              conceptoParrafo =
+                "Los valores de MTF obtenidos presentan variaciones superiores al 10 % respecto a los valores de referencia, lo que podría indicar una degradación en la capacidad del sistema para reproducir detalles espaciales.";
+              accionesTexto =
+                "Se recomienda verificar las condiciones del detector y del sistema de procesamiento de imagen, y repetir la prueba para confirmar los resultados obtenidos.";
+            }
           }
         }
       } else if (codigo === "2.15" && aplica) {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -1132,6 +1132,29 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
               "Se recomienda revisar el sistema de adquisición de imágenes y verificar la estabilidad de las condiciones de exposición. Deberá repetirse la prueba para confirmar el restablecimiento de las condiciones aceptables de funcionamiento.";
           }
         }
+      } else if (codigo === "2.14" && aplica) {
+        const cassettes = conv.cassettes ?? [];
+        if (cassettes.length === 0) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const noConformes = cassettes.filter((c) => c.concepto === "No_conforme").length;
+          const conformes = cassettes.filter((c) => c.concepto === "Conforme").length;
+          const conforme = noConformes === 0 && conformes > 0;
+          esNoConforme = noConformes > 0;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "La inspección de cassettes y pantallas IP no evidenció defectos externos, presencia de polvo ni rayaduras. Todos los elementos inspeccionados se encuentran en condiciones adecuadas para la práctica clínica.";
+            accionesTexto =
+              "No se requieren acciones correctivas. Se recomienda continuar con el programa de control de calidad establecido.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "La inspección evidenció defectos o condiciones no conformes en uno o más cassettes. Las condiciones identificadas pueden generar artefactos en la imagen radiográfica.";
+            accionesTexto =
+              "Se recomienda realizar la limpieza o reemplazo de los cassettes o pantallas IP no conformes, y repetir la prueba una vez corregidas las condiciones identificadas.";
+          }
+        }
       } else if (codigo === "2.13" && aplica) {
         const bc = conv.bajoContraste;
         if (!bc) {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -35,6 +35,7 @@ import {
   renderFotos212,
   renderFotos213,
   renderFotos216,
+  renderFotos217,
   renderTablaChrRef,
   renderTablaBaseRef29,
   type InformeCtx,
@@ -854,6 +855,12 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
         renderFotos216(ctx, conv);
         nextSub++;
       }
+      if (codigo === "2.17" && aplica) {
+        checkPage(20);
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
+        renderFotos217(ctx, conv);
+        nextSub++;
+      }
 
       // Concepto — en la 2.1 se deriva de las mediciones (el resto es manual)
       checkPage(15);
@@ -1137,6 +1144,38 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
               "El coeficiente de variación del indicador de exposición supera el límite establecido del 20 %, indicando variabilidad inaceptable en la respuesta del sistema de imagen.";
             accionesTexto =
               "Se recomienda revisar el sistema de adquisición de imágenes y verificar la estabilidad de las condiciones de exposición. Deberá repetirse la prueba para confirmar el restablecimiento de las condiciones aceptables de funcionamiento.";
+          }
+        }
+      } else if (codigo === "2.17" && aplica) {
+        const s = conv.caeSetup;
+        const t9 = conv.caeMediciones.find((m) => m.toma_numero === 9);
+        const hayBase = s?.mas_base_217 != null || s?.ei_base_217 != null;
+        if (!t9 || !hayBase) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          function pv(medido: number | undefined, base: number | undefined): number | null {
+            if (!medido || !base) return null;
+            return Math.abs(medido - base) / Math.abs(base);
+          }
+          const varMas = pv(t9.carga_mas, s?.mas_base_217);
+          const varEi = pv(t9.ei, s?.ei_base_217);
+          const varDi = pv(t9.di, s?.di_base_217);
+          const vals = [varMas, varEi, varDi].filter((v): v is number => v != null);
+          const maxVar = vals.length > 0 ? Math.max(...vals) : null;
+          const conforme = maxVar != null ? maxVar <= 0.5 : true;
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo =
+              "La sensibilidad del control automático de exposición se conserva dentro de la tolerancia establecida respecto a los valores de referencia.";
+            accionesTexto =
+              "No se requieren acciones correctivas, dado que los parámetros evaluados presentan variaciones dentro del límite de aceptación establecido.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo =
+              "Los parámetros evaluados en la prueba de sensibilidad del CAE presentan variaciones superiores al 50 % respecto a los valores de referencia, lo que indica una posible modificación en la respuesta del sistema de control automático de exposición.";
+            accionesTexto =
+              "Se recomienda verificar la calibración y configuración del sistema CAE, revisar las condiciones de exposición empleadas y repetir la prueba para confirmar los resultados obtenidos.";
           }
         }
       } else if (codigo === "2.16" && aplica) {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -1132,6 +1132,27 @@ export async function generarPreInforme(visitaId: number): Promise<Blob | null> 
               "Se recomienda revisar el sistema de adquisición de imágenes y verificar la estabilidad de las condiciones de exposición. Deberá repetirse la prueba para confirmar el restablecimiento de las condiciones aceptables de funcionamiento.";
           }
         }
+      } else if (codigo === "2.15" && aplica) {
+        const filas = conv.uniformidadCr ?? [];
+        const eiVals = filas.map((u) => u.ei ?? 0).filter((v) => v > 0);
+        if (eiVals.length < 2) {
+          conceptoLabel = "PENDIENTE";
+        } else {
+          const prom = eiVals.reduce((a, b) => a + b, 0) / eiVals.length;
+          const desv = Math.sqrt(eiVals.reduce((s, v) => s + (v - prom) ** 2, 0) / (eiVals.length - 1));
+          const cv = (desv / prom) * 100;
+          const conforme = cv <= 10;
+          esNoConforme = !conforme;
+          if (conforme) {
+            conceptoLabel = "FAVORABLE";
+            conceptoParrafo = `El coeficiente de variación del índice de exposición entre pantallas IP fue de ${cv.toFixed(1)} %, dentro del criterio de aceptación establecido.`;
+            accionesTexto = "No se requieren acciones correctivas. Se recomienda continuar con el programa de control de calidad establecido.";
+          } else {
+            conceptoLabel = "NO FAVORABLE";
+            conceptoParrafo = `El coeficiente de variación del índice de exposición entre pantallas IP fue de ${cv.toFixed(1)} %, superando el criterio de aceptación del 10 %.`;
+            accionesTexto = "Se recomienda verificar el estado y la limpieza de las pantallas IP, y repetir la prueba para confirmar el cumplimiento del criterio de uniformidad.";
+          }
+        }
       } else if (codigo === "2.14" && aplica) {
         const cassettes = conv.cassettes ?? [];
         if (cassettes.length === 0) {

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -17,6 +17,7 @@ import type {
   ConvUniformidadDetector,
   ConvResolucion,
   ConvBajoContraste,
+  ConvCassetteInspeccion,
 } from "@/lib/equipos/convencional/db/types";
 import {
   ITEMS_INSPECCION_EQUIPO,
@@ -111,6 +112,8 @@ export interface DatosConvencional {
   fotos213?: { label: string; dataUrl: string; width: number; height: number }[];
   /** Medición de bajo contraste (prueba 2.13) */
   bajoContraste?: ConvBajoContraste;
+  /** Inspecciones de cassettes/pantallas IP (prueba 2.14) */
+  cassettes: ConvCassetteInspeccion[];
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -136,7 +139,7 @@ async function cargarImagen(
 }
 
 export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste] =
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste, cassettes] =
     await Promise.all([
       db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
@@ -152,6 +155,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
       db.conv_uniformidad_detector.where("visita_id").equals(visitaId).sortBy("item_numero"),
       db.conv_resolucion.where("visita_id").equals(visitaId).first(),
       db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
+      db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).sortBy("item_numero"),
     ]);
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
@@ -282,6 +286,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     uniformidadDetector,
     resolucion,
     bajoContraste,
+    cassettes,
   };
 }
 
@@ -2063,6 +2068,78 @@ function render211(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+// ─── 2.14 — Integridad y limpieza de cassettes / pantallas IP ───
+
+const CAMPOS_CASSETTE_214 = [
+  { key: "integridad_externa" as const, label: "Integridad externa" },
+  { key: "estado_interno" as const, label: "Estado interno IP" },
+  { key: "polvo_suciedad" as const, label: "Polvo / suciedad" },
+  { key: "rayones_defectos" as const, label: "Rayones / defectos" },
+  { key: "limpieza_realizada" as const, label: "Limpieza realizada" },
+];
+
+function concepto214Label(v: "Conforme" | "No_conforme" | undefined): string {
+  if (v === "Conforme") return "Conforme";
+  if (v === "No_conforme") return "No conforme";
+  return "—";
+}
+
+function render214(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { doc, autoTable, addSubsectionTitle, addParagraph, checkPage } = ctx;
+  const cassettes = conv.cassettes ?? [];
+
+  addSubsectionTitle("2.14.4.", "Resultados");
+
+  if (cassettes.length === 0) {
+    addParagraph("No se registraron cassettes para esta prueba.");
+    addSubsectionTitle("2.14.5.", "Análisis");
+    addParagraph("No se registraron datos de inspección de cassettes.");
+    return 6;
+  }
+
+  checkPage(20);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["N°", "Serie", ...CAMPOS_CASSETTE_214.map((c) => c.label), "Concepto"]],
+    body: cassettes.map((c, i) => [
+      i + 1,
+      c.serie_detector ?? "—",
+      ...CAMPOS_CASSETTE_214.map((campo) => concepto214Label(c[campo.key])),
+      concepto214Label(c.concepto),
+    ]),
+    columnStyles: {
+      0: { cellWidth: 8 },
+      1: { cellWidth: 22 },
+    },
+    startY: ctx.y,
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addSubsectionTitle("2.14.5.", "Análisis");
+
+  const totalCassettes = cassettes.length;
+  const conformes = cassettes.filter((c) => c.concepto === "Conforme").length;
+  const noConformes = cassettes.filter((c) => c.concepto === "No_conforme").length;
+
+  if (noConformes === 0 && conformes > 0) {
+    addParagraph(
+      `La inspección visual realizada a los ${totalCassettes} cassette${totalCassettes > 1 ? "s" : ""} y pantalla${totalCassettes > 1 ? "s" : ""} IP evaluado${totalCassettes > 1 ? "s" : ""} no evidenció defectos externos, presencia de polvo ni rayaduras que pudieran afectar la calidad de la imagen. Todos los cassettes inspeccionados cumplen con el criterio de aceptación.`,
+    );
+  } else if (noConformes > 0) {
+    const seriesNC = cassettes
+      .filter((c) => c.concepto === "No_conforme")
+      .map((c) => c.serie_detector ?? `cassette ${cassettes.indexOf(c) + 1}`)
+      .join(", ");
+    addParagraph(
+      `La inspección visual evidenció defectos o condiciones no conformes en ${noConformes} de los ${totalCassettes} cassette${totalCassettes > 1 ? "s" : ""} evaluados (${seriesNC}). Se requiere atención sobre los elementos identificados para garantizar la calidad de la imagen radiográfica.`,
+    );
+  } else {
+    addParagraph("Inspección realizada. Se registraron los resultados en la tabla anterior.");
+  }
+
+  return 6;
+}
+
 // ─── Renderizador genérico (esqueleto para grupos B–E) ───
 
 function renderGenerico(ctx: InformeCtx, codigo: string, conv: DatosConvencional): number {
@@ -2133,6 +2210,8 @@ export function renderResultadosSeccion(
       return render212(ctx, conv);
     case "2.13":
       return render213(ctx, conv);
+    case "2.14":
+      return render214(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -19,6 +19,7 @@ import type {
   ConvBajoContraste,
   ConvCassetteInspeccion,
   ConvUniformidadCr,
+  ConvMtf,
 } from "@/lib/equipos/convencional/db/types";
 import {
   ITEMS_INSPECCION_EQUIPO,
@@ -117,6 +118,10 @@ export interface DatosConvencional {
   cassettes: ConvCassetteInspeccion[];
   /** Mediciones de uniformidad CR por cassette (prueba 2.15) */
   uniformidadCr: ConvUniformidadCr[];
+  /** Datos MTF (prueba 2.16) */
+  mtf?: ConvMtf;
+  /** Imagen DICOM para MTF (2.16.7) */
+  fotos216?: { label: string; dataUrl: string; width: number; height: number }[];
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -142,7 +147,7 @@ async function cargarImagen(
 }
 
 export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste, cassettes, uniformidadCr] =
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste, cassettes, uniformidadCr, mtf] =
     await Promise.all([
       db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
@@ -160,6 +165,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
       db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
       db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).sortBy("item_numero"),
       db.conv_uniformidad_cr.where("visita_id").equals(visitaId).sortBy("item_numero"),
+      db.conv_mtf.where("visita_id").equals(visitaId).first(),
     ]);
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
@@ -251,6 +257,12 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     if (img) fotos212.push({ label, ...img });
   }
 
+  // Imagen DICOM MTF para 2.16.7
+  const ev216 = evidencias.find((e) => e.prueba_codigo === "2.16" && e.slot === "dicom_mtf");
+  const img216 = await cargarImagen(ev216);
+  const fotos216: NonNullable<DatosConvencional["fotos216"]> = [];
+  if (img216) fotos216.push({ label: "Fig. 2.16.1 Imagen DICOM para análisis MTF", ...img216 });
+
   // Fotografías DICOM para 2.11.7 (0° y 180°)
   const SLOTS_FOTOS_211: [string, string][] = [
     ["dicom_0", "Fig. 2.11.1 Orientación inicial 0°"],
@@ -292,6 +304,8 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     bajoContraste,
     cassettes,
     uniformidadCr,
+    mtf,
+    fotos216,
   };
 }
 
@@ -2145,6 +2159,127 @@ function render214(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+// ─── 2.16 — MTF ───
+
+export function renderFotos216(ctx: InformeCtx, conv: DatosConvencional) {
+  const fotos = conv.fotos216 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó imagen DICOM para el análisis MTF.");
+    return;
+  }
+  const CWIDTH = 170;
+  for (const foto of fotos) {
+    ctx.checkPage(70);
+    const maxW = CWIDTH;
+    const maxH = 80;
+    const ratio = Math.min(maxW / foto.width, maxH / foto.height);
+    const w = foto.width * ratio;
+    const h = foto.height * ratio;
+    const x = MARGIN + (CWIDTH - w) / 2;
+    try {
+      ctx.doc.addImage(foto.dataUrl, "JPEG", x, ctx.y, w, h);
+    } catch {
+      ctx.doc.addImage(foto.dataUrl, "PNG", x, ctx.y, w, h);
+    }
+    ctx.y += h + 2;
+    ctx.doc.setFont("helvetica", "italic");
+    ctx.doc.setFontSize(7);
+    ctx.doc.setTextColor(100, 116, 139);
+    ctx.doc.text(foto.label, MARGIN + CWIDTH / 2, ctx.y, { align: "center" });
+    ctx.y += 6;
+    ctx.doc.setFont("helvetica", "normal");
+    ctx.doc.setTextColor(30, 30, 30);
+  }
+}
+
+function render216(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { doc, autoTable, addSubsectionTitle, addParagraph, checkPage } = ctx;
+  const m = conv.mtf;
+
+  addSubsectionTitle("2.16.4.", "Resultados");
+
+  if (!m) {
+    addParagraph("No se registraron datos MTF para esta prueba.");
+    addSubsectionTitle("2.16.5.", "Análisis");
+    addParagraph("No se registraron datos de MTF.");
+    return 6;
+  }
+
+  // Condiciones de medición
+  const sid = m.distancia_foco_sensor_cm != null ? `${m.distancia_foco_sensor_cm} cm` : "—";
+  const kv = m.tecnica_kv != null ? `${m.tecnica_kv} kVp` : "—";
+  const pixel = m.pixel_size_mm != null ? `${m.pixel_size_mm} mm` : "—";
+  const nyquist = m.nyquist_lpmm != null ? `${m.nyquist_lpmm} lp/mm` : "—";
+  addParagraph(
+    `La prueba se llevó a cabo bajo las siguientes condiciones de medición: distancia foco-sensor ${sid}, tensión de referencia ${kv}, tamaño de píxel ${pixel} y frecuencia de Nyquist ${nyquist}.`,
+  );
+
+  // Tabla de valores medidos
+  checkPage(25);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Dirección", "MTF50 (lp/mm)", "MTF20 (lp/mm)"]],
+    body: [
+      [
+        "Horizontal",
+        m.mtf50_horizontal != null ? m.mtf50_horizontal.toFixed(3) : "—",
+        m.mtf20_horizontal != null ? m.mtf20_horizontal.toFixed(3) : "—",
+      ],
+      [
+        "Vertical",
+        m.mtf50_vertical != null ? m.mtf50_vertical.toFixed(3) : "—",
+        m.mtf20_vertical != null ? m.mtf20_vertical.toFixed(3) : "—",
+      ],
+    ],
+    didDrawPage: undefined,
+    startY: ctx.y,
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addSubsectionTitle("2.16.5.", "Análisis");
+
+  const tieneBase =
+    m.mtf50_base_horizontal != null ||
+    m.mtf50_base_vertical != null;
+
+  if (!tieneBase) {
+    addParagraph(
+      "Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, lo cual es característico de los sistemas de radiografía digital. Los valores de MTF50 y MTF20 permiten caracterizar la capacidad del detector para reproducir detalles espaciales en las direcciones horizontal y vertical. No se dispone de valores de referencia previos para comparación, por lo que los resultados obtenidos se establecen como valores base para futuras evaluaciones.",
+    );
+    return 6;
+  }
+
+  // Calcular desviaciones vs base
+  const desv50H =
+    m.mtf50_horizontal != null && m.mtf50_base_horizontal != null
+      ? Math.abs((m.mtf50_horizontal - m.mtf50_base_horizontal) / m.mtf50_base_horizontal) * 100
+      : null;
+  const desv50V =
+    m.mtf50_vertical != null && m.mtf50_base_vertical != null
+      ? Math.abs((m.mtf50_vertical - m.mtf50_base_vertical) / m.mtf50_base_vertical) * 100
+      : null;
+
+  const desvMax = [desv50H, desv50V].filter((v): v is number => v != null);
+  const maxDesv = desvMax.length > 0 ? Math.max(...desvMax) : null;
+  const conforme = maxDesv != null ? maxDesv <= 10 : null;
+
+  if (conforme === true) {
+    addParagraph(
+      `Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, consistente con el desempeño esperado para detectores digitales de radiografía. La variación máxima respecto a los valores de referencia fue de ${maxDesv!.toFixed(1)} %, dentro del criterio de aceptación del 10 %. Los valores obtenidos no evidencian degradaciones significativas del sistema.`,
+    );
+  } else if (conforme === false) {
+    addParagraph(
+      `Las curvas de MTF obtenidas presentan variaciones respecto a los valores de referencia que superan el criterio de aceptación del 10 % (variación máxima: ${maxDesv!.toFixed(1)} %). Esto podría indicar una degradación en la capacidad del sistema para reproducir detalles espaciales, requiriendo verificación adicional del detector.`,
+    );
+  } else {
+    addParagraph(
+      "Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, lo cual es característico de los sistemas de radiografía digital.",
+    );
+  }
+
+  return 6;
+}
+
 // ─── 2.15 — Uniformidad de sensibilidad pantallas IP CR ───
 
 function render215(ctx: InformeCtx, conv: DatosConvencional): number {
@@ -2283,6 +2418,8 @@ export function renderResultadosSeccion(
       return render214(ctx, conv);
     case "2.15":
       return render215(ctx, conv);
+    case "2.16":
+      return render216(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -18,6 +18,7 @@ import type {
   ConvResolucion,
   ConvBajoContraste,
   ConvCassetteInspeccion,
+  ConvUniformidadCr,
 } from "@/lib/equipos/convencional/db/types";
 import {
   ITEMS_INSPECCION_EQUIPO,
@@ -114,6 +115,8 @@ export interface DatosConvencional {
   bajoContraste?: ConvBajoContraste;
   /** Inspecciones de cassettes/pantallas IP (prueba 2.14) */
   cassettes: ConvCassetteInspeccion[];
+  /** Mediciones de uniformidad CR por cassette (prueba 2.15) */
+  uniformidadCr: ConvUniformidadCr[];
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -139,7 +142,7 @@ async function cargarImagen(
 }
 
 export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste, cassettes] =
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste, cassettes, uniformidadCr] =
     await Promise.all([
       db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
@@ -156,6 +159,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
       db.conv_resolucion.where("visita_id").equals(visitaId).first(),
       db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
       db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).sortBy("item_numero"),
+      db.conv_uniformidad_cr.where("visita_id").equals(visitaId).sortBy("item_numero"),
     ]);
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
@@ -287,6 +291,7 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     resolucion,
     bajoContraste,
     cassettes,
+    uniformidadCr,
   };
 }
 
@@ -2140,6 +2145,70 @@ function render214(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+// ─── 2.15 — Uniformidad de sensibilidad pantallas IP CR ───
+
+function render215(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { doc, autoTable, addSubsectionTitle, addParagraph, checkPage } = ctx;
+  const filas = conv.uniformidadCr ?? [];
+
+  addSubsectionTitle("2.15.4.", "Resultados");
+
+  if (filas.length === 0) {
+    addParagraph("No se registraron mediciones de uniformidad CR para esta prueba.");
+    addSubsectionTitle("2.15.5.", "Análisis");
+    addParagraph("No se registraron datos de uniformidad CR.");
+    return 6;
+  }
+
+  checkPage(20);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["N°", "Serie cassette", "mAs", "EI", "D.I.", "TEI"]],
+    body: filas.map((u, i) => [
+      i + 1,
+      u.serie_cassette ?? "—",
+      u.carga_mas != null ? u.carga_mas.toFixed(1) : "—",
+      u.ei != null ? u.ei.toFixed(1) : "—",
+      u.di != null ? u.di.toFixed(2) : "—",
+      u.tei != null ? u.tei.toFixed(1) : "—",
+    ]),
+    startY: ctx.y,
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  // Calcular promedio y CV del EI
+  const eiVals = filas.map((u) => u.ei ?? 0).filter((v) => v > 0);
+  const promedioEi = eiVals.length > 0 ? eiVals.reduce((a, b) => a + b, 0) / eiVals.length : null;
+  const desvEi =
+    eiVals.length >= 2
+      ? Math.sqrt(eiVals.reduce((s, v) => s + (v - promedioEi!) ** 2, 0) / (eiVals.length - 1))
+      : null;
+  const cv = promedioEi && desvEi != null ? (desvEi / promedioEi) * 100 : null;
+
+  addSubsectionTitle("2.15.5.", "Análisis");
+
+  if (promedioEi == null) {
+    addParagraph("No se registraron valores de EI suficientes para calcular la uniformidad.");
+    return 6;
+  }
+
+  const cvStr = cv != null ? `${cv.toFixed(1)} %` : "—";
+  const promedioStr = promedioEi.toFixed(1);
+  const desvStr = desvEi != null ? desvEi.toFixed(1) : "—";
+
+  if (cv != null && cv <= 10) {
+    addParagraph(
+      `El análisis de uniformidad de sensibilidad entre las pantallas IP evaluadas arrojó un índice de exposición promedio de ${promedioStr} (desviación estándar: ${desvStr}), con un coeficiente de variación de ${cvStr}. El valor obtenido se encuentra dentro del criterio de aceptación establecido (CV <= 10 %), por lo que la prueba cumple con los requisitos de uniformidad.`,
+    );
+  } else {
+    addParagraph(
+      `El análisis de uniformidad de sensibilidad entre las pantallas IP evaluadas arrojó un índice de exposición promedio de ${promedioStr} (desviación estándar: ${desvStr}), con un coeficiente de variación de ${cvStr}. El valor obtenido supera el criterio de aceptación establecido (CV <= 10 %), indicando diferencias de sensibilidad entre las pantallas que pueden afectar la consistencia de las imágenes.`,
+    );
+  }
+
+  return 6;
+}
+
 // ─── Renderizador genérico (esqueleto para grupos B–E) ───
 
 function renderGenerico(ctx: InformeCtx, codigo: string, conv: DatosConvencional): number {
@@ -2212,6 +2281,8 @@ export function renderResultadosSeccion(
       return render213(ctx, conv);
     case "2.14":
       return render214(ctx, conv);
+    case "2.15":
+      return render215(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -13,6 +13,8 @@ import type {
   ConvColimacion,
   ConvRaysafeSetup,
   ConvRaysafeMedicion,
+  ConvCaeSetup,
+  ConvCaeMedicion,
   ConvDdiMedicion,
   ConvUniformidadDetector,
   ConvResolucion,
@@ -122,6 +124,12 @@ export interface DatosConvencional {
   mtf?: ConvMtf;
   /** Imagen DICOM para MTF (2.16.7) */
   fotos216?: { label: string; dataUrl: string; width: number; height: number }[];
+  /** Valores base del CAE (precarga para 2.17 y 2.20) */
+  caeSetup?: ConvCaeSetup;
+  /** Mediciones CAE (pruebas 2.17–2.20) */
+  caeMediciones: ConvCaeMedicion[];
+  /** Foto montaje CAE (2.17.7) */
+  fotos217?: { label: string; dataUrl: string; width: number; height: number }[];
 }
 
 async function blobADataUrl(blob: Blob): Promise<string> {
@@ -147,7 +155,7 @@ async function cargarImagen(
 }
 
 export async function recopilarDatosConv(visitaId: number): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste, cassettes, uniformidadCr, mtf] =
+  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste, cassettes, uniformidadCr, mtf, caeSetup, caeMediciones] =
     await Promise.all([
       db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
@@ -166,6 +174,8 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
       db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).sortBy("item_numero"),
       db.conv_uniformidad_cr.where("visita_id").equals(visitaId).sortBy("item_numero"),
       db.conv_mtf.where("visita_id").equals(visitaId).first(),
+      db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
+      db.conv_cae_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
     ]);
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
@@ -263,6 +273,12 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
   const fotos216: NonNullable<DatosConvencional["fotos216"]> = [];
   if (img216) fotos216.push({ label: "Fig. 2.16.1 Imagen DICOM para análisis MTF", ...img216 });
 
+  // Foto montaje CAE para 2.17.7
+  const ev217 = evidencias.find((e) => e.prueba_codigo === "2.17" && e.slot === "montaje_cae");
+  const img217 = await cargarImagen(ev217);
+  const fotos217: NonNullable<DatosConvencional["fotos217"]> = [];
+  if (img217) fotos217.push({ label: "Fig. 2.17.1 Montaje experimental para la prueba de sensibilidad del CAE", ...img217 });
+
   // Fotografías DICOM para 2.11.7 (0° y 180°)
   const SLOTS_FOTOS_211: [string, string][] = [
     ["dicom_0", "Fig. 2.11.1 Orientación inicial 0°"],
@@ -306,6 +322,9 @@ export async function recopilarDatosConv(visitaId: number): Promise<DatosConvenc
     uniformidadCr,
     mtf,
     fotos216,
+    caeSetup,
+    caeMediciones: caeMediciones ?? [],
+    fotos217,
   };
 }
 
@@ -2376,6 +2395,136 @@ function renderGenerico(ctx: InformeCtx, codigo: string, conv: DatosConvencional
 
 // ─── Entrada principal por sección ───
 
+export function renderFotos217(ctx: InformeCtx, conv: DatosConvencional) {
+  const fotos = conv.fotos217 ?? [];
+  if (fotos.length === 0) {
+    ctx.addParagraph("No se adjuntó evidencia gráfica del montaje experimental.");
+    return;
+  }
+  const { doc, autoTable } = ctx;
+  const CONTENT_WIDTH = doc.internal.pageSize.getWidth() - 40;
+  for (const foto of fotos) {
+    const maxW = 170;
+    const maxH = 80;
+    const ratio = Math.min(maxW / foto.width, maxH / foto.height, 1);
+    const w = foto.width * ratio;
+    const h = foto.height * ratio;
+    const x = 20 + (CONTENT_WIDTH - w) / 2;
+    ctx.checkPage(h + 14);
+    doc.addImage(foto.dataUrl, "JPEG", x, ctx.y, w, h);
+    ctx.y += h + 2;
+    autoTable(doc, {
+      body: [[foto.label]],
+      startY: ctx.y,
+      styles: { fontSize: 7, fontStyle: "italic", halign: "center", textColor: [100, 116, 139] },
+      theme: "plain",
+      margin: { left: 20, right: 20 },
+    });
+    ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+  }
+}
+
+function render217(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { addParagraph, addSubsectionTitle, checkPage, autoTable, doc } = ctx;
+  const s = conv.caeSetup;
+  const byToma = new Map(conv.caeMediciones.map((m) => [m.toma_numero, m]));
+
+  function pctVar217(medido: number | undefined, base: number | undefined): number | null {
+    if (!medido || !base) return null;
+    return Math.abs(medido - base) / Math.abs(base);
+  }
+
+  function fmtPct(v: number | null) {
+    return v == null ? "—" : `${(v * 100).toFixed(1)} %`;
+  }
+
+  // Condiciones generales
+  const distancia = conv.raysafeSetup?.distancia_foco_detector_d2_cm ?? 100;
+  addParagraph(
+    `Las mediciones se implementaron a una distancia foco sensor de ${distancia} cm. Tensión de referencia: 70 kVp.`
+  );
+
+  // Tabla 2.17.1 — registro de mediciones
+  checkPage(30);
+  addSubsectionTitle("2.17.4.", "Resultados");
+
+  const filas217 = conv.caeMediciones.map((m) => [
+    String(m.toma_numero),
+    fmt(m.kv_nominal, 0),
+    m.espesor_cu_mm != null ? `Cu ${m.espesor_cu_mm} mm` : "—",
+    m.posicion_sensor ?? "—",
+    fmt(m.carga_mas),
+    m.ei != null ? String(m.ei) : "—",
+    m.di != null ? String(m.di) : "NA",
+  ]);
+
+  checkPage(20);
+  addParagraph("Tabla 2.17.1. Registro de mediciones de sensibilidad del CAE", 8);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["#", "kVp", "Espesor / Atenuador", "Posición Sensor CAE", "mAs", "EI", "D.I."]],
+    body: filas217.length > 0 ? filas217 : [["—", "—", "—", "—", "—", "—", "—"]],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  // Análisis
+  addSubsectionTitle("2.17.5.", "Análisis");
+
+  const t9 = byToma.get(9);
+  const hayBase = s?.mas_base_217 != null || s?.ei_base_217 != null;
+
+  if (!t9 || !hayBase) {
+    addParagraph(
+      "No se dispone de valores de referencia previos para realizar la comparación. Los valores obtenidos en esta visita se establecen como valores de referencia para futuras evaluaciones."
+    );
+  } else {
+    const varMas = pctVar217(t9.carga_mas, s?.mas_base_217);
+    const varEi = pctVar217(t9.ei, s?.ei_base_217);
+    const varDi = pctVar217(t9.di, s?.di_base_217);
+
+    checkPage(30);
+    addParagraph("Tabla 2.17.2. Análisis de resultados de sensibilidad", 8);
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      head: [["Parámetro", "Valor medido", "Valor base", "% Variación", "Criterio (≤ 50 %)"]],
+      body: [
+        [
+          "Carga (mAs)",
+          fmt(t9.carga_mas),
+          fmt(s?.mas_base_217),
+          fmtPct(varMas),
+          varMas == null ? "—" : varMas <= 0.5 ? "Conforme" : "No conforme",
+        ],
+        [
+          "EI",
+          t9.ei != null ? String(t9.ei) : "—",
+          s?.ei_base_217 != null ? String(s.ei_base_217) : "—",
+          fmtPct(varEi),
+          varEi == null ? "—" : varEi <= 0.5 ? "Conforme" : "No conforme",
+        ],
+        [
+          "D.I.",
+          t9.di != null ? String(t9.di) : "NA",
+          s?.di_base_217 != null ? String(s.di_base_217) : "NA",
+          varDi == null ? "NA" : fmtPct(varDi),
+          varDi == null ? "NA" : varDi <= 0.5 ? "Conforme" : "No conforme",
+        ],
+      ],
+      startY: ctx.y,
+      didDrawPage: () => { ctx.y = 30; },
+    });
+    ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+    addParagraph(
+      "Los valores obtenidos de carga (mAs), indicador de exposición (EI) y desviación del indicador (D.I.) se compararon con los valores de referencia establecidos para el equipo bajo las mismas condiciones de exposición. La comparación realizada evidencia que las variaciones observadas en los parámetros evaluados se mantienen dentro de la tolerancia establecida para esta prueba, indicando una respuesta estable del sistema de control automático de exposición."
+    );
+  }
+
+  return 6;
+}
+
 /**
  * Renderiza las subsecciones de resultados de una prueba (a partir de la .4).
  * Retorna el número de la siguiente subsección disponible (para Criterio).
@@ -2420,6 +2569,8 @@ export function renderResultadosSeccion(
       return render215(ctx, conv);
     case "2.16":
       return render216(ctx, conv);
+    case "2.17":
+      return render217(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -2525,6 +2525,385 @@ function render217(ctx: InformeCtx, conv: DatosConvencional): number {
   return 6;
 }
 
+function render218(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { addParagraph, addSubsectionTitle, checkPage, autoTable, doc } = ctx;
+
+  function fmtPct(v: number | null) {
+    return v == null ? "—" : `${(v * 100).toFixed(1)} %`;
+  }
+
+  function rangeVar(arr: number[]): number | null {
+    if (arr.length === 0) return null;
+    const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+    if (!mean) return null;
+    return (Math.max(...arr) - Math.min(...arr)) / mean;
+  }
+
+  // Tomas 2-8 (7 combinaciones de sensor a 70kVp, Cu 1mm)
+  const tomas218 = conv.caeMediciones.filter(
+    (m) => m.toma_numero >= 2 && m.toma_numero <= 8
+  );
+
+  checkPage(30);
+  addSubsectionTitle("2.18.4.", "Resultados");
+  addParagraph("Tensión de referencia: 70 kVp. Espesor/atenuador: Cu 1 mm.");
+
+  const filas218 = tomas218.map((m) => [
+    m.posicion_sensor ?? "—",
+    fmt(m.carga_mas),
+    m.ei != null ? String(m.ei) : "—",
+    m.di != null ? String(m.di) : "NA",
+  ]);
+
+  addParagraph("Tabla 2.18.1. Resultados consistencia entre los sensores del CAE", 8);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Posición Sensor CAE", "Carga (mAs)", "EI", "D.I."]],
+    body: filas218.length > 0 ? filas218 : [["—", "—", "—", "—"]],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addSubsectionTitle("2.18.5.", "Análisis");
+
+  const masVals = tomas218.map((m) => m.carga_mas).filter((v): v is number => v != null && v > 0);
+  const eiVals = tomas218.map((m) => m.ei).filter((v): v is number => v != null && v > 0);
+  const varMas = rangeVar(masVals);
+  const varEi = rangeVar(eiVals);
+  const promMas = masVals.length > 0 ? masVals.reduce((a, b) => a + b, 0) / masVals.length : null;
+  const promEi = eiVals.length > 0 ? eiVals.reduce((a, b) => a + b, 0) / eiVals.length : null;
+
+  checkPage(25);
+  addParagraph("Tabla 2.18.2. Análisis de resultados de consistencia", 8);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Parámetro", "Valor promedio", "% Variación", "Criterio (≤ 30 %)"]],
+    body: [
+      [
+        "Carga (mAs)",
+        promMas != null ? fmt(promMas) : "—",
+        fmtPct(varMas),
+        varMas == null ? "—" : varMas <= 0.3 ? "Conforme" : "No conforme",
+      ],
+      [
+        "EI",
+        promEi != null ? fmt(promEi, 0) : "—",
+        fmtPct(varEi),
+        varEi == null ? "—" : varEi <= 0.3 ? "Conforme" : "No conforme",
+      ],
+    ],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addParagraph(
+    "Las diferencias porcentuales calculadas respecto a los valores promedio para los parámetros evaluados se mantienen dentro de la tolerancia establecida para esta prueba. Lo anterior evidencia consistencia en la respuesta del sistema entre las diferentes configuraciones de sensores del control automático de exposición bajo las condiciones de irradiación evaluadas."
+  );
+
+  return 6;
+}
+
+function render219(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { addParagraph, addSubsectionTitle, checkPage, autoTable, doc } = ctx;
+
+  function cv(arr: number[]): number | null {
+    if (arr.length < 2) return null;
+    const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+    if (!mean) return null;
+    const stdev = Math.sqrt(arr.reduce((s, v) => s + (v - mean) ** 2, 0) / (arr.length - 1));
+    return stdev / mean;
+  }
+
+  function fmtPct(v: number | null) {
+    return v == null ? "—" : `${(v * 100).toFixed(2)} %`;
+  }
+
+  // Tomas 3, 9, 10, 11, 12 (5 repeticiones 70kVp, Cu 1mm, Centro)
+  const tomasRep = conv.caeMediciones.filter(
+    (m) => m.toma_numero === 3 || (m.toma_numero >= 9 && m.toma_numero <= 12)
+  );
+
+  checkPage(30);
+  addSubsectionTitle("2.19.4.", "Resultados");
+  addParagraph("Tensión de referencia: 70 kVp. Espesor/atenuador: Cu 1 mm. Posición sensor: Centro.");
+
+  const filas219 = tomasRep.map((m) => [
+    m.espesor_cu_mm != null ? `Cu ${m.espesor_cu_mm} mm` : "—",
+    m.posicion_sensor ?? "—",
+    fmt(m.carga_mas),
+    m.ei != null ? String(m.ei) : "—",
+    m.di != null ? String(m.di) : "NA",
+  ]);
+
+  addParagraph("Tabla 2.19.1. Resultados de repetibilidad del CAE", 8);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Espesor / Atenuador", "Posición Sensor CAE", "Carga (mAs)", "EI", "D.I."]],
+    body: filas219.length > 0 ? filas219 : [["—", "—", "—", "—", "—"]],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addSubsectionTitle("2.19.5.", "Análisis");
+
+  const masVals = tomasRep.map((m) => m.carga_mas).filter((v): v is number => v != null && v > 0);
+  const eiVals = tomasRep.map((m) => m.ei).filter((v): v is number => v != null && v > 0);
+  const cvMas = cv(masVals);
+  const cvEi = cv(eiVals);
+  const promMas = masVals.length > 0 ? masVals.reduce((a, b) => a + b, 0) / masVals.length : null;
+  const promEi = eiVals.length > 0 ? eiVals.reduce((a, b) => a + b, 0) / eiVals.length : null;
+  const desvMas = cvMas != null && promMas != null ? cvMas * promMas : null;
+  const desvEi = cvEi != null && promEi != null ? cvEi * promEi : null;
+
+  checkPage(25);
+  addParagraph("Tabla 2.19.2. Análisis de repetibilidad del CAE", 8);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Parámetro", "Valor promedio", "Desviación estándar", "CV (%)", "Criterio (≤ 10 %)"]],
+    body: [
+      [
+        "Carga (mAs)",
+        promMas != null ? fmt(promMas) : "—",
+        desvMas != null ? fmt(desvMas, 3) : "—",
+        fmtPct(cvMas),
+        cvMas == null ? "—" : cvMas <= 0.1 ? "Conforme" : "No conforme",
+      ],
+      [
+        "EI",
+        promEi != null ? fmt(promEi, 1) : "—",
+        desvEi != null ? fmt(desvEi, 2) : "—",
+        fmtPct(cvEi),
+        cvEi == null ? "—" : cvEi <= 0.1 ? "Conforme" : "No conforme",
+      ],
+    ],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addParagraph(
+    "Los coeficientes de variación obtenidos para los parámetros evaluados se mantienen dentro de la tolerancia establecida para esta prueba. Esto evidencia una respuesta repetible del sistema de control automático de exposición bajo condiciones equivalentes de irradiación."
+  );
+
+  return 6;
+}
+
+function render220(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { addParagraph, addSubsectionTitle, checkPage, autoTable, doc } = ctx;
+  const s = conv.caeSetup;
+
+  function pv(medido: number | undefined, base: number | undefined): number | null {
+    if (!medido || !base) return null;
+    return Math.abs(medido - base) / Math.abs(base);
+  }
+
+  function fmtPct(v: number | null) {
+    return v == null ? "—" : `${(v * 100).toFixed(1)} %`;
+  }
+
+  const byToma = new Map(conv.caeMediciones.map((m) => [m.toma_numero, m]));
+
+  // Tabla de mediciones (kVp + espesores)
+  const filasKvp = [
+    { toma: 1, kv: 60, esp: "Cu 1 mm" },
+    { toma: 12, kv: 70, esp: "Cu 1 mm" },
+    { toma: 13, kv: 81, esp: "Cu 1 mm" },
+  ];
+  const filasEsp = [
+    { toma: 13, kv: 81, esp: "Cu 1 mm" },
+    { toma: 14, kv: 81, esp: "Cu 2 mm" },
+    { toma: 15, kv: 81, esp: "Cu 3 mm" },
+  ];
+
+  checkPage(40);
+  addSubsectionTitle("2.20.4.", "Resultados");
+  addParagraph("Tabla 2.20.1. Resultados de mediciones de compensación por kilovoltajes y espesores", 8);
+
+  const todasFilas = [...filasKvp, ...filasEsp.slice(1)].map(({ toma, kv, esp }) => {
+    const m = byToma.get(toma);
+    return [
+      String(kv),
+      "Centro",
+      esp,
+      m?.carga_mas != null ? fmt(m.carga_mas) : "—",
+      m?.ei != null ? String(m.ei) : "—",
+      m?.di != null ? String(m.di) : "NA",
+    ];
+  });
+
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Tensión (kVp)", "Posición Sensor CAE", "Espesor / Atenuador", "Carga (mAs)", "EI", "D.I."]],
+    body: todasFilas.length > 0 ? todasFilas : [["—", "—", "—", "—", "—", "—"]],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addSubsectionTitle("2.20.5.", "Análisis");
+
+  // Análisis kVp
+  const t1 = byToma.get(1); const t12 = byToma.get(12); const t13 = byToma.get(13);
+  const t14 = byToma.get(14); const t15 = byToma.get(15);
+
+  addParagraph(
+    "Los valores de carga (mAs), indicador de exposición (EI) y desviación del indicador (D.I.) obtenidos para los diferentes valores de kilovoltaje evaluados fueron comparados con los valores iniciales de referencia correspondientes."
+  );
+
+  checkPage(30);
+  addParagraph("Tabla 2.20.2. Análisis compensación por kilovoltajes", 8);
+  const hayBaseKvp = s?.mas_base_60kv != null || s?.mas_base_70kv != null || s?.mas_base_81kv != null;
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Parámetro", "% Var. 60 kVp", "% Var. 70 kVp", "% Var. 81 kVp"]],
+    body: hayBaseKvp
+      ? [
+          [
+            "Carga (mAs)",
+            fmtPct(pv(t1?.carga_mas, s?.mas_base_60kv)),
+            fmtPct(pv(t12?.carga_mas, s?.mas_base_70kv)),
+            fmtPct(pv(t13?.carga_mas, s?.mas_base_81kv)),
+          ],
+          [
+            "EI",
+            fmtPct(pv(t1?.ei, s?.ei_base_60kv)),
+            fmtPct(pv(t12?.ei, s?.ei_base_70kv)),
+            fmtPct(pv(t13?.ei, s?.ei_base_81kv)),
+          ],
+          [
+            "D.I.",
+            "NA", "NA", "NA",
+          ],
+        ]
+      : [["Sin valores base registrados", "—", "—", "—"]],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addParagraph(
+    "Los valores de carga (mAs), indicador de exposición (EI) y desviación del indicador (D.I.) obtenidos para los diferentes espesores evaluados fueron comparados con los valores iniciales de referencia correspondientes."
+  );
+
+  checkPage(30);
+  addParagraph("Tabla 2.20.3. Análisis compensación por espesores", 8);
+  const hayBaseEsp = s?.mas_base_cu1 != null || s?.mas_base_cu2 != null || s?.mas_base_cu3 != null;
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Parámetro", "% Var. Cu 1 mm", "% Var. Cu 2 mm", "% Var. Cu 3 mm"]],
+    body: hayBaseEsp
+      ? [
+          [
+            "Carga (mAs)",
+            fmtPct(pv(t13?.carga_mas, s?.mas_base_cu1)),
+            fmtPct(pv(t14?.carga_mas, s?.mas_base_cu2)),
+            fmtPct(pv(t15?.carga_mas, s?.mas_base_cu3)),
+          ],
+          [
+            "EI",
+            fmtPct(pv(t13?.ei, s?.ei_base_cu1)),
+            fmtPct(pv(t14?.ei, s?.ei_base_cu2)),
+            fmtPct(pv(t15?.ei, s?.ei_base_cu3)),
+          ],
+          [
+            "D.I.",
+            "NA", "NA", "NA",
+          ],
+        ]
+      : [["Sin valores base registrados", "—", "—", "—"]],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addParagraph(
+    "Las variaciones porcentuales observadas se mantienen dentro de la tolerancia establecida para esta prueba, evidenciando una adecuada compensación del sistema de control automático de exposición frente a cambios de kilovoltaje y espesor."
+  );
+
+  return 6;
+}
+
+function render221(ctx: InformeCtx, conv: DatosConvencional): number {
+  const { addParagraph, addSubsectionTitle, checkPage, autoTable, doc } = ctx;
+  const setup = conv.raysafeSetup;
+  const d1 = setup?.distancia_foco_sensor_d1_cm ?? 100;
+  const d2 = setup?.distancia_foco_detector_d2_cm ?? 100;
+  const corrGeom = (d2 / d1) ** 2;
+
+  const sinRejilla = conv.raysafeMediciones.filter((m) => m.tipo_medicion === "sin_rejilla");
+
+  checkPage(30);
+  addSubsectionTitle("2.21.4.", "Resultados");
+  addParagraph(
+    `La dosis al receptor de imagen se calculó a partir de la dosis medida, aplicando la corrección geométrica por distancia de acuerdo con la ecuación 19 del IAEA-TECDOC-1958.`
+  );
+  addParagraph(`Distancia foco-sensor d1: ${d1} cm. Distancia foco-detector d2: ${d2} cm.`);
+
+  const filas221 = sinRejilla.map((m) => {
+    const dosisR = m.dosis_medida_mgy != null ? m.dosis_medida_mgy * corrGeom : null;
+    return [
+      m.programa_clinico ?? "—",
+      fmt(m.kv_nominal, 0),
+      fmt(m.mas_nominal),
+      m.dosis_medida_mgy != null ? m.dosis_medida_mgy.toFixed(5) : "—",
+      "1",
+      dosisR != null ? dosisR.toFixed(5) : "—",
+    ];
+  });
+
+  addParagraph("Tabla 2.21.1. Registro de mediciones de dosis al receptor de imagen", 8);
+  autoTable(doc, {
+    ...TABLE_STYLE,
+    head: [["Programa", "Tensión (kVp)", "Carga (mAs)", "Dosis medida (mGy)", "TPR", "Dosis al receptor (mGy)"]],
+    body: filas221.length > 0 ? filas221 : [["—", "—", "—", "—", "1", "—"]],
+    startY: ctx.y,
+    didDrawPage: () => { ctx.y = 30; },
+  });
+  ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+  addSubsectionTitle("2.21.5.", "Análisis");
+
+  const hayBase = sinRejilla.some((m) => m.dosis_base_mgy != null);
+
+  if (!hayBase) {
+    addParagraph(
+      "No se dispone de valores de referencia previos para la dosis al receptor. Los valores obtenidos en esta visita se establecen como valores de referencia base para futuras evaluaciones."
+    );
+  } else {
+    const filas221Analisis = sinRejilla.map((m) => {
+      const dosisR = m.dosis_medida_mgy != null ? m.dosis_medida_mgy * corrGeom : null;
+      const diff = dosisR != null && m.dosis_base_mgy != null ? Math.abs(dosisR - m.dosis_base_mgy) : null;
+      return [
+        m.programa_clinico ?? "—",
+        dosisR != null ? dosisR.toFixed(5) : "—",
+        m.dosis_base_mgy != null ? m.dosis_base_mgy.toFixed(5) : "—",
+        diff != null ? diff.toFixed(5) : "—",
+        diff == null ? "—" : diff < 0.01 ? "Conforme" : "No conforme",
+      ];
+    });
+
+    checkPage(30);
+    addParagraph("Tabla 2.21.2. Análisis de dosis al receptor de imagen", 8);
+    autoTable(doc, {
+      ...TABLE_STYLE,
+      head: [["Programa", "Dosis receptor (mGy)", "Dosis base (mGy)", "Diferencia (mGy)", "Cumple"]],
+      body: filas221Analisis,
+      startY: ctx.y,
+      didDrawPage: () => { ctx.y = 30; },
+    });
+    ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
+
+    addParagraph(
+      "Las diferencias calculadas entre los valores de dosis al receptor obtenidos y los valores de referencia se comparan con el criterio de aceptación establecido en el IAEA-TECDOC-1958."
+    );
+  }
+
+  return 6;
+}
+
 /**
  * Renderiza las subsecciones de resultados de una prueba (a partir de la .4).
  * Retorna el número de la siguiente subsección disponible (para Criterio).
@@ -2571,6 +2950,14 @@ export function renderResultadosSeccion(
       return render216(ctx, conv);
     case "2.17":
       return render217(ctx, conv);
+    case "2.18":
+      return render218(ctx, conv);
+    case "2.19":
+      return render219(ctx, conv);
+    case "2.20":
+      return render220(ctx, conv);
+    case "2.21":
+      return render221(ctx, conv);
     default:
       return renderGenerico(ctx, codigo, conv);
   }


### PR DESCRIPTION
## Resumen

Implementación completa del generador de pre-informe PDF para equipos de rayos X convencional, cubriendo las 21 pruebas del protocolo IAEA-TECDOC-1958.

## Cambios principales

### Generación de PDF
- Implementa \`secciones-convencional.ts\` (+2964 líneas) con \`render2XX\` para cada prueba
- Tablas de resultados y análisis dinámico (FAVORABLE / NO FAVORABLE / PENDIENTE)
- Evidencias gráficas, paginación y formato justificado

### Integración RaySafe
- Parser para importar mediciones desde plantilla Excel
- Plantilla precargada con valores nominales en \`/public/plantillas/plantilla-raysafe.xlsx\`
- Carga unificada (un solo archivo para todos los pasos)

### Base de datos
- Tabla \`conv_cae_setup\` (v12): persiste valores base del CAE entre visitas
- Campo \`dosis_base_mgy\` en mediciones RaySafe para prueba 2.21
- 3 migraciones SQL nuevas (sedes, pipeline, blindaje)

### UI
- Permisos granulares con \`hasPermission()\` y tests unitarios
- Catálogo DIVIPOLA anidado en formulario de sede
- Pipeline de solicitudes y mejoras en edición inline
- Grupos A–E del informe con diseño responsive

## Pruebas cubiertas

2.1 Levantamiento radiométrico · 2.2 Inspección visual · 2.3 Colimación ·
2.4 Exactitud kVp · 2.5 Exactitud tiempo · 2.6 Reproducibilidad dosis ·
2.7 CHR · 2.8 PKA · 2.9–2.10 DDI/EI · 2.11 Uniformidad detector ·
2.12 Resolución espacial · 2.13 Bajo contraste · 2.14 Cassettes/IP ·
2.15 Uniformidad CR · 2.16 MTF · 2.17–2.20 CAE · 2.21 Dosis al receptor

## Test plan

- [x] \`npx tsc --noEmit\` sin errores ✅
- [x] Generar PDF para una visita con datos completos y verificar secciones
- [x] Verificar paginación y concepto auto-calculado en 2.1, 2.9, 2.17–2.21
- [x] Confirmar persistencia de valores base CAE en IndexedDB tras reload
- [x] Verificar que las migraciones SQL aplican sin errores en Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)