### PR TITLE
fix: esquema conv_* de Supabase, duplicados en 2.2 y porcentajes de llenado

### DIFF
--- a/src/app/dashboard/visitas/[id]/conv/grupo-a/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-a/page.tsx
@@ -40,15 +40,16 @@ import {
 
 /** Catálogo de elementos de protección radiológica estandarizados */
 const CATALOGO_ELEMENTOS_PROTECCION = [
-  "Chaleco plomado",
-  "Protector de tiroides",
-  "Guantes plomados",
-  "Gafas plomadas",
-  "Protector gonadal",
   "Biombo plomado / mampara móvil",
-  "Falda plomada",
+  "Chaleco plomado",
+  "Delantal con cuello incluido",
   "Delantal plomado",
+  "Falda plomada",
+  "Gafas plomadas",
+  "Guantes plomados",
   "Porta-sueros plomado",
+  "Protector de tiroides",
+  "Protector gonadal",
   "Otro",
 ];
 
@@ -340,8 +341,16 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
   }, [isReady, visitaId]);
 
   // ─── Initialize setup if missing ───
+  // Guard síncrono: la consulta combinada (data) se vuelve a ejecutar cada vez
+  // que CUALQUIERA de sus 5 tablas cambia — incluida la que escribe este mismo
+  // efecto u otro hermano (p.ej. inspección). Eso puede reinvocar el efecto
+  // antes de que el insert previo se refleje en `data`, duplicando filas. El
+  // ref evita un segundo insert dentro del mismo montaje/visita.
+  const setupInsertadoRef = useRef<string | null>(null);
   useEffect(() => {
     if (!data || data.setup) return;
+    if (setupInsertadoRef.current === visitaId) return;
+    setupInsertadoRef.current = visitaId;
     db.conv_levantamiento_setup.add({
       id: randomUUID(),
       visita_id: visitaId,
@@ -353,9 +362,12 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
     });
   }, [data, visitaId]);
 
-  // ─── Initialize inspection items if missing ───
+  // ─── Initialize inspection items if missing ─── (mismo guard, ver arriba)
+  const inspeccionInsertadaRef = useRef<string | null>(null);
   useEffect(() => {
     if (!data || data.inspeccion.length > 0) return;
+    if (inspeccionInsertadaRef.current === visitaId) return;
+    inspeccionInsertadaRef.current = visitaId;
     const now = new Date().toISOString();
     const items: ConvInspeccionItem[] = [
       ...ITEMS_INSPECCION_EQUIPO.map((_, i) => ({
@@ -363,6 +375,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
         visita_id: visitaId,
         seccion: "equipo" as const,
         item_numero: i + 1,
+        concepto: "Conforme" as const,
         creado_en: now,
       })),
       ...ITEMS_CONDICIONES_OPERACION.map((_, i) => ({
@@ -370,6 +383,7 @@ export default function GrupoAPage({ params }: { params: Promise<{ id: string }>
         visita_id: visitaId,
         seccion: "condiciones_operacion" as const,
         item_numero: i + 1,
+        concepto: "Conforme" as const,
         creado_en: now,
       })),
     ];

--- a/src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-b/page.tsx
@@ -338,8 +338,16 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
   }, [isReady, visitaId]);
 
   // ─── Initialize setup ───
+  // Guard síncrono: la consulta combinada (data) se reejecuta cada vez que
+  // cualquiera de sus tablas cambia — incluida la que escribe el efecto
+  // hermano de disparos. Eso puede reinvocar este efecto antes de que el
+  // insert previo se refleje en `data`, duplicando filas. El ref evita un
+  // segundo insert dentro del mismo montaje/visita.
+  const setupInsertadoRef = useRef<string | null>(null);
   useEffect(() => {
     if (!data || data.setup) return;
+    if (setupInsertadoRef.current === visitaId) return;
+    setupInsertadoRef.current = visitaId;
     db.conv_raysafe_setup.add({
       id: randomUUID(),
       visita_id: visitaId,
@@ -350,9 +358,12 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
     });
   }, [data, visitaId]);
 
-  // ─── Initialize default shots ───
+  // ─── Initialize default shots ─── (mismo guard, ver arriba)
+  const disparosInsertadosRef = useRef<string | null>(null);
   useEffect(() => {
     if (!data || data.mediciones.length > 0) return;
+    if (disparosInsertadosRef.current === visitaId) return;
+    disparosInsertadosRef.current = visitaId;
     const now = new Date().toISOString();
     let toma = 1;
     const rows: import("@/lib/equipos/convencional/db/types").ConvRaysafeMedicion[] = [];
@@ -414,7 +425,9 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
     );
   }, [data, visitaId]);
 
-  // ─── Copiar nominales de con_rejilla → kerma (una sola vez) ───
+  // ─── Backfill: rellenar sin_rejilla/kerma vacíos con la técnica ya
+  //     capturada en con_rejilla (solo huecos — nunca sobreescribe lo ya
+  //     digitado). Cubre visitas empezadas antes de este cambio. ───
   useEffect(() => {
     if (!data) return;
     const conRejillaMap = new Map(
@@ -422,17 +435,22 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
         .filter((m) => m.tipo_medicion === "con_rejilla" && m.programa_clinico)
         .map((m) => [m.programa_clinico!, m])
     );
-    for (const k of data.mediciones.filter((m) => m.tipo_medicion === "kerma")) {
-      if (!k.id || !k.programa_clinico) continue;
-      const ref = conRejillaMap.get(k.programa_clinico);
+    for (const m of data.mediciones) {
+      if (!m.id || !m.programa_clinico) continue;
+      const ref = conRejillaMap.get(m.programa_clinico);
       if (!ref) continue;
       const updates: Record<string, unknown> = {};
-      if (k.kv_nominal == null && ref.kv_nominal != null) updates.kv_nominal = ref.kv_nominal;
-      if (k.ma_nominal == null && ref.ma_nominal != null) updates.ma_nominal = ref.ma_nominal;
-      if (k.tiempo_nominal_s == null && ref.tiempo_nominal_s != null)
-        updates.tiempo_nominal_s = ref.tiempo_nominal_s;
-      if (k.mas_nominal == null && ref.mas_nominal != null) updates.mas_nominal = ref.mas_nominal;
-      if (Object.keys(updates).length > 0) db.conv_raysafe_mediciones.update(k.id, updates);
+      if (m.tipo_medicion === "sin_rejilla") {
+        if (m.kv_nominal == null && ref.kv_nominal != null) updates.kv_nominal = ref.kv_nominal;
+        if (m.ma_nominal == null && ref.ma_nominal != null) updates.ma_nominal = ref.ma_nominal;
+        if (m.tiempo_nominal_s == null && ref.tiempo_nominal_s != null)
+          updates.tiempo_nominal_s = ref.tiempo_nominal_s;
+        if (m.mas_nominal == null && ref.mas_nominal != null) updates.mas_nominal = ref.mas_nominal;
+      } else if (m.tipo_medicion === "kerma") {
+        if (m.kv_nominal == null && ref.kv_nominal != null) updates.kv_nominal = ref.kv_nominal;
+        if (m.mas_nominal == null && ref.mas_nominal != null) updates.mas_nominal = ref.mas_nominal;
+      }
+      if (Object.keys(updates).length > 0) db.conv_raysafe_mediciones.update(m.id, updates);
     }
   }, [data, visitaId]);
 
@@ -494,6 +512,32 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
     );
   }
 
+  /**
+   * "Con rejilla" es la única técnica editable para un programa clínico; al
+   * guardarla se propaga a la toma "sin rejilla" (mismos 4 campos) y a la
+   * toma "kerma" (solo kV y mAs, los únicos que esa tabla usa) del mismo
+   * programa, para no digitar la misma técnica tres veces.
+   */
+  async function updateNominalConRejilla(
+    conRejillaId: string,
+    programaClinico: string | undefined,
+    field: CampoNominal,
+    value: number | undefined
+  ) {
+    await db.conv_raysafe_mediciones.update(conRejillaId, { [field]: value });
+    if (!programaClinico) return;
+    const sinRejillaMatch = sinRejilla.find((m) => m.programa_clinico === programaClinico);
+    if (sinRejillaMatch?.id) {
+      await db.conv_raysafe_mediciones.update(sinRejillaMatch.id, { [field]: value });
+    }
+    if (field === "kv_nominal" || field === "mas_nominal") {
+      const kermaMatch = kerma.find((m) => m.programa_clinico === programaClinico);
+      if (kermaMatch?.id) {
+        await db.conv_raysafe_mediciones.update(kermaMatch.id, { [field]: value });
+      }
+    }
+  }
+
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
     const existing = data?.evidencias?.find(
@@ -533,6 +577,11 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
   const conRejilla = (data?.mediciones ?? []).filter((m) => m.tipo_medicion === "con_rejilla");
   const sinRejilla = (data?.mediciones ?? []).filter((m) => m.tipo_medicion === "sin_rejilla");
   const kerma = (data?.mediciones ?? []).filter((m) => m.tipo_medicion === "kerma");
+  // "Con rejilla" es la única técnica editable; sin rejilla y kerma la reflejan
+  // en espejo por programa clínico (misma técnica real, sin volver a digitarla).
+  const conRejillaPorPrograma = new Map(
+    conRejilla.filter((m) => m.programa_clinico).map((m) => [m.programa_clinico!, m])
+  );
 
   // ─── Loading ───
   if (!isReady || data === undefined) {
@@ -829,7 +878,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
                 </tr>
               </thead>
               <tbody>
-                {conRejilla.map((m, idx) => (
+                {conRejilla.map((m) => (
                   <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
                     <td className="py-1.5 px-1.5 font-black text-primary">{m.toma_numero}</td>
                     <td className="py-1.5 px-1.5 font-medium text-slate-700">
@@ -845,9 +894,12 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
                             defaultValue={m[field] ?? ""}
                             onBlur={(e) =>
                               m.id &&
-                              updateMedicion(m.id, {
-                                [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                              })
+                              updateNominalConRejilla(
+                                m.id,
+                                m.programa_clinico,
+                                field,
+                                e.target.value ? parseFloat(e.target.value) : undefined
+                              )
                             }
                           />
                         </td>
@@ -888,7 +940,8 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
             title="Mediciones SIN rejilla (programas clínicos)"
             icon={Zap}
           >
-            Mismos programas pero sin rejilla. Necesario para calcular la dosis al receptor.
+            Mismos programas pero sin rejilla. Necesario para calcular la dosis al receptor. La
+            técnica (kV, mA, t, mAs) se toma automáticamente de &ldquo;Con rejilla&rdquo;.
           </StepHeader>
 
           <Tip>
@@ -964,66 +1017,66 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
                 </tr>
               </thead>
               <tbody>
-                {sinRejilla.map((m) => (
-                  <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                    <td className="py-1.5 px-1.5 font-black text-primary">{m.toma_numero}</td>
-                    <td className="py-1.5 px-1.5 font-medium text-slate-700">
-                      {m.programa_clinico}
-                    </td>
-                    {(["kv_nominal", "ma_nominal", "tiempo_nominal_s", "mas_nominal"] as const).map(
-                      (field) => (
+                {sinRejilla.map((m) => {
+                  const ref = m.programa_clinico
+                    ? conRejillaPorPrograma.get(m.programa_clinico)
+                    : undefined;
+                  return (
+                    <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
+                      <td className="py-1.5 px-1.5 font-black text-primary">{m.toma_numero}</td>
+                      <td className="py-1.5 px-1.5 font-medium text-slate-700">
+                        {m.programa_clinico}
+                      </td>
+                      {(
+                        ["kv_nominal", "ma_nominal", "tiempo_nominal_s", "mas_nominal"] as const
+                      ).map((field) => (
                         <td key={field} className="py-1.5 px-1.5">
-                          <Input
-                            type="number"
-                            step="0.01"
-                            className="rounded-lg h-7 text-xs font-medium border-slate-200 w-16"
-                            defaultValue={m[field] ?? ""}
-                            onBlur={(e) =>
-                              m.id &&
-                              updateMedicion(m.id, {
-                                [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                              })
-                            }
+                          <CeldaLectura
+                            value={ref?.[field] ?? null}
+                            tono="espejo"
+                            widthClass="w-16"
                           />
                         </td>
-                      )
-                    )}
-                    {(["kv_medido", "tiempo_medido_s", "dosis_medida_mgy"] as const).map(
-                      (field) => (
-                        <td key={field} className="py-1.5 px-1.5">
-                          <Input
-                            type="number"
-                            step="0.001"
-                            className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
-                            defaultValue={m[field] ?? ""}
-                            placeholder="—"
-                            onBlur={(e) =>
-                              m.id &&
-                              updateMedicion(m.id, {
-                                [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                              })
-                            }
-                          />
-                        </td>
-                      )
-                    )}
-                    <td className="py-1.5 px-1.5">
-                      <Input
-                        type="number"
-                        step="0.001"
-                        className="rounded-lg h-7 text-xs font-medium border-amber-200 bg-amber-50/50 w-20"
-                        defaultValue={m.dosis_base_mgy ?? ""}
-                        placeholder="—"
-                        onBlur={(e) =>
-                          m.id &&
-                          updateMedicion(m.id, {
-                            dosis_base_mgy: e.target.value ? parseFloat(e.target.value) : undefined,
-                          })
-                        }
-                      />
-                    </td>
-                  </tr>
-                ))}
+                      ))}
+                      {(["kv_medido", "tiempo_medido_s", "dosis_medida_mgy"] as const).map(
+                        (field) => (
+                          <td key={field} className="py-1.5 px-1.5">
+                            <Input
+                              type="number"
+                              step="0.001"
+                              className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
+                              defaultValue={m[field] ?? ""}
+                              placeholder="—"
+                              onBlur={(e) =>
+                                m.id &&
+                                updateMedicion(m.id, {
+                                  [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                                })
+                              }
+                            />
+                          </td>
+                        )
+                      )}
+                      <td className="py-1.5 px-1.5">
+                        <Input
+                          type="number"
+                          step="0.001"
+                          className="rounded-lg h-7 text-xs font-medium border-amber-200 bg-amber-50/50 w-20"
+                          defaultValue={m.dosis_base_mgy ?? ""}
+                          placeholder="—"
+                          onBlur={(e) =>
+                            m.id &&
+                            updateMedicion(m.id, {
+                              dosis_base_mgy: e.target.value
+                                ? parseFloat(e.target.value)
+                                : undefined,
+                            })
+                          }
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -1039,6 +1092,7 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
             icon={Zap}
           >
             Mide el Kerma en aire y calcula el factor de corrección del producto dosis-área (PKA).
+            El kV y mAs se toman automáticamente de &ldquo;Con rejilla&rdquo;.
           </StepHeader>
 
           <Alert>Retire el filtro de cobre antes de estas mediciones.</Alert>
@@ -1077,42 +1131,61 @@ export default function GrupoBPage({ params }: { params: Promise<{ id: string }>
                 </tr>
               </thead>
               <tbody>
-                {kerma.map((m) => (
-                  <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                    <td className="py-1.5 px-1 font-black text-primary">{m.toma_numero}</td>
-                    <td className="py-1.5 px-1 font-medium text-slate-700">{m.programa_clinico}</td>
-                    {(
-                      [
-                        "kv_nominal",
-                        "mas_nominal",
-                        "dap_nominal",
-                        "distancia_foco_sensor_cm" as "dap_nominal",
-                        "distancia_foco_detector_cm" as "dap_nominal",
-                        "ancho_irradiacion_cm",
-                        "largo_irradiacion_cm",
-                        "dosis_medida_mgy",
-                      ] as const
-                    ).map((field) => (
-                      <td key={field} className="py-1.5 px-1">
-                        <Input
-                          type="number"
-                          step="0.01"
-                          className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
-                          defaultValue={
-                            ((m as unknown as Record<string, unknown>)[field] as string) ?? ""
-                          }
-                          placeholder="—"
-                          onBlur={(e) =>
-                            m.id &&
-                            updateMedicion(m.id, {
-                              [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                            })
-                          }
+                {kerma.map((m) => {
+                  const ref = m.programa_clinico
+                    ? conRejillaPorPrograma.get(m.programa_clinico)
+                    : undefined;
+                  return (
+                    <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
+                      <td className="py-1.5 px-1 font-black text-primary">{m.toma_numero}</td>
+                      <td className="py-1.5 px-1 font-medium text-slate-700">
+                        {m.programa_clinico}
+                      </td>
+                      <td className="py-1.5 px-1">
+                        <CeldaLectura
+                          value={ref?.kv_nominal ?? null}
+                          tono="espejo"
+                          widthClass="w-20"
                         />
                       </td>
-                    ))}
-                  </tr>
-                ))}
+                      <td className="py-1.5 px-1">
+                        <CeldaLectura
+                          value={ref?.mas_nominal ?? null}
+                          tono="espejo"
+                          widthClass="w-20"
+                        />
+                      </td>
+                      {(
+                        [
+                          "dap_nominal",
+                          "distancia_foco_sensor_cm" as "dap_nominal",
+                          "distancia_foco_detector_cm" as "dap_nominal",
+                          "ancho_irradiacion_cm",
+                          "largo_irradiacion_cm",
+                          "dosis_medida_mgy",
+                        ] as const
+                      ).map((field) => (
+                        <td key={field} className="py-1.5 px-1">
+                          <Input
+                            type="number"
+                            step="0.01"
+                            className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
+                            defaultValue={
+                              ((m as unknown as Record<string, unknown>)[field] as string) ?? ""
+                            }
+                            placeholder="—"
+                            onBlur={(e) =>
+                              m.id &&
+                              updateMedicion(m.id, {
+                                [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                              })
+                            }
+                          />
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/src/app/dashboard/visitas/[id]/conv/grupo-c/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-c/page.tsx
@@ -57,9 +57,7 @@ const DISPAROS_CAE: {
   { toma: 15, kv: 81, cu: 3, sensor: "Centro", para: "2.20 esp" },
 ];
 
-const SLOTS_IMAGEN = [
-  { slot: "montaje_cae", label: "Montaje experimental CAE" },
-];
+const SLOTS_IMAGEN = [{ slot: "montaje_cae", label: "Montaje experimental CAE" }];
 
 // ─── Helpers ───
 
@@ -298,8 +296,13 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
   }, [isReady, visitaId]);
 
   // ─── Initialize default rows ───
+  // Guard síncrono contra reinvocaciones del efecto (misma consulta
+  // combinada reejecutándose) antes de que el bulkAdd previo se refleje.
+  const disparosInsertadosRef = useRef<string | null>(null);
   useEffect(() => {
     if (!data || data.mediciones.length > 0) return;
+    if (disparosInsertadosRef.current === visitaId) return;
+    disparosInsertadosRef.current = visitaId;
     const now = new Date().toISOString();
     const rows = DISPAROS_CAE.map((d) => ({
       id: randomUUID(),
@@ -323,7 +326,7 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
     const existing = data?.evidencias?.find(
-      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot,
+      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
       await db.conv_evidencias.update(existing.id, { blob_local: blob });
@@ -344,7 +347,7 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
 
   async function removeImage(pruebaCodigo: string, slot: string) {
     const existing = data?.evidencias?.find(
-      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot,
+      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) await db.conv_evidencias.delete(existing.id);
   }
@@ -509,7 +512,8 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
             Control Automatico de Exposicion (CAE)
           </h2>
           <p className="text-slate-500 font-medium text-sm mt-1">
-            Verifica sensibilidad, consistencia entre sensores, repetibilidad y compensacion del CAE.
+            Verifica sensibilidad, consistencia entre sensores, repetibilidad y compensacion del
+            CAE.
           </p>
         </div>
         <Button
@@ -532,12 +536,8 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
             Configura el CAE y coloca el atenuador de cobre.
           </StepHeader>
 
-          <Alert>
-            Revisar la configuracion del colimador — debe estar en modo MANUAL.
-          </Alert>
-          <Alert>
-            Si se mueve la placa de cobre, se debe repetir toda la ronda de disparos.
-          </Alert>
+          <Alert>Revisar la configuracion del colimador — debe estar en modo MANUAL.</Alert>
+          <Alert>Si se mueve la placa de cobre, se debe repetir toda la ronda de disparos.</Alert>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {SLOTS_IMAGEN.map((s) => (
@@ -569,16 +569,25 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
             <table className="w-full min-w-[800px] text-xs">
               <thead>
                 <tr className="border-b border-slate-200">
-                  {["#", "kVp", "Cu (mm)", "Sensor CAE", "mAs", "EI", "D.I.", "TEI", "DAP", "Para"].map(
-                    (label) => (
-                      <th
-                        key={label}
-                        className="text-[9px] font-black text-slate-400 uppercase tracking-widest text-left py-2 px-1.5"
-                      >
-                        {label}
-                      </th>
-                    ),
-                  )}
+                  {[
+                    "#",
+                    "kVp",
+                    "Cu (mm)",
+                    "Sensor CAE",
+                    "mAs",
+                    "EI",
+                    "D.I.",
+                    "TEI",
+                    "DAP",
+                    "Para",
+                  ].map((label) => (
+                    <th
+                      key={label}
+                      className="text-[9px] font-black text-slate-400 uppercase tracking-widest text-left py-2 px-1.5"
+                    >
+                      {label}
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody>
@@ -587,12 +596,8 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
                   return (
                     <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
                       <td className="py-1.5 px-1.5 font-black text-primary">{m.toma_numero}</td>
-                      <td className="py-1.5 px-1.5 text-slate-600 font-mono">
-                        {m.kv_nominal}
-                      </td>
-                      <td className="py-1.5 px-1.5 text-slate-600 font-mono">
-                        {m.espesor_cu_mm}
-                      </td>
+                      <td className="py-1.5 px-1.5 text-slate-600 font-mono">{m.kv_nominal}</td>
+                      <td className="py-1.5 px-1.5 text-slate-600 font-mono">{m.espesor_cu_mm}</td>
                       <td className="py-1.5 px-1.5 text-slate-600 font-medium text-[11px]">
                         {m.posicion_sensor}
                       </td>
@@ -627,9 +632,16 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
       </Card>
 
       {/* ═══ VALORES BASE (Precarga) ═══ */}
-      <Card key={`setup-${setup?.id ?? "new"}`} className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
+      <Card
+        key={`setup-${setup?.id ?? "new"}`}
+        className="border-none shadow-sm rounded-2xl bg-white overflow-hidden"
+      >
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Valores base" title="Valores de referencia (visita anterior)" icon={SlidersHorizontal}>
+          <StepHeader
+            step="Valores base"
+            title="Valores de referencia (visita anterior)"
+            icon={SlidersHorizontal}
+          >
             Si es la primera visita, estos campos quedan vacios y se establece la referencia.
           </StepHeader>
 
@@ -666,9 +678,18 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
             <div className="space-y-3">
               {(
                 [
-                  { kv: "60", fields: { mas: "mas_base_60kv", ei: "ei_base_60kv", di: "di_base_60kv" } },
-                  { kv: "70", fields: { mas: "mas_base_70kv", ei: "ei_base_70kv", di: "di_base_70kv" } },
-                  { kv: "81", fields: { mas: "mas_base_81kv", ei: "ei_base_81kv", di: "di_base_81kv" } },
+                  {
+                    kv: "60",
+                    fields: { mas: "mas_base_60kv", ei: "ei_base_60kv", di: "di_base_60kv" },
+                  },
+                  {
+                    kv: "70",
+                    fields: { mas: "mas_base_70kv", ei: "ei_base_70kv", di: "di_base_70kv" },
+                  },
+                  {
+                    kv: "81",
+                    fields: { mas: "mas_base_81kv", ei: "ei_base_81kv", di: "di_base_81kv" },
+                  },
                 ] as const
               ).map(({ kv, fields }) => (
                 <div key={kv} className="grid grid-cols-4 gap-2 items-end">
@@ -699,9 +720,18 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
             <div className="space-y-3">
               {(
                 [
-                  { cu: "1", fields: { mas: "mas_base_cu1", ei: "ei_base_cu1", di: "di_base_cu1" } },
-                  { cu: "2", fields: { mas: "mas_base_cu2", ei: "ei_base_cu2", di: "di_base_cu2" } },
-                  { cu: "3", fields: { mas: "mas_base_cu3", ei: "ei_base_cu3", di: "di_base_cu3" } },
+                  {
+                    cu: "1",
+                    fields: { mas: "mas_base_cu1", ei: "ei_base_cu1", di: "di_base_cu1" },
+                  },
+                  {
+                    cu: "2",
+                    fields: { mas: "mas_base_cu2", ei: "ei_base_cu2", di: "di_base_cu2" },
+                  },
+                  {
+                    cu: "3",
+                    fields: { mas: "mas_base_cu3", ei: "ei_base_cu3", di: "di_base_cu3" },
+                  },
                 ] as const
               ).map(({ cu, fields }) => (
                 <div key={cu} className="grid grid-cols-4 gap-2 items-end">
@@ -760,7 +790,11 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
       {/* 2.18 Consistencia */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-4">
-          <StepHeader step="Prueba 2.18" title="Consistencia entre sensores del CAE" icon={SlidersHorizontal}>
+          <StepHeader
+            step="Prueba 2.18"
+            title="Consistencia entre sensores del CAE"
+            icon={SlidersHorizontal}
+          >
             Variacion (MAX-MIN)/promedio entre las 7 combinaciones de sensor. Limite: &le; 30%.
           </StepHeader>
           <ResultRow
@@ -788,7 +822,8 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-4">
           <StepHeader step="Prueba 2.19" title="Repetibilidad del CAE" icon={SlidersHorizontal}>
-            CV (desviacion estandar / promedio) de las 4 repeticiones (tomas 9-12). Limite: CV &le; 10%.
+            CV (desviacion estandar / promedio) de las 4 repeticiones (tomas 9-12). Limite: CV &le;
+            10%.
           </StepHeader>
           <ResultRow
             label="Carga (mAs)"
@@ -849,7 +884,11 @@ export default function GrupoCaePage({ params }: { params: Promise<{ id: string 
       {/* 2.20 Compensación espesores */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-4">
-          <StepHeader step="Prueba 2.20b" title="Compensacion por espesores" icon={SlidersHorizontal}>
+          <StepHeader
+            step="Prueba 2.20b"
+            title="Compensacion por espesores"
+            icon={SlidersHorizontal}
+          >
             Variacion de cada parametro respecto a base por espesor de Cu. Limite: &le; 30%.
           </StepHeader>
           {(["1", "2", "3"] as const).map((cu) => {

--- a/src/app/dashboard/visitas/[id]/conv/grupo-d/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-d/page.tsx
@@ -290,8 +290,13 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
   }, [isReady, visitaId]);
 
   // ─── Initialize default DDI rows (6 tomas: grupo 1 ×3, grupos 2-4 ×1) ───
+  // Guard síncrono contra reinvocaciones del efecto (misma consulta
+  // combinada reejecutándose) antes de que el bulkAdd previo se refleje.
+  const ddiInsertadoRef = useRef<string | null>(null);
   useEffect(() => {
     if (!data || data.ddiMediciones.length > 0) return;
+    if (ddiInsertadoRef.current === visitaId) return;
+    ddiInsertadoRef.current = visitaId;
     const now = new Date().toISOString();
     const rows = [
       { grupo: 1, toma_numero: 1 },
@@ -322,7 +327,7 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
     const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
     if (t1?.ei_base != null) setBaseEi29(String(t1.ei_base));
     if (t1?.di_base != null) setBaseDi29(String(t1.di_base));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [(data?.ddiMediciones.length ?? 0) > 0]);
 
   // ─── Save helpers ───
@@ -375,7 +380,7 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
     const existing = data?.evidencias?.find(
-      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot,
+      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
       await db.conv_evidencias.update(existing.id, { blob_local: blob });
@@ -396,7 +401,7 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
 
   async function removeImage(pruebaCodigo: string, slot: string) {
     const existing = data?.evidencias?.find(
-      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot,
+      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) await db.conv_evidencias.delete(existing.id);
   }
@@ -483,8 +488,8 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
             DDI/EI, Integridad y Uniformidad CR
           </h2>
           <p className="text-slate-500 font-medium text-sm mt-1">
-            Control de calidad del indicador de dosis digital, repetibilidad, inspeccion de cassettes
-            y uniformidad de pantallas IP.
+            Control de calidad del indicador de dosis digital, repetibilidad, inspeccion de
+            cassettes y uniformidad de pantallas IP.
           </p>
         </div>
         <Button
@@ -507,7 +512,11 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
       {/* Setup */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Pruebas 2.9 / 2.10 — Setup" title="Preparacion DDI/EI" icon={MonitorCheck}>
+          <StepHeader
+            step="Pruebas 2.9 / 2.10 — Setup"
+            title="Preparacion DDI/EI"
+            icon={MonitorCheck}
+          >
             Configura el montaje para la medicion del indicador de dosis digital.
           </StepHeader>
 
@@ -532,8 +541,8 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
           <StepHeader step="Registro de mediciones" title="Disparos DDI/EI" icon={MonitorCheck}>
-            Grupo 1 (3 repeticiones) para prueba 2.9 y repetibilidad 2.10. Grupos 2-4 para
-            cassettes adicionales.
+            Grupo 1 (3 repeticiones) para prueba 2.9 y repetibilidad 2.10. Grupos 2-4 para cassettes
+            adicionales.
           </StepHeader>
 
           <div className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
@@ -606,7 +615,11 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
       {/* Valores base para 2.9 */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Valores base" title="Referencia visita anterior (2.9)" icon={MonitorCheck}>
+          <StepHeader
+            step="Valores base"
+            title="Referencia visita anterior (2.9)"
+            icon={MonitorCheck}
+          >
             Si es primera visita, estos campos quedan vacios y se establece la referencia.
           </StepHeader>
           <div className="grid grid-cols-2 gap-3">
@@ -720,14 +733,21 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
 
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Prueba 2.14" title="Integridad y limpieza de cassettes / pantallas IP" icon={MonitorCheck}>
+          <StepHeader
+            step="Prueba 2.14"
+            title="Integridad y limpieza de cassettes / pantallas IP"
+            icon={MonitorCheck}
+          >
             Inspecciona cada cassette o detector CR disponible.
           </StepHeader>
 
           <Alert>Solicitar al cliente que realice limpieza antes de la inspeccion.</Alert>
 
           {(data.cassettes ?? []).map((c, idx) => (
-            <CollapsibleSection key={c.id} title={`Cassette ${idx + 1}${c.serie_detector ? ` — ${c.serie_detector}` : ""}`}>
+            <CollapsibleSection
+              key={c.id}
+              title={`Cassette ${idx + 1}${c.serie_detector ? ` — ${c.serie_detector}` : ""}`}
+            >
               <div className="space-y-3">
                 <div className="space-y-1">
                   <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
@@ -744,7 +764,10 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   {CAMPOS_CASSETTE.map((campo) => (
-                    <div key={campo.key} className="flex items-center justify-between p-2 bg-slate-50 rounded-lg">
+                    <div
+                      key={campo.key}
+                      className="flex items-center justify-between p-2 bg-slate-50 rounded-lg"
+                    >
                       <span className="text-[11px] font-medium text-slate-600">{campo.label}</span>
                       <ConceptoSelect
                         value={c[campo.key]}
@@ -795,13 +818,15 @@ export default function GrupoDPage({ params }: { params: Promise<{ id: string }>
 
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Prueba 2.15" title="Uniformidad de sensibilidad de pantallas IP CR" icon={MonitorCheck}>
+          <StepHeader
+            step="Prueba 2.15"
+            title="Uniformidad de sensibilidad de pantallas IP CR"
+            icon={MonitorCheck}
+          >
             Mide la uniformidad del EI entre cassettes. Tecnica: 70 kVp, Cu 1mm, distancia 100 cm.
           </StepHeader>
 
-          <Tip>
-            Solo aplica a sistemas CR (con cassettes). No aplica a detectores DR fijos.
-          </Tip>
+          <Tip>Solo aplica a sistemas CR (con cassettes). No aplica a detectores DR fijos.</Tip>
 
           <div className="overflow-x-auto -mx-4 sm:-mx-5 px-4 sm:px-5">
             <table className="w-full min-w-[500px] text-xs">

--- a/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
+++ b/src/app/dashboard/visitas/[id]/conv/grupo-e/page.tsx
@@ -99,7 +99,11 @@ function CollapsibleSection({
         className="w-full flex items-center justify-between p-3 bg-slate-50 hover:bg-slate-100 transition-colors"
       >
         <span className="text-xs font-black text-slate-600 uppercase tracking-widest">{title}</span>
-        {open ? <ChevronUp className="w-4 h-4 text-slate-400" /> : <ChevronDown className="w-4 h-4 text-slate-400" />}
+        {open ? (
+          <ChevronUp className="w-4 h-4 text-slate-400" />
+        ) : (
+          <ChevronDown className="w-4 h-4 text-slate-400" />
+        )}
       </button>
       {open && <div className="p-3 space-y-3">{children}</div>}
     </div>
@@ -239,16 +243,43 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
   }, [isReady, visitaId]);
 
   // ─── Initialize singletons ───
+  // Guard síncrono por tabla: la consulta combinada se reejecuta cada vez que
+  // cualquiera de las 6 tablas cambia (incluida la que escribe este mismo
+  // efecto), pudiendo reinvocarlo antes de que un insert previo se refleje
+  // en `data` y duplicar filas. Un ref por singleton evita el doble insert.
+  const colimacionInsertadaRef = useRef<string | null>(null);
+  const resolucionInsertadaRef = useRef<string | null>(null);
+  const bajoContrasteInsertadoRef = useRef<string | null>(null);
+  const mtfInsertadoRef = useRef<string | null>(null);
   useEffect(() => {
     if (!data) return;
     const now = new Date().toISOString();
-    if (!data.colimacion) {
-      db.conv_colimacion.add({ id: randomUUID(), visita_id: visitaId, sid_cm: 100, tecnica_kv: 75, creado_en: now, sync_status: "pending" as const, last_modified: now });
+    if (!data.colimacion && colimacionInsertadaRef.current !== visitaId) {
+      colimacionInsertadaRef.current = visitaId;
+      db.conv_colimacion.add({
+        id: randomUUID(),
+        visita_id: visitaId,
+        sid_cm: 100,
+        tecnica_kv: 75,
+        creado_en: now,
+        sync_status: "pending" as const,
+        last_modified: now,
+      });
     }
-    if (!data.resolucion) {
-      db.conv_resolucion.add({ id: randomUUID(), visita_id: visitaId, sid_cm: 100, tecnica_kv: 75, creado_en: now, sync_status: "pending" as const, last_modified: now });
+    if (!data.resolucion && resolucionInsertadaRef.current !== visitaId) {
+      resolucionInsertadaRef.current = visitaId;
+      db.conv_resolucion.add({
+        id: randomUUID(),
+        visita_id: visitaId,
+        sid_cm: 100,
+        tecnica_kv: 75,
+        creado_en: now,
+        sync_status: "pending" as const,
+        last_modified: now,
+      });
     }
-    if (!data.bajoContraste) {
+    if (!data.bajoContraste && bajoContrasteInsertadoRef.current !== visitaId) {
+      bajoContrasteInsertadoRef.current = visitaId;
       db.conv_bajo_contraste.add({
         id: randomUUID(),
         visita_id: visitaId,
@@ -259,7 +290,8 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
         last_modified: now,
       });
     }
-    if (!data.mtf) {
+    if (!data.mtf && mtfInsertadoRef.current !== visitaId) {
+      mtfInsertadoRef.current = visitaId;
       db.conv_mtf.add({
         id: randomUUID(),
         visita_id: visitaId,
@@ -322,7 +354,7 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
     const existing = data?.evidencias?.find(
-      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot,
+      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
       await db.conv_evidencias.update(existing.id, { blob_local: blob });
@@ -343,7 +375,7 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
 
   async function removeImage(pruebaCodigo: string, slot: string) {
     const existing = data?.evidencias?.find(
-      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot,
+      (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) await db.conv_evidencias.delete(existing.id);
   }
@@ -388,16 +420,14 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
         if (!center) return { uniformidades: [] as number[], max: null as number | null };
         const uniformidades = [1, 2, 3, 4].map((i) => {
           const roi = num(det[`roi_${i}_vmp_${suffix}` as keyof typeof det]);
-          return roi && center ? Math.abs(100 * (roi - center) / center) : 0;
+          return roi && center ? Math.abs((100 * (roi - center)) / center) : 0;
         });
         return { uniformidades, max: Math.max(...uniformidades) };
       };
       const ac = calcOrientation("ac");
       const ca = calcOrientation("ca");
       const maxGlobal =
-        ac.max !== null && ca.max !== null
-          ? Math.max(ac.max, ca.max)
-          : ac.max ?? ca.max;
+        ac.max !== null && ca.max !== null ? Math.max(ac.max, ca.max) : (ac.max ?? ca.max);
       return { det, ac, ca, maxGlobal };
     });
   }, [data?.uniformidadDet]);
@@ -474,8 +504,13 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
           ═══════════════════════════════════════════ */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Prueba 2.3" title="Sistema de colimacion y perpendicularidad" icon={Target}>
-            Coincidencia del campo luminoso con el campo de radiacion. Tolerancia: &lt; 2% por lado, &lt; 4% total.
+          <StepHeader
+            step="Prueba 2.3"
+            title="Sistema de colimacion y perpendicularidad"
+            icon={Target}
+          >
+            Coincidencia del campo luminoso con el campo de radiacion. Tolerancia: &lt; 2% por lado,
+            &lt; 4% total.
           </StepHeader>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -496,9 +531,17 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
           <CollapsibleSection title="Tecnica y distancia">
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
               <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">SID (cm)</label>
-                <Input type="number" className="rounded-xl h-9 text-sm font-medium" defaultValue={colim?.sid_cm ?? 100}
-                  onBlur={(e) => updateColimacion({ sid_cm: e.target.value ? parseFloat(e.target.value) : 100 })} />
+                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                  SID (cm)
+                </label>
+                <Input
+                  type="number"
+                  className="rounded-xl h-9 text-sm font-medium"
+                  defaultValue={colim?.sid_cm ?? 100}
+                  onBlur={(e) =>
+                    updateColimacion({ sid_cm: e.target.value ? parseFloat(e.target.value) : 100 })
+                  }
+                />
               </div>
               {[
                 ["tecnica_kv", "kVp", "75"],
@@ -506,11 +549,23 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                 ["tecnica_mas", "mAs", ""],
               ].map(([field, label, ph]) => (
                 <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">{label}</label>
-                  <Input type="number" step="0.01" className="rounded-xl h-9 text-sm font-medium"
-                    defaultValue={(colim as Record<string, unknown> | undefined)?.[field] as string ?? ""}
+                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                    {label}
+                  </label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    className="rounded-xl h-9 text-sm font-medium"
+                    defaultValue={
+                      ((colim as Record<string, unknown> | undefined)?.[field] as string) ?? ""
+                    }
                     placeholder={ph}
-                    onBlur={(e) => updateColimacion({ [field]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                    onBlur={(e) =>
+                      updateColimacion({
+                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                      })
+                    }
+                  />
                 </div>
               ))}
             </div>
@@ -523,18 +578,50 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                 <div key={d.key} className="grid grid-cols-3 gap-2 items-end">
                   <div className="text-xs font-black text-primary">{d.label}</div>
                   <div className="space-y-1">
-                    <label className="text-[9px] font-black text-slate-400 uppercase">Nominal (cm)</label>
-                    <Input type="number" step="0.1" className="rounded-lg h-8 text-xs font-medium"
-                      defaultValue={(colim as Record<string, unknown> | undefined)?.[`${d.key}_nominal`] as string ?? ""}
+                    <label className="text-[9px] font-black text-slate-400 uppercase">
+                      Nominal (cm)
+                    </label>
+                    <Input
+                      type="number"
+                      step="0.1"
+                      className="rounded-lg h-8 text-xs font-medium"
+                      defaultValue={
+                        ((colim as Record<string, unknown> | undefined)?.[
+                          `${d.key}_nominal`
+                        ] as string) ?? ""
+                      }
                       placeholder="—"
-                      onBlur={(e) => updateColimacion({ [`${d.key}_nominal`]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                      onBlur={(e) =>
+                        updateColimacion({
+                          [`${d.key}_nominal`]: e.target.value
+                            ? parseFloat(e.target.value)
+                            : undefined,
+                        })
+                      }
+                    />
                   </div>
                   <div className="space-y-1">
-                    <label className="text-[9px] font-black text-slate-400 uppercase">Medido (cm)</label>
-                    <Input type="number" step="0.1" className="rounded-lg h-8 text-xs font-medium border-blue-200 bg-blue-50/50"
-                      defaultValue={(colim as Record<string, unknown> | undefined)?.[`${d.key}_medido`] as string ?? ""}
+                    <label className="text-[9px] font-black text-slate-400 uppercase">
+                      Medido (cm)
+                    </label>
+                    <Input
+                      type="number"
+                      step="0.1"
+                      className="rounded-lg h-8 text-xs font-medium border-blue-200 bg-blue-50/50"
+                      defaultValue={
+                        ((colim as Record<string, unknown> | undefined)?.[
+                          `${d.key}_medido`
+                        ] as string) ?? ""
+                      }
                       placeholder="—"
-                      onBlur={(e) => updateColimacion({ [`${d.key}_medido`]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                      onBlur={(e) =>
+                        updateColimacion({
+                          [`${d.key}_medido`]: e.target.value
+                            ? parseFloat(e.target.value)
+                            : undefined,
+                        })
+                      }
+                    />
                   </div>
                 </div>
               ))}
@@ -548,9 +635,16 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                 <table className="w-full text-xs">
                   <thead>
                     <tr className="border-b border-slate-200">
-                      {["Direccion", "Nominal", "Medido", "Dif (cm)", "Var %", "Tol", ""].map((h) => (
-                        <th key={h} className="text-[9px] font-black text-slate-400 uppercase text-left py-1.5 px-1.5">{h}</th>
-                      ))}
+                      {["Direccion", "Nominal", "Medido", "Dif (cm)", "Var %", "Tol", ""].map(
+                        (h) => (
+                          <th
+                            key={h}
+                            className="text-[9px] font-black text-slate-400 uppercase text-left py-1.5 px-1.5"
+                          >
+                            {h}
+                          </th>
+                        )
+                      )}
                     </tr>
                   </thead>
                   <tbody>
@@ -560,16 +654,26 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                         <td className="py-1.5 px-1.5 font-mono">{d.nominal || "—"}</td>
                         <td className="py-1.5 px-1.5 font-mono">{d.medido || "—"}</td>
                         <td className="py-1.5 px-1.5 font-mono">{d.diff.toFixed(1)}</td>
-                        <td className="py-1.5 px-1.5 font-mono font-bold">{d.varPct.toFixed(1)}%</td>
+                        <td className="py-1.5 px-1.5 font-mono font-bold">
+                          {d.varPct.toFixed(1)}%
+                        </td>
                         <td className="py-1.5 px-1.5 text-slate-400">&lt; 2%</td>
-                        <td className="py-1.5 px-1.5"><ConceptoBadge concepto={d.concepto} /></td>
+                        <td className="py-1.5 px-1.5">
+                          <ConceptoBadge concepto={d.concepto} />
+                        </td>
                       </tr>
                     ))}
                     <tr className="border-t-2 border-slate-200">
-                      <td className="py-1.5 px-1.5 font-black text-slate-700" colSpan={4}>Total</td>
-                      <td className="py-1.5 px-1.5 font-mono font-black">{colimacionResults.totalVar.toFixed(1)}%</td>
+                      <td className="py-1.5 px-1.5 font-black text-slate-700" colSpan={4}>
+                        Total
+                      </td>
+                      <td className="py-1.5 px-1.5 font-mono font-black">
+                        {colimacionResults.totalVar.toFixed(1)}%
+                      </td>
                       <td className="py-1.5 px-1.5 text-slate-400">&lt; 4%</td>
-                      <td className="py-1.5 px-1.5"><ConceptoBadge concepto={colimacionResults.conceptoTotal} /></td>
+                      <td className="py-1.5 px-1.5">
+                        <ConceptoBadge concepto={colimacionResults.conceptoTotal} />
+                      </td>
                     </tr>
                   </tbody>
                 </table>
@@ -587,12 +691,16 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
             >
               <option value="">Seleccionar posicion</option>
               {POSICIONES_ESFERA.map((p) => (
-                <option key={p.value} value={p.value}>{p.label}</option>
+                <option key={p.value} value={p.value}>
+                  {p.label}
+                </option>
               ))}
             </select>
             {colimacionResults?.perpConcepto && (
               <div className="flex items-center justify-between mt-2">
-                <span className="text-xs font-medium text-slate-600">Concepto perpendicularidad</span>
+                <span className="text-xs font-medium text-slate-600">
+                  Concepto perpendicularidad
+                </span>
                 <ConceptoBadge concepto={colimacionResults.perpConcepto} />
               </div>
             )}
@@ -605,7 +713,11 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
           ═══════════════════════════════════════════ */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Prueba 2.11" title="Uniformidad y artefactos del detector" icon={Target}>
+          <StepHeader
+            step="Prueba 2.11"
+            title="Uniformidad y artefactos del detector"
+            icon={Target}
+          >
             Analisis de ROIs en imagenes DICOM a 0° y 180°. Se repite por cada chasis CR o DR.
           </StepHeader>
 
@@ -614,30 +726,60 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
           <Alert>Poner filtro de cobre a la salida del tubo. Colimar para cubrir el cobre.</Alert>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <ImageSlot label="Imagen DICOM 0°" evidencia={getEvidencia("2.11", "dicom_0")}
-              onCapture={(f) => captureImage("2.11", "dicom_0", f)} onRemove={() => removeImage("2.11", "dicom_0")} />
-            <ImageSlot label="Imagen DICOM 180°" evidencia={getEvidencia("2.11", "dicom_180")}
-              onCapture={(f) => captureImage("2.11", "dicom_180", f)} onRemove={() => removeImage("2.11", "dicom_180")} />
+            <ImageSlot
+              label="Imagen DICOM 0°"
+              evidencia={getEvidencia("2.11", "dicom_0")}
+              onCapture={(f) => captureImage("2.11", "dicom_0", f)}
+              onRemove={() => removeImage("2.11", "dicom_0")}
+            />
+            <ImageSlot
+              label="Imagen DICOM 180°"
+              evidencia={getEvidencia("2.11", "dicom_180")}
+              onCapture={(f) => captureImage("2.11", "dicom_180", f)}
+              onRemove={() => removeImage("2.11", "dicom_180")}
+            />
           </div>
 
           {uniformidadResults.map((ur, idx) => (
-            <CollapsibleSection key={ur.det.id} title={`Detector ${idx + 1}${ur.det.serie_detector ? ` — ${ur.det.serie_detector}` : ""}`}>
+            <CollapsibleSection
+              key={ur.det.id}
+              title={`Detector ${idx + 1}${ur.det.serie_detector ? ` — ${ur.det.serie_detector}` : ""}`}
+            >
               <div className="space-y-3">
-                <Input className="rounded-xl h-8 text-xs font-medium" placeholder="Serie del detector"
+                <Input
+                  className="rounded-xl h-8 text-xs font-medium"
+                  placeholder="Serie del detector"
                   defaultValue={ur.det.serie_detector ?? ""}
-                  onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { serie_detector: e.target.value || undefined })} />
+                  onBlur={(e) =>
+                    ur.det.id &&
+                    updateUniformidadDet(ur.det.id, { serie_detector: e.target.value || undefined })
+                  }
+                />
 
                 {/* Tolerancia */}
                 <div className="flex items-center gap-2">
-                  <label className="text-[10px] font-black text-slate-400 uppercase whitespace-nowrap">Tolerancia (%)</label>
-                  <Input type="number" step="1" className="rounded-lg h-7 text-xs font-medium w-20"
+                  <label className="text-[10px] font-black text-slate-400 uppercase whitespace-nowrap">
+                    Tolerancia (%)
+                  </label>
+                  <Input
+                    type="number"
+                    step="1"
+                    className="rounded-lg h-7 text-xs font-medium w-20"
                     defaultValue={ur.det.tolerancia_pct ?? 15}
-                    onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { tolerancia_pct: e.target.value ? parseFloat(e.target.value) : 15 })} />
+                    onBlur={(e) =>
+                      ur.det.id &&
+                      updateUniformidadDet(ur.det.id, {
+                        tolerancia_pct: e.target.value ? parseFloat(e.target.value) : 15,
+                      })
+                    }
+                  />
                 </div>
 
                 {(["ac", "ca"] as const).map((orient) => (
                   <div key={orient} className="space-y-2">
-                    <p className="text-[10px] font-black text-slate-500 uppercase">{orient === "ac" ? "0° (Anodo-Catodo)" : "180° (Catodo-Anodo)"}</p>
+                    <p className="text-[10px] font-black text-slate-500 uppercase">
+                      {orient === "ac" ? "0° (Anodo-Catodo)" : "180° (Catodo-Anodo)"}
+                    </p>
                     <div className="grid grid-cols-5 gap-2">
                       {[0, 1, 2, 3, 4].map((i) => {
                         const vmpField = `roi_${i}_vmp_${orient}` as keyof typeof ur.det;
@@ -647,21 +789,46 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                             <label className="text-[9px] font-black text-slate-400 uppercase">
                               {i === 0 ? "ROIc" : `ROI${i}`}
                             </label>
-                            <Input type="number" step="0.1" className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50"
-                              defaultValue={ur.det[vmpField] as number ?? ""}
+                            <Input
+                              type="number"
+                              step="0.1"
+                              className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50"
+                              defaultValue={(ur.det[vmpField] as number) ?? ""}
                               placeholder="VMP"
-                              onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { [vmpField]: e.target.value ? parseFloat(e.target.value) : undefined })} />
-                            <Input type="number" step="0.1" className="rounded-lg h-7 text-xs font-medium border-slate-200"
-                              defaultValue={ur.det[desvField] as number ?? ""}
+                              onBlur={(e) =>
+                                ur.det.id &&
+                                updateUniformidadDet(ur.det.id, {
+                                  [vmpField]: e.target.value
+                                    ? parseFloat(e.target.value)
+                                    : undefined,
+                                })
+                              }
+                            />
+                            <Input
+                              type="number"
+                              step="0.1"
+                              className="rounded-lg h-7 text-xs font-medium border-slate-200"
+                              defaultValue={(ur.det[desvField] as number) ?? ""}
                               placeholder="Desv."
-                              onBlur={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { [desvField]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                              onBlur={(e) =>
+                                ur.det.id &&
+                                updateUniformidadDet(ur.det.id, {
+                                  [desvField]: e.target.value
+                                    ? parseFloat(e.target.value)
+                                    : undefined,
+                                })
+                              }
+                            />
                           </div>
                         );
                       })}
                     </div>
                     {(orient === "ac" ? ur.ac : ur.ca).max !== null && (
                       <p className="text-[10px] text-slate-500">
-                        Uniformidad max: <span className="font-black text-slate-800">{(orient === "ac" ? ur.ac : ur.ca).max?.toFixed(1)}%</span>
+                        Uniformidad max:{" "}
+                        <span className="font-black text-slate-800">
+                          {(orient === "ac" ? ur.ac : ur.ca).max?.toFixed(1)}%
+                        </span>
                       </p>
                     )}
                   </div>
@@ -670,45 +837,77 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                 {/* Artefactos */}
                 <div className="grid grid-cols-2 gap-3">
                   <div className="flex items-center gap-2">
-                    <input type="checkbox" className="rounded" checked={ur.det.pixeles_defectuosos ?? false}
-                      onChange={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { pixeles_defectuosos: e.target.checked })} />
+                    <input
+                      type="checkbox"
+                      className="rounded"
+                      checked={ur.det.pixeles_defectuosos ?? false}
+                      onChange={(e) =>
+                        ur.det.id &&
+                        updateUniformidadDet(ur.det.id, { pixeles_defectuosos: e.target.checked })
+                      }
+                    />
                     <span className="text-xs text-slate-600">Pixeles defectuosos</span>
                   </div>
                   <div className="flex items-center gap-2">
-                    <input type="checkbox" className="rounded" checked={ur.det.artefactos ?? false}
-                      onChange={(e) => ur.det.id && updateUniformidadDet(ur.det.id, { artefactos: e.target.checked })} />
+                    <input
+                      type="checkbox"
+                      className="rounded"
+                      checked={ur.det.artefactos ?? false}
+                      onChange={(e) =>
+                        ur.det.id &&
+                        updateUniformidadDet(ur.det.id, { artefactos: e.target.checked })
+                      }
+                    />
                     <span className="text-xs text-slate-600">Artefactos visibles</span>
                   </div>
                 </div>
 
-                {ur.maxGlobal !== null && (() => {
-                  const tolerancia = ur.det.tolerancia_pct ?? 15;
-                  const conforme = ur.maxGlobal <= tolerancia && !ur.det.pixeles_defectuosos && !ur.det.artefactos;
-                  return (
-                    <div className={`flex items-center justify-between p-2 rounded-lg ${conforme ? "bg-green-50" : "bg-red-50"}`}>
-                      <div className="flex flex-col gap-0.5">
-                        <span className="text-xs font-bold text-slate-700">Uniformidad max global</span>
-                        <span className={`text-[10px] font-black ${conforme ? "text-green-700" : "text-red-600"}`}>
-                          {conforme ? "FAVORABLE" : "NO FAVORABLE"}
+                {ur.maxGlobal !== null &&
+                  (() => {
+                    const tolerancia = ur.det.tolerancia_pct ?? 15;
+                    const conforme =
+                      ur.maxGlobal <= tolerancia &&
+                      !ur.det.pixeles_defectuosos &&
+                      !ur.det.artefactos;
+                    return (
+                      <div
+                        className={`flex items-center justify-between p-2 rounded-lg ${conforme ? "bg-green-50" : "bg-red-50"}`}
+                      >
+                        <div className="flex flex-col gap-0.5">
+                          <span className="text-xs font-bold text-slate-700">
+                            Uniformidad max global
+                          </span>
+                          <span
+                            className={`text-[10px] font-black ${conforme ? "text-green-700" : "text-red-600"}`}
+                          >
+                            {conforme ? "FAVORABLE" : "NO FAVORABLE"}
+                          </span>
+                        </div>
+                        <span
+                          className={`text-xs font-black ${conforme ? "text-green-700" : "text-red-600"}`}
+                        >
+                          {ur.maxGlobal.toFixed(1)}%
                         </span>
                       </div>
-                      <span className={`text-xs font-black ${conforme ? "text-green-700" : "text-red-600"}`}>
-                        {ur.maxGlobal.toFixed(1)}%
-                      </span>
-                    </div>
-                  );
-                })()}
+                    );
+                  })()}
 
-                <button type="button" onClick={() => ur.det.id && removeUniformidadDet(ur.det.id)}
-                  className="text-xs text-red-400 hover:text-red-600 font-bold">
+                <button
+                  type="button"
+                  onClick={() => ur.det.id && removeUniformidadDet(ur.det.id)}
+                  className="text-xs text-red-400 hover:text-red-600 font-bold"
+                >
                   Eliminar detector
                 </button>
               </div>
             </CollapsibleSection>
           ))}
 
-          <Button variant="outline" className="w-full rounded-xl border-dashed border-2 h-10 font-bold text-sm"
-            onClick={addUniformidadDet}>
+          <Button
+            variant="outline"
+            className="w-full rounded-xl border-dashed border-2 h-10 font-bold text-sm"
+            onClick={addUniformidadDet}
+          >
             <Plus className="w-4 h-4 mr-2" /> Agregar detector / chasis
           </Button>
         </CardContent>
@@ -719,64 +918,123 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
           ═══════════════════════════════════════════ */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Prueba 2.12" title="Resolucion espacial de alto contraste" icon={Target}>
+          <StepHeader
+            step="Prueba 2.12"
+            title="Resolucion espacial de alto contraste"
+            icon={Target}
+          >
             Identifica el grupo de barras mas fino visible en el patron de resolucion.
           </StepHeader>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <ImageSlot label="Foto montaje experimental" evidencia={getEvidencia("2.12", "montaje_resolucion")}
-              onCapture={(f) => captureImage("2.12", "montaje_resolucion", f)} onRemove={() => removeImage("2.12", "montaje_resolucion")} />
-            <ImageSlot label="Radiografía del patrón de resolución" evidencia={getEvidencia("2.12", "dicom_resolucion")}
-              onCapture={(f) => captureImage("2.12", "dicom_resolucion", f)} onRemove={() => removeImage("2.12", "dicom_resolucion")} />
+            <ImageSlot
+              label="Foto montaje experimental"
+              evidencia={getEvidencia("2.12", "montaje_resolucion")}
+              onCapture={(f) => captureImage("2.12", "montaje_resolucion", f)}
+              onRemove={() => removeImage("2.12", "montaje_resolucion")}
+            />
+            <ImageSlot
+              label="Radiografía del patrón de resolución"
+              evidencia={getEvidencia("2.12", "dicom_resolucion")}
+              onCapture={(f) => captureImage("2.12", "dicom_resolucion", f)}
+              onRemove={() => removeImage("2.12", "dicom_resolucion")}
+            />
           </div>
 
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">SID (cm)</label>
-              <Input type="number" className="rounded-xl h-9 text-sm font-medium" defaultValue={resol?.sid_cm ?? 100}
-                onBlur={(e) => updateResolucion({ sid_cm: e.target.value ? parseFloat(e.target.value) : 100 })} />
+              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                SID (cm)
+              </label>
+              <Input
+                type="number"
+                className="rounded-xl h-9 text-sm font-medium"
+                defaultValue={resol?.sid_cm ?? 100}
+                onBlur={(e) =>
+                  updateResolucion({ sid_cm: e.target.value ? parseFloat(e.target.value) : 100 })
+                }
+              />
             </div>
             <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">kVp</label>
-              <Input type="number" className="rounded-xl h-9 text-sm font-medium" defaultValue={resol?.tecnica_kv ?? 75}
-                onBlur={(e) => updateResolucion({ tecnica_kv: e.target.value ? parseFloat(e.target.value) : undefined })} />
+              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                kVp
+              </label>
+              <Input
+                type="number"
+                className="rounded-xl h-9 text-sm font-medium"
+                defaultValue={resol?.tecnica_kv ?? 75}
+                onBlur={(e) =>
+                  updateResolucion({
+                    tecnica_kv: e.target.value ? parseFloat(e.target.value) : undefined,
+                  })
+                }
+              />
             </div>
             <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">mAs</label>
-              <Input type="number" className="rounded-xl h-9 text-sm font-medium" defaultValue={resol?.tecnica_mas ?? ""}
-                onBlur={(e) => updateResolucion({ tecnica_mas: e.target.value ? parseFloat(e.target.value) : undefined })} />
+              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                mAs
+              </label>
+              <Input
+                type="number"
+                className="rounded-xl h-9 text-sm font-medium"
+                defaultValue={resol?.tecnica_mas ?? ""}
+                onBlur={(e) =>
+                  updateResolucion({
+                    tecnica_mas: e.target.value ? parseFloat(e.target.value) : undefined,
+                  })
+                }
+              />
             </div>
           </div>
 
           <div className="space-y-1">
-            <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">pl/mm visibles</label>
+            <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+              pl/mm visibles
+            </label>
             <select
               className="w-full rounded-xl h-9 text-sm font-black border border-blue-200 bg-blue-50/50 px-3 focus:outline-none focus:ring-2 focus:ring-primary"
               value={resol?.pares_lineas_plmm ?? ""}
-              onChange={(e) => updateResolucion({ pares_lineas_plmm: e.target.value ? parseFloat(e.target.value) : undefined })}>
+              onChange={(e) =>
+                updateResolucion({
+                  pares_lineas_plmm: e.target.value ? parseFloat(e.target.value) : undefined,
+                })
+              }
+            >
               <option value="">— Seleccionar —</option>
-              {[5.0, 4.6, 4.3, 4.0, 3.9, 3.7, 3.4, 3.1, 2.8, 2.5, 2.4, 2.3, 2.0, 1.8, 1.6, 1.4, 1.2, 1.0, 0.9, 0.8, 0.7, 0.6].map((v) => (
-                <option key={v} value={v}>{v.toFixed(1)} pl/mm</option>
+              {[
+                5.0, 4.6, 4.3, 4.0, 3.9, 3.7, 3.4, 3.1, 2.8, 2.5, 2.4, 2.3, 2.0, 1.8, 1.6, 1.4, 1.2,
+                1.0, 0.9, 0.8, 0.7, 0.6,
+              ].map((v) => (
+                <option key={v} value={v}>
+                  {v.toFixed(1)} pl/mm
+                </option>
               ))}
             </select>
           </div>
 
-          {resol?.pares_lineas_plmm != null && (() => {
-            const conforme = resol.pares_lineas_plmm >= 2.4;
-            return (
-              <div className={`flex items-center justify-between p-2 rounded-lg ${conforme ? "bg-green-50" : "bg-red-50"}`}>
-                <div className="flex flex-col gap-0.5">
-                  <span className="text-xs font-bold text-slate-700">Resolución espacial</span>
-                  <span className={`text-[10px] font-black ${conforme ? "text-green-700" : "text-red-600"}`}>
-                    {conforme ? "FAVORABLE" : "NO FAVORABLE"}
+          {resol?.pares_lineas_plmm != null &&
+            (() => {
+              const conforme = resol.pares_lineas_plmm >= 2.4;
+              return (
+                <div
+                  className={`flex items-center justify-between p-2 rounded-lg ${conforme ? "bg-green-50" : "bg-red-50"}`}
+                >
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-xs font-bold text-slate-700">Resolución espacial</span>
+                    <span
+                      className={`text-[10px] font-black ${conforme ? "text-green-700" : "text-red-600"}`}
+                    >
+                      {conforme ? "FAVORABLE" : "NO FAVORABLE"}
+                    </span>
+                  </div>
+                  <span
+                    className={`text-xs font-black ${conforme ? "text-green-700" : "text-red-600"}`}
+                  >
+                    {resol.pares_lineas_plmm.toFixed(1)} pl/mm
                   </span>
                 </div>
-                <span className={`text-xs font-black ${conforme ? "text-green-700" : "text-red-600"}`}>
-                  {resol.pares_lineas_plmm.toFixed(1)} pl/mm
-                </span>
-              </div>
-            );
-          })()}
+              );
+            })()}
         </CardContent>
       </Card>
 
@@ -785,12 +1043,20 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
           ═══════════════════════════════════════════ */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Prueba 2.13" title="Umbral de sensibilidad a bajo contraste" icon={Target}>
+          <StepHeader
+            step="Prueba 2.13"
+            title="Umbral de sensibilidad a bajo contraste"
+            icon={Target}
+          >
             Marca los niveles de contraste visibles en la imagen del phantom.
           </StepHeader>
 
-          <ImageSlot label="Montaje patron bajo contraste" evidencia={getEvidencia("2.13", "montaje_bajo_contraste")}
-            onCapture={(f) => captureImage("2.13", "montaje_bajo_contraste", f)} onRemove={() => removeImage("2.13", "montaje_bajo_contraste")} />
+          <ImageSlot
+            label="Montaje patron bajo contraste"
+            evidencia={getEvidencia("2.13", "montaje_bajo_contraste")}
+            onCapture={(f) => captureImage("2.13", "montaje_bajo_contraste", f)}
+            onRemove={() => removeImage("2.13", "montaje_bajo_contraste")}
+          />
 
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
             {NIVELES_CONTRASTE.map((nc) => {
@@ -820,14 +1086,22 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
           ═══════════════════════════════════════════ */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 space-y-5">
-          <StepHeader step="Prueba 2.16" title="Funcion de transferencia de modulacion (MTF)" icon={Target}>
+          <StepHeader
+            step="Prueba 2.16"
+            title="Funcion de transferencia de modulacion (MTF)"
+            icon={Target}
+          >
             Analisis MTF con ImageJ. Registra los valores MTF50 y MTF20 horizontal y vertical.
           </StepHeader>
 
           <Alert>Quitar el filtro de cobre para esta prueba.</Alert>
 
-          <ImageSlot label="Imagen DICOM para MTF" evidencia={getEvidencia("2.16", "dicom_mtf")}
-            onCapture={(f) => captureImage("2.16", "dicom_mtf", f)} onRemove={() => removeImage("2.16", "dicom_mtf")} />
+          <ImageSlot
+            label="Imagen DICOM para MTF"
+            evidencia={getEvidencia("2.16", "dicom_mtf")}
+            onCapture={(f) => captureImage("2.16", "dicom_mtf", f)}
+            onRemove={() => removeImage("2.16", "dicom_mtf")}
+          />
 
           <CollapsibleSection title="Tecnica y parametros">
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
@@ -838,11 +1112,23 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                 ["nyquist_lpmm", "Nyquist (lp/mm)", "3.33"],
               ].map(([field, label, ph]) => (
                 <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">{label}</label>
-                  <Input type="number" step="0.01" className="rounded-xl h-9 text-sm font-medium"
-                    defaultValue={(mtfData as Record<string, unknown> | undefined)?.[field] as string ?? ""}
+                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                    {label}
+                  </label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    className="rounded-xl h-9 text-sm font-medium"
+                    defaultValue={
+                      ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
+                    }
                     placeholder={ph}
-                    onBlur={(e) => updateMtf({ [field]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                    onBlur={(e) =>
+                      updateMtf({
+                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                      })
+                    }
+                  />
                 </div>
               ))}
             </div>
@@ -857,11 +1143,23 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                 ["mtf20_vertical", "MTF20 Vertical (lp/mm)"],
               ].map(([field, label]) => (
                 <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">{label}</label>
-                  <Input type="number" step="0.01" className="rounded-xl h-9 text-sm font-medium border-blue-200 bg-blue-50/50"
-                    defaultValue={(mtfData as Record<string, unknown> | undefined)?.[field] as string ?? ""}
+                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                    {label}
+                  </label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    className="rounded-xl h-9 text-sm font-medium border-blue-200 bg-blue-50/50"
+                    defaultValue={
+                      ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
+                    }
                     placeholder="—"
-                    onBlur={(e) => updateMtf({ [field]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                    onBlur={(e) =>
+                      updateMtf({
+                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                      })
+                    }
+                  />
                 </div>
               ))}
             </div>
@@ -877,11 +1175,23 @@ export default function GrupoEPage({ params }: { params: Promise<{ id: string }>
                 ["mtf20_base_vertical", "MTF20 Base Vert."],
               ].map(([field, label]) => (
                 <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">{label}</label>
-                  <Input type="number" step="0.01" className="rounded-xl h-9 text-sm font-medium"
-                    defaultValue={(mtfData as Record<string, unknown> | undefined)?.[field] as string ?? ""}
+                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                    {label}
+                  </label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    className="rounded-xl h-9 text-sm font-medium"
+                    defaultValue={
+                      ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
+                    }
                     placeholder="—"
-                    onBlur={(e) => updateMtf({ [field]: e.target.value ? parseFloat(e.target.value) : undefined })} />
+                    onBlur={(e) =>
+                      updateMtf({
+                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                      })
+                    }
+                  />
                 </div>
               ))}
             </div>

--- a/src/app/dashboard/visitas/[id]/pre-informe/page.tsx
+++ b/src/app/dashboard/visitas/[id]/pre-informe/page.tsx
@@ -72,7 +72,20 @@ function SeccionCard({
 }) {
   const Icon = GRUPO_ICONS[catalogo.grupo] ?? FileText;
   const analisisRef = useRef<HTMLTextAreaElement>(null);
+  const accionesRef = useRef<HTMLTextAreaElement>(null);
   const sinCriterio = !tieneCriterio(catalogo.codigo);
+
+  // Acciones correctivas con predeterminado editable — solo 2.1, 2.2 y 2.13
+  // (las demás pruebas usan el textarea libre, solo visible en No conforme).
+  const tieneAccionesPredeterminadas = Boolean(
+    catalogo.accionesConforme || catalogo.accionesNoConforme
+  );
+  const accionDefault =
+    conceptoEfectivo === "Conforme"
+      ? catalogo.accionesConforme
+      : conceptoEfectivo === "No_conforme"
+        ? catalogo.accionesNoConforme
+        : undefined;
 
   return (
     <div
@@ -150,19 +163,50 @@ function SeccionCard({
             </p>
           </div>
 
-          {/* Acciones correctivas */}
-          {conceptoEfectivo === "No_conforme" && (
+          {/* Acciones correctivas — 2.1/2.2/2.13 traen predeterminado editable
+              según el concepto (Conforme/No conforme); el resto usa texto
+              libre, solo visible cuando el concepto es No conforme. */}
+          {tieneAccionesPredeterminadas && accionDefault != null ? (
             <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                Acciones correctivas
-              </label>
+              <div className="flex items-center justify-between gap-2">
+                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                  Acciones correctivas
+                </label>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (accionesRef.current) accionesRef.current.value = accionDefault;
+                    onUpdateAcciones(accionDefault);
+                  }}
+                  className="inline-flex items-center gap-1 text-[10px] font-bold text-slate-400 hover:text-primary transition-colors"
+                >
+                  <RotateCcw className="w-3 h-3" />
+                  Restaurar predeterminado
+                </button>
+              </div>
               <textarea
+                ref={accionesRef}
+                key={`${seccion.id}-${conceptoEfectivo}`}
                 className="w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                defaultValue={seccion.acciones_correctivas ?? ""}
+                defaultValue={seccion.acciones_correctivas ?? accionDefault}
                 placeholder="Describa las acciones correctivas requeridas..."
                 onBlur={(e) => onUpdateAcciones(e.target.value)}
               />
             </div>
+          ) : (
+            conceptoEfectivo === "No_conforme" && (
+              <div className="space-y-1">
+                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                  Acciones correctivas
+                </label>
+                <textarea
+                  className="w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                  defaultValue={seccion.acciones_correctivas ?? ""}
+                  placeholder="Describa las acciones correctivas requeridas..."
+                  onBlur={(e) => onUpdateAcciones(e.target.value)}
+                />
+              </div>
+            )
           )}
 
           {/* Análisis — solo para secciones con texto de análisis (2.2).

--- a/src/lib/equipos/convencional/informe-secciones.ts
+++ b/src/lib/equipos/convencional/informe-secciones.ts
@@ -19,6 +19,10 @@ export interface SeccionInfoCatalogo {
   criterio: string;
   /** Texto por defecto del análisis (editable por el físico, p.ej. 2.2) */
   analisis?: string;
+  /** Acciones correctivas predeterminadas cuando el concepto es Conforme/Favorable (editable) */
+  accionesConforme?: string;
+  /** Acciones correctivas predeterminadas cuando el concepto es No conforme/No favorable (editable) */
+  accionesNoConforme?: string;
 }
 
 export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
@@ -35,6 +39,9 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
       "Se realizó el levantamiento radiométrico mediante mediciones de radiación dispersa en puntos representativos del área donde se encuentra instalado el equipo de radiología general. Las mediciones se efectuaron utilizando una cámara de ionización o un detector de estado sólido calibrado en términos de dosis equivalente ambiental H*(10), posicionando un simulador de dispersión en la ubicación habitual del paciente durante la exposición, aplicando la técnica máxima utilizada en la práctica clínica. Los puntos de medición evaluados se presentan en el diagrama radiométrico de la instalación.",
     criterio:
       "Área controlada (trabajadores): H*(10) <= 5 mSv/año. Área supervisada (público): H*(10) <= 0.5 mSv/año.",
+    accionesConforme: "No se requieren acciones correctivas.",
+    accionesNoConforme:
+      "Se recomienda evaluar las condiciones de blindaje de la instalación, revisar la carga de trabajo del equipo y adoptar las medidas de protección radiológica necesarias para garantizar el cumplimiento de los niveles de restricción de dosis establecidos. Una vez subsanada la condición identificada, se deberá repetir el estudio radiométrico para verificar el cumplimiento de los criterios establecidos.",
   },
   {
     codigo: "2.2",
@@ -51,6 +58,9 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
       "La inspección visual se considera aceptable cuando los componentes visibles del equipo y las condiciones de operación de la instalación se encuentran en buen estado físico, sin deterioros, fugas o defectos que puedan comprometer la protección radiológica del operador, los pacientes o el público.",
     analisis:
       "La inspección visual realizada al equipo de radiografía general y a las condiciones de operación de la instalación permitió verificar que los componentes visibles del sistema de rayos X se encuentran en adecuado estado físico, con el fin de identificar deterioros, fugas de aceite, daños mecánicos o anomalías en los cables de alimentación y control.\n\nAsimismo, se revisaron las condiciones de operación del equipo, la señalización de radioprotección y los elementos de seguridad presentes en la instalación para determinar si son consistentes con los requerimientos para la operación segura del equipo evaluado.",
+    accionesConforme: "No se requieren acciones correctivas.",
+    accionesNoConforme:
+      "Se recomienda corregir las condiciones no conformes identificadas durante la inspección visual y verificar nuevamente el cumplimiento de los criterios establecidos antes de continuar con la operación del equipo.",
   },
   {
     codigo: "2.3",
@@ -165,7 +175,8 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
     orden: 11,
     objetivo:
       "Evaluar e identificar la fuente de los artefactos visualizados en las imágenes radiográficas digitales. Verificar la uniformidad de la imagen.",
-    instrumentacion: "Detector de imagen CR o DR, lámina de cobre 1 mm Cu, software de procesamiento de imagen.",
+    instrumentacion:
+      "Detector de imagen CR o DR, lámina de cobre 1 mm Cu, software de procesamiento de imagen.",
     metodologia:
       "La evaluación de uniformidad del detector se realizó siguiendo el procedimiento descrito en el IAEA-TECDOC-1958, obteniendo imágenes uniformes del detector mediante la interposición de una lámina de cobre y registrando el valor medio de píxel en diferentes regiones de interés (ROI) distribuidas en la imagen. Adicionalmente, se realizó inspección visual para identificar la presencia de píxeles defectuosos o artefactos.",
     criterio:
@@ -196,13 +207,18 @@ export const CATALOGO_SECCIONES: SeccionInfoCatalogo[] = [
       "La prueba se realizó conforme al procedimiento descrito en el IAEA-TECDOC-1958, utilizando el módulo de bajo contraste del fantoma correspondiente. Se adquirió la imagen bajo condiciones representativas de operación y se evaluó visualmente la cantidad de detalles de bajo contraste visibles en la imagen.",
     criterio:
       "Debe observarse una cantidad mayor a tres masas o tener un porcentaje de contraste inferior a 4 %.",
+    accionesConforme:
+      "No se requieren acciones correctivas. Se recomienda continuar con el programa de control de calidad establecido.",
+    accionesNoConforme:
+      "Se deberá verificar el detector, el sistema de procesamiento de imagen y las condiciones de exposición, y repetir la prueba para confirmar el cumplimiento de los criterios establecidos.",
   },
   {
     codigo: "2.14",
     nombre: "Integridad y limpieza de cassettes y pantallas IP",
     grupo: "D",
     orden: 14,
-    objetivo: "Verificar la integridad, limpieza y la ausencia de otros defectos en los cassettes y pantallas de fósforo fotoestimulable (IP CR).",
+    objetivo:
+      "Verificar la integridad, limpieza y la ausencia de otros defectos en los cassettes y pantallas de fósforo fotoestimulable (IP CR).",
     instrumentacion: "Cassettes y paño antimotas.",
     metodologia:
       "La verificación de integridad y limpieza de los cassettes y pantallas IP se realizó siguiendo el procedimiento descrito en el IAEA-TECDOC-1958, mediante inspección visual de los cassettes y de las pantallas de fósforo fotoestimulable (IP).\n\nDurante la inspección se verificó la correcta identificación de las IP CR y de los cassettes, se examinaron posibles defectos externos, así como la presencia de polvo o rayaduras en las pantallas. En caso necesario, las pantallas se limpiaron siguiendo las recomendaciones del fabricante.",

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -917,12 +917,17 @@ export async function generarPreInforme(visitaId: string): Promise<Blob | null> 
           conceptoParrafo =
             "La inspección visual evidenció condiciones que requieren corrección, al identificarse elementos que no cumplen con los criterios de aceptación establecidos para el estado físico del equipo, las condiciones de operación o los elementos de protección radiológica.";
           accionesTexto =
+            seccion.acciones_correctivas?.trim() ||
+            cat?.accionesNoConforme ||
             "Se recomienda corregir las condiciones no conformes identificadas durante la inspección visual y verificar nuevamente el cumplimiento de los criterios establecidos antes de continuar con la operación del equipo.";
         } else {
           conceptoLabel = "FAVORABLE";
           conceptoParrafo =
             "La inspección visual evidenció que el estado físico del equipo, las condiciones de operación de la instalación y los elementos de protección radiológica cumplen con los criterios establecidos para la operación segura del equipo evaluado.";
-          accionesTexto = "No se requieren acciones correctivas.";
+          accionesTexto =
+            seccion.acciones_correctivas?.trim() ||
+            cat?.accionesConforme ||
+            "No se requieren acciones correctivas.";
         }
       } else if (esAuto21) {
         if (esPendiente) {
@@ -932,12 +937,17 @@ export async function generarPreInforme(visitaId: string): Promise<Blob | null> 
           conceptoParrafo =
             "Las dosis equivalentes anuales estimadas en algunas áreas evaluadas superan los niveles de restricción de dosis establecidos para áreas supervisadas, por lo que las condiciones radiológicas de la instalación requieren evaluación y adopción de medidas correctivas.";
           accionesTexto =
+            seccion.acciones_correctivas?.trim() ||
+            cat?.accionesNoConforme ||
             "Se recomienda evaluar las condiciones de blindaje de la instalación, revisar la carga de trabajo del equipo y adoptar las medidas de protección radiológica necesarias para garantizar el cumplimiento de los niveles de restricción de dosis establecidos. Una vez subsanada la condición identificada, se deberá repetir el estudio radiométrico para verificar el cumplimiento de los criterios establecidos.";
         } else {
           conceptoLabel = "FAVORABLE";
           conceptoParrafo =
             "Las dosis equivalentes anuales estimadas en las áreas evaluadas se encuentran por debajo de los niveles de restricción de dosis establecidos para áreas controladas y supervisadas, por lo que las condiciones radiológicas de la instalación se consideran aceptables para la operación del equipo evaluado.";
-          accionesTexto = "No se requieren acciones correctivas.";
+          accionesTexto =
+            seccion.acciones_correctivas?.trim() ||
+            cat?.accionesConforme ||
+            "No se requieren acciones correctivas.";
         }
       } else if (codigo === "2.4" && aplica) {
         if (esPendiente) {
@@ -1189,12 +1199,16 @@ export async function generarPreInforme(visitaId: string): Promise<Blob | null> 
           conceptoParrafo =
             "El sistema cuenta con el umbral de sensibilidad suficiente para el contexto de la práctica clínica.";
           accionesTexto =
+            seccion.acciones_correctivas?.trim() ||
+            cat?.accionesConforme ||
             "No se requieren acciones correctivas. Se recomienda continuar con el programa de control de calidad establecido.";
         } else {
           conceptoLabel = "NO FAVORABLE";
           conceptoParrafo =
             "El sistema no cuenta con el umbral de sensibilidad suficiente para el contexto de la práctica clínica.";
           accionesTexto =
+            seccion.acciones_correctivas?.trim() ||
+            cat?.accionesNoConforme ||
             "Se deberá verificar el detector, el sistema de procesamiento de imagen y las condiciones de exposición, y repetir la prueba para confirmar el cumplimiento de los criterios establecidos.";
         }
       } else if (codigo === "2.12" && aplica) {

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -154,29 +154,76 @@ async function cargarImagen(
   }
 }
 
+/**
+ * Deduplica filas con la misma clave natural, quedándose con la que tenga
+ * más información — protege el PDF contra inserts duplicados causados por
+ * la condición de carrera ya corregida en los efectos de inicialización de
+ * los formularios de captura (ver grupo-a..e/page.tsx).
+ */
+function dedupePorClave<T>(
+  rows: T[],
+  claveDe: (r: T) => string,
+  tieneDato: (r: T) => boolean
+): T[] {
+  const porClave = new Map<string, T>();
+  for (const r of rows) {
+    const k = claveDe(r);
+    const actual = porClave.get(k);
+    if (!actual || (!tieneDato(actual) && tieneDato(r))) porClave.set(k, r);
+  }
+  return [...porClave.values()];
+}
+
 export async function recopilarDatosConv(visitaId: string): Promise<DatosConvencional> {
-  const [secciones, setup, mediciones, inspeccion, elementos, resultadosArr, evidencias, colimacion, raysafeSetup, raysafeMediciones, ddiMediciones, uniformidadDetector, resolucion, bajoContraste, cassettes, uniformidadCr, mtf, caeSetup, caeMediciones] =
-    await Promise.all([
-      db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
-      db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
-      db.conv_mediciones.where("visita_id").equals(visitaId).sortBy("punto_numero"),
-      db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray(),
-      db.conv_elementos_proteccion.where("visita_id").equals(visitaId).toArray(),
-      db.conv_resultados_prueba.where("visita_id").equals(visitaId).toArray(),
-      db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
-      db.conv_colimacion.where("visita_id").equals(visitaId).first(),
-      db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
-      db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
-      db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
-      db.conv_uniformidad_detector.where("visita_id").equals(visitaId).sortBy("item_numero"),
-      db.conv_resolucion.where("visita_id").equals(visitaId).first(),
-      db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
-      db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).sortBy("item_numero"),
-      db.conv_uniformidad_cr.where("visita_id").equals(visitaId).sortBy("item_numero"),
-      db.conv_mtf.where("visita_id").equals(visitaId).first(),
-      db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
-      db.conv_cae_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
-    ]);
+  const [
+    secciones,
+    setup,
+    mediciones,
+    inspeccionRaw,
+    elementos,
+    resultadosArr,
+    evidencias,
+    colimacion,
+    raysafeSetup,
+    raysafeMediciones,
+    ddiMediciones,
+    uniformidadDetector,
+    resolucion,
+    bajoContraste,
+    cassettes,
+    uniformidadCr,
+    mtf,
+    caeSetup,
+    caeMediciones,
+  ] = await Promise.all([
+    db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
+    db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
+    db.conv_mediciones.where("visita_id").equals(visitaId).sortBy("punto_numero"),
+    db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray(),
+    db.conv_elementos_proteccion.where("visita_id").equals(visitaId).toArray(),
+    db.conv_resultados_prueba.where("visita_id").equals(visitaId).toArray(),
+    db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+    db.conv_colimacion.where("visita_id").equals(visitaId).first(),
+    db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
+    db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
+    db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
+    db.conv_uniformidad_detector.where("visita_id").equals(visitaId).sortBy("item_numero"),
+    db.conv_resolucion.where("visita_id").equals(visitaId).first(),
+    db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
+    db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).sortBy("item_numero"),
+    db.conv_uniformidad_cr.where("visita_id").equals(visitaId).sortBy("item_numero"),
+    db.conv_mtf.where("visita_id").equals(visitaId).first(),
+    db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
+    db.conv_cae_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
+  ]);
+
+  // Deduplica ítems de inspección con el mismo (sección, número) — ver
+  // dedupePorClave arriba. Se queda con la fila que tenga concepto evaluado.
+  const inspeccion = dedupePorClave(
+    inspeccionRaw,
+    (i) => `${i.seccion}-${i.item_numero}`,
+    (i) => Boolean(i.concepto)
+  );
 
   // Si el físico nunca abrió la página de pre-informe, usar el catálogo completo
   const seccionesEfectivas: ConvInformeSeccion[] =
@@ -217,8 +264,14 @@ export async function recopilarDatosConv(visitaId: string): Promise<DatosConvenc
 
   // Fotografías de la 2.3 (sección 2.3.7): montaje y patrón de colimación
   const SLOTS_FOTOS_23: [string, string][] = [
-    ["montaje_colimacion", "Fig. 2.3.1. Montaje experimental para la verificación del sistema de colimación"],
-    ["patron_colimacion", "Fig. 2.3.2. Imagen radiográfica del patrón de colimación con la posición del rayo central"],
+    [
+      "montaje_colimacion",
+      "Fig. 2.3.1. Montaje experimental para la verificación del sistema de colimación",
+    ],
+    [
+      "patron_colimacion",
+      "Fig. 2.3.2. Imagen radiográfica del patrón de colimación con la posición del rayo central",
+    ],
   ];
   const fotos23: NonNullable<DatosConvencional["fotos23"]> = [];
   for (const [slot, label] of SLOTS_FOTOS_23) {
@@ -231,26 +284,38 @@ export async function recopilarDatosConv(visitaId: string): Promise<DatosConvenc
   const ev24 = evidencias.find((e) => e.prueba_codigo === "2.4" && e.slot === "montaje_raysafe");
   const img24 = await cargarImagen(ev24);
   const fotos24: NonNullable<DatosConvencional["fotos24"]> = [];
-  if (img24) fotos24.push({ label: "Fig. Implementación de instrumentación en la prueba", ...img24 });
+  if (img24)
+    fotos24.push({ label: "Fig. Implementación de instrumentación en la prueba", ...img24 });
   const fotos25: NonNullable<DatosConvencional["fotos25"]> = [];
-  if (img24) fotos25.push({ label: "Fig 2.5.1. Implementación de instrumentación en la prueba", ...img24 });
+  if (img24)
+    fotos25.push({ label: "Fig 2.5.1. Implementación de instrumentación en la prueba", ...img24 });
   const fotos26: NonNullable<DatosConvencional["fotos26"]> = [];
-  if (img24) fotos26.push({ label: "Fig 2.6.1 Implementación de instrumentación en la prueba", ...img24 });
+  if (img24)
+    fotos26.push({ label: "Fig 2.6.1 Implementación de instrumentación en la prueba", ...img24 });
   const fotos27: NonNullable<DatosConvencional["fotos27"]> = [];
-  if (img24) fotos27.push({ label: "Fig 2.7.1 Implementación de instrumentación en la prueba", ...img24 });
+  if (img24)
+    fotos27.push({ label: "Fig 2.7.1 Implementación de instrumentación en la prueba", ...img24 });
   const fotos28: NonNullable<DatosConvencional["fotos28"]> = [];
-  if (img24) fotos28.push({ label: "Fig 2.1.8 Implementación de instrumentación en la prueba", ...img24 });
+  if (img24)
+    fotos28.push({ label: "Fig 2.1.8 Implementación de instrumentación en la prueba", ...img24 });
 
   // Fotografía de montaje DDI (secciones 2.9.7 y 2.10.7)
   const ev29 = evidencias.find((e) => e.prueba_codigo === "2.9" && e.slot === "montaje_ddi");
   const img29 = await cargarImagen(ev29);
   const fotos29: NonNullable<DatosConvencional["fotos29"]> = [];
-  if (img29) fotos29.push({ label: "Fig. 2.9.1 Montaje experimental para la prueba DDI/EI", ...img29 });
+  if (img29)
+    fotos29.push({ label: "Fig. 2.9.1 Montaje experimental para la prueba DDI/EI", ...img29 });
   const fotos210: NonNullable<DatosConvencional["fotos210"]> = [];
-  if (img29) fotos210.push({ label: "Fig. 2.10.1 Montaje experimental para la prueba de repetibilidad DDI/EI", ...img29 });
+  if (img29)
+    fotos210.push({
+      label: "Fig. 2.10.1 Montaje experimental para la prueba de repetibilidad DDI/EI",
+      ...img29,
+    });
 
   // Fotografía patrón bajo contraste para 2.13.7
-  const ev213 = evidencias.find((e) => e.prueba_codigo === "2.13" && e.slot === "montaje_bajo_contraste");
+  const ev213 = evidencias.find(
+    (e) => e.prueba_codigo === "2.13" && e.slot === "montaje_bajo_contraste"
+  );
   const img213 = await cargarImagen(ev213);
   const fotos213: NonNullable<DatosConvencional["fotos213"]> = [];
   if (img213) fotos213.push({ label: "Fig. 2.13.1 Patrón de bajo contraste", ...img213 });
@@ -277,7 +342,11 @@ export async function recopilarDatosConv(visitaId: string): Promise<DatosConvenc
   const ev217 = evidencias.find((e) => e.prueba_codigo === "2.17" && e.slot === "montaje_cae");
   const img217 = await cargarImagen(ev217);
   const fotos217: NonNullable<DatosConvencional["fotos217"]> = [];
-  if (img217) fotos217.push({ label: "Fig. 2.17.1 Montaje experimental para la prueba de sensibilidad del CAE", ...img217 });
+  if (img217)
+    fotos217.push({
+      label: "Fig. 2.17.1 Montaje experimental para la prueba de sensibilidad del CAE",
+      ...img217,
+    });
 
   // Fotografías DICOM para 2.11.7 (0° y 180°)
   const SLOTS_FOTOS_211: [string, string][] = [
@@ -732,7 +801,11 @@ export function renderFotos213(ctx: InformeCtx, conv: DatosConvencional) {
     const h = f.height * scale;
     ctx.checkPage(h + 16);
     const x = MARGIN + (CWIDTH - w) / 2;
-    try { doc.addImage(f.dataUrl, x, ctx.y, w, h); } catch { /* no renderizable */ }
+    try {
+      doc.addImage(f.dataUrl, x, ctx.y, w, h);
+    } catch {
+      /* no renderizable */
+    }
     doc.setFont("helvetica", "italic");
     doc.setFontSize(7);
     doc.setTextColor(...COLOR_GRAY);
@@ -764,7 +837,11 @@ export function renderFotos212(ctx: InformeCtx, conv: DatosConvencional) {
       const w = f.width * scale;
       const h = f.height * scale;
       const x = MARGIN + j * colW + (colW - w) / 2;
-      try { doc.addImage(f.dataUrl, x, ctx.y, w, h); } catch { /* no renderizable */ }
+      try {
+        doc.addImage(f.dataUrl, x, ctx.y, w, h);
+      } catch {
+        /* no renderizable */
+      }
       doc.setFont("helvetica", "italic");
       doc.setFontSize(7);
       doc.setTextColor(...COLOR_GRAY);
@@ -797,7 +874,11 @@ export function renderFotos211(ctx: InformeCtx, conv: DatosConvencional) {
       const w = f.width * scale;
       const h = f.height * scale;
       const x = MARGIN + j * colW + (colW - w) / 2;
-      try { doc.addImage(f.dataUrl, x, ctx.y, w, h); } catch { /* no renderizable */ }
+      try {
+        doc.addImage(f.dataUrl, x, ctx.y, w, h);
+      } catch {
+        /* no renderizable */
+      }
       doc.setFont("helvetica", "italic");
       doc.setFontSize(7);
       doc.setTextColor(...COLOR_GRAY);
@@ -1100,7 +1181,14 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
     ...TABLE_STYLE,
     startY: ctx.y,
     body: [
-      ["Tensión (kV)", fmt(c.tecnica_kv, 0), "Exposición (mAs)", fmt(c.tecnica_mas, 1), "Distancia foco-receptor, SID (cm)", fmt(c.sid_cm, 0)],
+      [
+        "Tensión (kV)",
+        fmt(c.tecnica_kv, 0),
+        "Exposición (mAs)",
+        fmt(c.tecnica_mas, 1),
+        "Distancia foco-receptor, SID (cm)",
+        fmt(c.sid_cm, 0),
+      ],
     ],
     columnStyles: {
       0: { cellWidth: 28, fontStyle: "bold", fillColor: COLOR_ALT_ROW },
@@ -1117,29 +1205,59 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
   const DIRS = [
     { label: "Ánodo (cabeza)", nom: c.anodo_nominal, med: c.anodo_medido },
     { label: "Cátodo (pies)", nom: c.catodo_nominal, med: c.catodo_medido },
-    { label: "Izquierda",     nom: c.izquierda_nominal, med: c.izquierda_medido },
-    { label: "Derecha",       nom: c.derecha_nominal,   med: c.derecha_medido },
+    { label: "Izquierda", nom: c.izquierda_nominal, med: c.izquierda_medido },
+    { label: "Derecha", nom: c.derecha_nominal, med: c.derecha_medido },
   ];
 
   const rows = DIRS.map(({ label, nom, med }) => {
     const diff = Math.abs(num(med) - num(nom));
     const varPct = (diff * 100) / sid;
     const concepto = varPct < 2 ? "Conforme" : "No conforme";
-    return [label, fmt(nom, 0), fmt(med, 0), diff.toFixed(1), varPct.toFixed(1) + " %", "< 2 %", concepto];
+    return [
+      label,
+      fmt(nom, 0),
+      fmt(med, 0),
+      diff.toFixed(1),
+      varPct.toFixed(1) + " %",
+      "< 2 %",
+      concepto,
+    ];
   });
 
   const totalVar = rows.reduce((s, r) => s + parseFloat(r[4]), 0);
-  const conceptoTotal = rows.every((r) => parseFloat(r[4]) < 2) && totalVar < 4 ? "Conforme" : "No conforme";
+  const conceptoTotal =
+    rows.every((r) => parseFloat(r[4]) < 2) && totalVar < 4 ? "Conforme" : "No conforme";
 
   ctx.checkPage(40);
-  addCaption(ctx, "Tabla 2.3.1. Registro de mediciones para la coincidencia del campo luminoso con el campo de radiación");
+  addCaption(
+    ctx,
+    "Tabla 2.3.1. Registro de mediciones para la coincidencia del campo luminoso con el campo de radiación"
+  );
   autoTable(doc, {
     ...TABLE_STYLE,
     startY: ctx.y,
-    head: [["Dirección", "Campo luminoso (cm)", "Campo de radiación (cm)", "Diferencia (cm)", "Variación (%)", "Tolerancia", "Concepto"]],
+    head: [
+      [
+        "Dirección",
+        "Campo luminoso (cm)",
+        "Campo de radiación (cm)",
+        "Diferencia (cm)",
+        "Variación (%)",
+        "Tolerancia",
+        "Concepto",
+      ],
+    ],
     body: [
       ...rows,
-      ["Total (suma de desviaciones opuestas)", "", "", "", totalVar.toFixed(1) + " %", "< 4 %", conceptoTotal],
+      [
+        "Total (suma de desviaciones opuestas)",
+        "",
+        "",
+        "",
+        totalVar.toFixed(1) + " %",
+        "< 4 %",
+        conceptoTotal,
+      ],
     ],
     columnStyles: { 0: { cellWidth: 36 }, 1: { cellWidth: 28 }, 2: { cellWidth: 28 } },
     didParseCell: colorearConcepto(6),
@@ -1148,7 +1266,7 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
 
   const esfera = c.posicion_esfera;
   const CRITERIO_ESFERA: Record<string, string> = {
-    "Centro": "Perpendicularidad del rayo central menor a 3°",
+    Centro: "Perpendicularidad del rayo central menor a 3°",
     "Primer circulo": "Perpendicularidad del rayo central menor a 3°",
     "Segundo circulo": "Perpendicularidad del rayo central menor a 3°",
     "Fuera del circulo externo": "Perpendicularidad del rayo central mayor a 3°",
@@ -1161,22 +1279,30 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
         : null;
 
   ctx.checkPage(28);
-  addCaption(ctx, "Tabla 2.3.2: Registro de mediciones para la perpendicularidad del campo de radiación");
+  addCaption(
+    ctx,
+    "Tabla 2.3.2: Registro de mediciones para la perpendicularidad del campo de radiación"
+  );
   autoTable(doc, {
     ...TABLE_STYLE,
     startY: ctx.y,
     head: [["Campo", "Valor"]],
     body: [
       ["Posición observada de la esfera", esfera ?? "—"],
-      ["Criterio de interpretación", esfera ? CRITERIO_ESFERA[esfera] ?? "—" : "—"],
+      ["Criterio de interpretación", esfera ? (CRITERIO_ESFERA[esfera] ?? "—") : "—"],
       ["Concepto", perpConcepto ?? "—"],
     ],
     columnStyles: { 0: { cellWidth: 70, fontStyle: "bold", fillColor: COLOR_ALT_ROW } },
     didParseCell: (data) => {
       if (data.section === "body" && data.row.index === 2 && data.column.index === 1) {
         const val = String(data.cell.raw);
-        if (val === "Conforme") { data.cell.styles.textColor = [16, 150, 80]; data.cell.styles.fontStyle = "bold"; }
-        else if (val === "No conforme") { data.cell.styles.textColor = [220, 50, 50]; data.cell.styles.fontStyle = "bold"; }
+        if (val === "Conforme") {
+          data.cell.styles.textColor = [16, 150, 80];
+          data.cell.styles.fontStyle = "bold";
+        } else if (val === "No conforme") {
+          data.cell.styles.textColor = [220, 50, 50];
+          data.cell.styles.fontStyle = "bold";
+        }
       }
     },
   });
@@ -1188,14 +1314,12 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
   const totalVarStr = totalVar.toFixed(0);
   let analisisTexto: string;
   if (conceptoTotal === "Conforme" && perpConcepto === "Conforme") {
-    analisisTexto =
-      `Los resultados obtenidos evidencian que la coincidencia entre el campo luminoso y el campo de radiación cumple con los criterios de aceptación establecidos, ya que las desviaciones individuales fueron inferiores al 2 % y la desviación total fue de ${totalVarStr} %. Adicionalmente, la perpendicularidad del rayo central presentó una desviación angular menor o igual a 3°, por lo que la prueba se considera conforme.`;
+    analisisTexto = `Los resultados obtenidos evidencian que la coincidencia entre el campo luminoso y el campo de radiación cumple con los criterios de aceptación establecidos, ya que las desviaciones individuales fueron inferiores al 2 % y la desviación total fue de ${totalVarStr} %. Adicionalmente, la perpendicularidad del rayo central presentó una desviación angular menor o igual a 3°, por lo que la prueba se considera conforme.`;
   } else if (conceptoTotal === "No conforme" && perpConcepto === "Conforme") {
     analisisTexto =
       "Los resultados obtenidos evidencian incumplimiento en la coincidencia entre el campo luminoso y el campo de radiación, debido a que una o más desviaciones superaron las tolerancias establecidas. No obstante, la perpendicularidad del rayo central presentó una desviación angular menor o igual a 3°. Por lo anterior, la prueba se considera no conforme.";
   } else if (conceptoTotal === "Conforme" && perpConcepto === "No conforme") {
-    analisisTexto =
-      `Los resultados obtenidos evidencian que la coincidencia entre el campo luminoso y el campo de radiación cumple con los criterios de aceptación establecidos, con una desviación total de ${totalVarStr} %. Sin embargo, la perpendicularidad del rayo central presentó una desviación angular superior a 3°, por lo que la prueba se considera no conforme.`;
+    analisisTexto = `Los resultados obtenidos evidencian que la coincidencia entre el campo luminoso y el campo de radiación cumple con los criterios de aceptación establecidos, con una desviación total de ${totalVarStr} %. Sin embargo, la perpendicularidad del rayo central presentó una desviación angular superior a 3°, por lo que la prueba se considera no conforme.`;
   } else {
     analisisTexto =
       "Los resultados obtenidos evidencian incumplimiento tanto en la coincidencia entre el campo luminoso y el campo de radiación como en la perpendicularidad del rayo central, por lo que la prueba se considera no conforme.";
@@ -1239,7 +1363,7 @@ const GRUPOS_TIEMPO_KV_CHR = new Set([1, 2, 6]);
 function render24(ctx: InformeCtx, conv: DatosConvencional): number {
   const { doc, autoTable } = ctx;
   const principales = conv.raysafeMediciones.filter(
-    (m) => m.tipo_medicion === "principal" && GRUPOS_TIEMPO_KV_CHR.has(m.grupo_numero ?? -1),
+    (m) => m.tipo_medicion === "principal" && GRUPOS_TIEMPO_KV_CHR.has(m.grupo_numero ?? -1)
   );
 
   ctx.addSubsectionTitle("2.4.4.", "Resultados");
@@ -1274,11 +1398,23 @@ function render24(ctx: InformeCtx, conv: DatosConvencional): number {
     });
 
   ctx.checkPage(40);
-  addCaption(ctx, "Tabla 2.4.1. Registro de mediciones para la exactitud y repetibilidad del tiempo de exposición");
+  addCaption(
+    ctx,
+    "Tabla 2.4.1. Registro de mediciones para la exactitud y repetibilidad del tiempo de exposición"
+  );
   autoTable(doc, {
     ...TABLE_STYLE,
     startY: ctx.y,
-    head: [["Tiempo nominal (s)", "Tiempo promedio medido (s)", "Desviación máxima (%)", "Desviación estándar (s)", "CV (%)", "Concepto"]],
+    head: [
+      [
+        "Tiempo nominal (s)",
+        "Tiempo promedio medido (s)",
+        "Desviación máxima (%)",
+        "Desviación estándar (s)",
+        "CV (%)",
+        "Concepto",
+      ],
+    ],
     body: rows,
     columnStyles: { 0: { cellWidth: 32 }, 5: { cellWidth: 24 } },
     didParseCell: colorearConcepto(5),
@@ -1286,10 +1422,10 @@ function render24(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.y = finalY(doc) + 4;
 
   ctx.addParagraph(
-    "La exactitud del tiempo de exposición se evaluó mediante la desviación máxima porcentual entre el tiempo nominal seleccionado y el tiempo medido con mayor desviación.",
+    "La exactitud del tiempo de exposición se evaluó mediante la desviación máxima porcentual entre el tiempo nominal seleccionado y el tiempo medido con mayor desviación."
   );
   ctx.addParagraph(
-    "La repetibilidad del sistema de temporización se evaluó mediante el coeficiente de variación (CV) calculado a partir de las mediciones repetidas para cada tiempo nominal.",
+    "La repetibilidad del sistema de temporización se evaluó mediante el coeficiente de variación (CV) calculado a partir de las mediciones repetidas para cada tiempo nominal."
   );
 
   ctx.addSubsectionTitle("2.4.5.", "Análisis");
@@ -1311,7 +1447,7 @@ function render24(ctx: InformeCtx, conv: DatosConvencional): number {
 function render25(ctx: InformeCtx, conv: DatosConvencional): number {
   const { doc, autoTable } = ctx;
   const principales = conv.raysafeMediciones.filter(
-    (m) => m.tipo_medicion === "principal" && GRUPOS_TIEMPO_KV_CHR.has(m.grupo_numero ?? -1),
+    (m) => m.tipo_medicion === "principal" && GRUPOS_TIEMPO_KV_CHR.has(m.grupo_numero ?? -1)
   );
 
   ctx.addSubsectionTitle("2.5.4.", "Resultados");
@@ -1346,11 +1482,23 @@ function render25(ctx: InformeCtx, conv: DatosConvencional): number {
     });
 
   ctx.checkPage(40);
-  addCaption(ctx, "Tabla 2.5.1. Registro de mediciones para la exactitud y repetibilidad de la tensión del tubo de rayos X");
+  addCaption(
+    ctx,
+    "Tabla 2.5.1. Registro de mediciones para la exactitud y repetibilidad de la tensión del tubo de rayos X"
+  );
   autoTable(doc, {
     ...TABLE_STYLE,
     startY: ctx.y,
-    head: [["Tensión nominal (kV)", "Tensión promedio medida (kV)", "Desviación máxima (%)", "Desviación estándar (kV)", "CV (%)", "Concepto"]],
+    head: [
+      [
+        "Tensión nominal (kV)",
+        "Tensión promedio medida (kV)",
+        "Desviación máxima (%)",
+        "Desviación estándar (kV)",
+        "CV (%)",
+        "Concepto",
+      ],
+    ],
     body: rows,
     columnStyles: { 0: { cellWidth: 32 }, 5: { cellWidth: 24 } },
     didParseCell: colorearConcepto(5),
@@ -1358,10 +1506,10 @@ function render25(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.y = finalY(doc) + 4;
 
   ctx.addParagraph(
-    "La exactitud de la tensión del tubo se evaluó mediante la desviación máxima porcentual entre la tensión nominal seleccionada y la tensión medida con mayor desviación.",
+    "La exactitud de la tensión del tubo se evaluó mediante la desviación máxima porcentual entre la tensión nominal seleccionada y la tensión medida con mayor desviación."
   );
   ctx.addParagraph(
-    "La repetibilidad del sistema de generación de alta tensión se evaluó mediante el coeficiente de variación (CV) calculado a partir de las mediciones repetidas para cada valor de tensión nominal.",
+    "La repetibilidad del sistema de generación de alta tensión se evaluó mediante el coeficiente de variación (CV) calculado a partir de las mediciones repetidas para cada valor de tensión nominal."
   );
 
   ctx.addSubsectionTitle("2.5.5.", "Análisis");
@@ -1383,7 +1531,7 @@ function render25(ctx: InformeCtx, conv: DatosConvencional): number {
 function render26(ctx: InformeCtx, conv: DatosConvencional): number {
   const { doc, autoTable } = ctx;
   const principales = conv.raysafeMediciones.filter(
-    (m) => m.tipo_medicion === "principal" && GRUPOS_TIEMPO_KV_CHR.has(m.grupo_numero ?? -1),
+    (m) => m.tipo_medicion === "principal" && GRUPOS_TIEMPO_KV_CHR.has(m.grupo_numero ?? -1)
   );
 
   ctx.addSubsectionTitle("2.6.4.", "Resultados");
@@ -1409,11 +1557,16 @@ function render26(ctx: InformeCtx, conv: DatosConvencional): number {
     });
 
   ctx.checkPage(36);
-  addCaption(ctx, "Tabla 2.6.1. Registro de mediciones para la capa hemirreductora del haz de rayos X");
+  addCaption(
+    ctx,
+    "Tabla 2.6.1. Registro de mediciones para la capa hemirreductora del haz de rayos X"
+  );
   autoTable(doc, {
     ...TABLE_STYLE,
     startY: ctx.y,
-    head: [["Tensión nominal (kV)", "CHR promedio medida (mm Al)", "CHR mínima (mm Al)", "Concepto"]],
+    head: [
+      ["Tensión nominal (kV)", "CHR promedio medida (mm Al)", "CHR mínima (mm Al)", "Concepto"],
+    ],
     body: rows,
     columnStyles: { 0: { cellWidth: 36 }, 3: { cellWidth: 28 } },
     didParseCell: colorearConcepto(3),
@@ -1421,7 +1574,7 @@ function render26(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.y = finalY(doc) + 4;
 
   ctx.addParagraph(
-    "Para la evaluación del cumplimiento se compararon los valores medidos con los valores mínimos de referencia de capa hemirreductora correspondientes a cada nivel de tensión.",
+    "Para la evaluación del cumplimiento se compararon los valores medidos con los valores mínimos de referencia de capa hemirreductora correspondientes a cada nivel de tensión."
   );
 
   ctx.addSubsectionTitle("2.6.5.", "Análisis");
@@ -1447,8 +1600,16 @@ export function renderTablaChrRef(ctx: InformeCtx) {
     ...TABLE_STYLE,
     startY: ctx.y,
     head: [["Tensión (kV)", "CHR mínima (mm Al)"]],
-    body: [["60", "1,8"], ["70", "2,1"], ["80", "2,3"], ["90", "2,5"]],
-    columnStyles: { 0: { halign: "center" as const, cellWidth: 45 }, 1: { halign: "center" as const, cellWidth: 45 } },
+    body: [
+      ["60", "1,8"],
+      ["70", "2,1"],
+      ["80", "2,3"],
+      ["90", "2,5"],
+    ],
+    columnStyles: {
+      0: { halign: "center" as const, cellWidth: 45 },
+      1: { halign: "center" as const, cellWidth: 45 },
+    },
     margin: { left: MARGIN + (170 - 90) / 2 },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
@@ -1482,7 +1643,7 @@ export function renderTablaBaseRef29(ctx: InformeCtx, conv: DatosConvencional) {
 function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const { doc, autoTable } = ctx;
   const shots80 = conv.raysafeMediciones.filter(
-    (m) => m.tipo_medicion === "principal" && m.kv_nominal === 80 && m.dosis_medida_mgy != null,
+    (m) => m.tipo_medicion === "principal" && m.kv_nominal === 80 && m.dosis_medida_mgy != null
   );
 
   ctx.addSubsectionTitle("2.7.4.", "Resultados");
@@ -1492,11 +1653,11 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
       `Tensión de referencia: 80 kVp\n` +
       `Distancia foco-detector: ${distancia} cm\n` +
       "Estimación del rendimiento: normalizado a 100 centímetros\n" +
-      "Factor de corrección por presión y temperatura del analizador: 1,0",
+      "Factor de corrección por presión y temperatura del analizador: 1,0"
   );
   ctx.addParagraph(
     "Las mediciones obtenidas se utilizaron para evaluar el valor del rendimiento del tubo de rayos X, " +
-      "la repetibilidad de la radiación de salida y la linealidad del rendimiento con respecto al mAs.",
+      "la repetibilidad de la radiación de salida y la linealidad del rendimiento con respecto al mAs."
   );
 
   if (shots80.length === 0) return SIN_DATOS(ctx);
@@ -1506,7 +1667,8 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const GRUPOS_LIN = new Set([2, 3, 4, 5]);
   const gruposNum = new Map<number, typeof shots80>();
   for (const m of shots80) {
-    if (m.grupo_numero == null || !GRUPOS_LIN.has(m.grupo_numero) || m.mas_nominal == null) continue;
+    if (m.grupo_numero == null || !GRUPOS_LIN.has(m.grupo_numero) || m.mas_nominal == null)
+      continue;
     if (!gruposNum.has(m.grupo_numero)) gruposNum.set(m.grupo_numero, []);
     gruposNum.get(m.grupo_numero)!.push(m);
   }
@@ -1548,7 +1710,12 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
       ...TABLE_STYLE,
       startY: ctx.y,
       head: [
-        ["Exposición nominal (mAs)", "Kerma en aire promedio (mGy)", "Rendimiento (µGy/mAs)", "Linealidad (%)"],
+        [
+          "Exposición nominal (mAs)",
+          "Kerma en aire promedio (mGy)",
+          "Rendimiento (µGy/mAs)",
+          "Linealidad (%)",
+        ],
       ],
       body: rowsLin,
       columnStyles: { 0: { cellWidth: 38 } },
@@ -1559,7 +1726,7 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.addParagraph(
     "El rendimiento del tubo se calculó como el cociente entre el kerma en aire medido y la carga " +
       "utilizada (mAs). La linealidad se evaluó mediante la comparación del rendimiento obtenido " +
-      "para los diferentes valores de carga.",
+      "para los diferentes valores de carga."
   );
 
   // ── Tabla 2.7.2: Repetibilidad (grupo 3 — 80kV/200mA/0.05s) ──
@@ -1583,11 +1750,14 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
 
   ctx.addParagraph(
     "La repetibilidad se evaluó a partir de exposiciones repetidas bajo las mismas condiciones " +
-      "de irradiación (80 kV y aproximadamente 10 mAs).",
+      "de irradiación (80 kV y aproximadamente 10 mAs)."
   );
 
   if (repShots.length > 0) {
-    const rowsIndiv: string[][] = repShots.map((m, i) => [String(i + 1), m.dosis_medida_mgy!.toFixed(4)]);
+    const rowsIndiv: string[][] = repShots.map((m, i) => [
+      String(i + 1),
+      m.dosis_medida_mgy!.toFixed(4),
+    ]);
 
     ctx.checkPage(40);
     addCaption(ctx, "Tabla 2.7.2. Repetibilidad de la radiación de salida");
@@ -1630,13 +1800,13 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
 
   if (conformeRep && conformeLin) {
     ctx.addParagraph(
-      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rMinStr} y ${rMaxStr} µGy/mAs para los diferentes valores de carga evaluados a 80 kV, lo que indica un comportamiento consistente del sistema de generación de radiación. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvStr} %, valor inferior al límite establecido. Asimismo, la linealidad del rendimiento con respecto al mAs presenta una desviación máxima de ${linStr} %, lo que indica un comportamiento proporcional entre la radiación de salida y la carga seleccionada. En conjunto, los resultados indican que el generador de rayos X presenta un comportamiento estable, reproducible y lineal bajo las condiciones de irradiación evaluadas.`,
+      `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rMinStr} y ${rMaxStr} µGy/mAs para los diferentes valores de carga evaluados a 80 kV, lo que indica un comportamiento consistente del sistema de generación de radiación. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvStr} %, valor inferior al límite establecido. Asimismo, la linealidad del rendimiento con respecto al mAs presenta una desviación máxima de ${linStr} %, lo que indica un comportamiento proporcional entre la radiación de salida y la carga seleccionada. En conjunto, los resultados indican que el generador de rayos X presenta un comportamiento estable, reproducible y lineal bajo las condiciones de irradiación evaluadas.`
     );
   } else {
     ctx.addParagraph(
       `Los resultados obtenidos evidencian que el rendimiento del tubo de rayos X presenta valores entre ${rMinStr} y ${rMaxStr} µGy/mAs para los diferentes valores de carga evaluados a 80 kV. La repetibilidad de la radiación de salida presenta un coeficiente de variación (CV) de ${cvStr} % y la linealidad del rendimiento con respecto al mAs presenta una desviación máxima de ${linStr} %.` +
         (!conformeRep ? ` La repetibilidad supera el criterio de aceptación del 5 %.` : "") +
-        (!conformeLin ? ` La linealidad supera el criterio de aceptación del 10 %.` : ""),
+        (!conformeLin ? ` La linealidad supera el criterio de aceptación del 10 %.` : "")
     );
   }
 
@@ -1689,7 +1859,15 @@ function render28(ctx: InformeCtx, conv: DatosConvencional): number {
   autoTable(doc, {
     ...TABLE_STYLE,
     startY: ctx.y,
-    head: [["Tensión (kV)", "Carga (mAs)", "DAP nominal (mGy·cm²)", "DAP estimado (mGy·cm²)", "Factor de corrección"]],
+    head: [
+      [
+        "Tensión (kV)",
+        "Carga (mAs)",
+        "DAP nominal (mGy·cm²)",
+        "DAP estimado (mGy·cm²)",
+        "Factor de corrección",
+      ],
+    ],
     body: rows.map((r) => [r.kv, r.mas, r.dapNom, r.dapEst, r.fc]),
     columnStyles: { 4: { cellWidth: 32 } },
   });
@@ -1699,7 +1877,7 @@ function render28(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.addSubsectionTitle("2.8.5.", "Análisis");
   ctx.addParagraph(
     "Se evidencian diferencias entre los valores estimados de PkA o DAP y los reportados por el equipo, " +
-      "lo que permite determinar un factor de corrección aplicable en evaluaciones dosimétricas posteriores.",
+      "lo que permite determinar un factor de corrección aplicable en evaluaciones dosimétricas posteriores."
   );
 
   return 6;
@@ -1737,9 +1915,7 @@ function render29(ctx: InformeCtx, conv: DatosConvencional): number {
 
   // Cálculo de desviaciones
   const eiDev =
-    eiBase != null && eiBase > 0 && ei != null
-      ? (Math.abs(ei - eiBase) / eiBase) * 100
-      : null;
+    eiBase != null && eiBase > 0 && ei != null ? (Math.abs(ei - eiBase) / eiBase) * 100 : null;
   const diDev =
     diBase != null && diBase !== 0 && di != null
       ? (Math.abs(di - diBase) / Math.abs(diBase)) * 100
@@ -1753,7 +1929,7 @@ function render29(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.addParagraph(
     conforme
       ? "Los valores del indicador de exposición (EI) y de la desviación del indicador (D.I.) presentan variaciones dentro del rango de tolerancia establecido (± 20 %), evidenciando una adecuada consistencia en la respuesta del sistema de adquisición de imagen bajo condiciones de exposición reproducibles."
-      : "Se evidencian desviaciones en el indicador de exposición (EI) y/o en la desviación del indicador (D.I.) fuera del rango de tolerancia establecido, lo que indica inconsistencias en la respuesta del sistema.",
+      : "Se evidencian desviaciones en el indicador de exposición (EI) y/o en la desviación del indicador (D.I.) fuera del rango de tolerancia establecido, lo que indica inconsistencias en la respuesta del sistema."
   );
 
   addCaption(ctx, "Tabla 2.9.2: Análisis de los indicadores de exposición");
@@ -1813,9 +1989,7 @@ function render210(ctx: InformeCtx, conv: DatosConvencional): number {
   const diAvg = ddiAvg(diVals);
   const diStd = ddiStd(diVals);
   const diCv =
-    diAvg != null && diAvg !== 0 && diStd != null
-      ? (diStd / Math.abs(diAvg)) * 100
-      : null;
+    diAvg != null && diAvg !== 0 && diStd != null ? (diStd / Math.abs(diAvg)) * 100 : null;
 
   const eiConf = eiCv != null ? (eiCv <= 20 ? "Conforme" : "No conforme") : "—";
   const diConf = diCv != null ? (diCv <= 20 ? "Conforme" : "No conforme") : "—";
@@ -1852,7 +2026,7 @@ function render210(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.addParagraph(
     conforme210
       ? "Los valores del indicador de exposición presentan baja dispersión bajo condiciones de exposición reproducibles. Los coeficientes de variación obtenidos se encuentran dentro del criterio de aceptación establecido, evidenciando una adecuada repetibilidad del sistema de adquisición de imagen."
-      : "Se evidencian variaciones en los indicadores evaluados superiores al criterio de aceptación establecido, lo que indica inestabilidad en la repetibilidad del sistema de adquisición de imagen.",
+      : "Se evidencian variaciones en los indicadores evaluados superiores al criterio de aceptación establecido, lo que indica inestabilidad en la repetibilidad del sistema de adquisición de imagen."
   );
 
   return 6;
@@ -1884,7 +2058,12 @@ function render213(ctx: InformeCtx, conv: DatosConvencional): number {
     ...TABLE_STYLE,
     startY: ctx.y,
     body: [
-      ["Distancia foco-receptor, SID (cm):", fmt(bc?.sid_cm, 0), "Tensión (kVp):", fmt(bc?.tecnica_kv, 0)],
+      [
+        "Distancia foco-receptor, SID (cm):",
+        fmt(bc?.sid_cm, 0),
+        "Tensión (kVp):",
+        fmt(bc?.tecnica_kv, 0),
+      ],
     ],
     headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
     bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" as const },
@@ -1916,16 +2095,19 @@ function render213(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.addSubsectionTitle("2.13.5.", "Análisis");
 
   const visibles = bc ? NIVELES_BC.filter((n) => bc[n.key]).length : null;
-  const bajoUmb = bc && (bc.contraste_2_8 || bc.contraste_1_8 || bc.contraste_1_3 || bc.contraste_0_9);
+  const bajoUmb =
+    bc && (bc.contraste_2_8 || bc.contraste_1_8 || bc.contraste_1_3 || bc.contraste_0_9);
   const conforme = visibles != null && (visibles > 3 || bajoUmb);
 
   if (visibles == null) {
     ctx.addParagraph("No se registraron datos para esta prueba.");
   } else if (conforme) {
-    ctx.addParagraph("Se observa una cantidad de masas superiores a las requeridas por el sistema.");
+    ctx.addParagraph(
+      "Se observa una cantidad de masas superiores a las requeridas por el sistema."
+    );
   } else {
     ctx.addParagraph(
-      `Se observa una cantidad de masas visible de ${visibles}, que no supera el mínimo requerido, y ninguno de los niveles de contraste evaluados alcanza valores por debajo del 4 %.`,
+      `Se observa una cantidad de masas visible de ${visibles}, que no supera el mínimo requerido, y ninguno de los niveles de contraste evaluados alcanza valores por debajo del 4 %.`
     );
   }
 
@@ -1948,7 +2130,12 @@ function render212(ctx: InformeCtx, conv: DatosConvencional): number {
     ...TABLE_STYLE,
     startY: ctx.y,
     body: [
-      ["Distancia foco-receptor, SID (cm):", fmt(resol?.sid_cm, 0), "Tensión (kVp):", fmt(resol?.tecnica_kv, 0)],
+      [
+        "Distancia foco-receptor, SID (cm):",
+        fmt(resol?.sid_cm, 0),
+        "Tensión (kVp):",
+        fmt(resol?.tecnica_kv, 0),
+      ],
     ],
     headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
     bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" as const },
@@ -1957,7 +2144,7 @@ function render212(ctx: InformeCtx, conv: DatosConvencional): number {
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 5;
 
   ctx.addParagraph(
-    "Se registró el grupo máximo de pares de líneas por milímetro visible de forma distinguible en la imagen obtenida.",
+    "Se registró el grupo máximo de pares de líneas por milímetro visible de forma distinguible en la imagen obtenida."
   );
 
   ctx.checkPage(14);
@@ -1965,7 +2152,12 @@ function render212(ctx: InformeCtx, conv: DatosConvencional): number {
     ...TABLE_STYLE,
     startY: ctx.y,
     head: [["Parámetro", "Valor"]],
-    body: [["Cantidad de pares de líneas visibles (pl/mm)", plmm != null ? `${plmm.toFixed(1)} pl/mm` : "—"]],
+    body: [
+      [
+        "Cantidad de pares de líneas visibles (pl/mm)",
+        plmm != null ? `${plmm.toFixed(1)} pl/mm` : "—",
+      ],
+    ],
     headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
     bodyStyles: { ...TABLE_STYLE.bodyStyles, halign: "center" as const },
     columnStyles: { 0: { halign: "left" as const } },
@@ -1975,17 +2167,17 @@ function render212(ctx: InformeCtx, conv: DatosConvencional): number {
   // ── 2.12.5 Análisis ──
   ctx.addSubsectionTitle("2.12.5.", "Análisis");
   ctx.addParagraph(
-    "El valor de resolución espacial obtenido fue comparado con el criterio de aceptación establecido en el protocolo de control de calidad aplicable.",
+    "El valor de resolución espacial obtenido fue comparado con el criterio de aceptación establecido en el protocolo de control de calidad aplicable."
   );
   if (plmm == null) {
     ctx.addParagraph("No se registró el valor de resolución espacial para esta prueba.");
   } else if (plmm >= 2.4) {
     ctx.addParagraph(
-      "Se observa que la resolución espacial observada corresponde a un valor que se encuentra por encima del mínimo requerido.",
+      "Se observa que la resolución espacial observada corresponde a un valor que se encuentra por encima del mínimo requerido."
     );
   } else {
     ctx.addParagraph(
-      "Se observa que la resolución espacial observada corresponde a un valor que se encuentra por debajo del mínimo requerido.",
+      "Se observa que la resolución espacial observada corresponde a un valor que se encuentra por debajo del mínimo requerido."
     );
   }
 
@@ -2008,7 +2200,7 @@ function render211(ctx: InformeCtx, conv: DatosConvencional): number {
 
   ctx.addParagraph(
     "Se obtuvieron imágenes uniformes con el detector orientado en las direcciones ánodo–cátodo (AC, posición inicial) " +
-      "y cátodo–ánodo (CA, rotación de 180°). En cada imagen se evaluaron cinco regiones de interés (ROI) distribuidas sobre el detector.",
+      "y cátodo–ánodo (CA, rotación de 180°). En cada imagen se evaluaron cinco regiones de interés (ROI) distribuidas sobre el detector."
   );
 
   const roiLabels = ["ROIc (central)", "ROI 1", "ROI 2", "ROI 3", "ROI 4"];
@@ -2073,9 +2265,7 @@ function render211(ctx: InformeCtx, conv: DatosConvencional): number {
     const maxAc = calcMax("ac");
     const maxCa = calcMax("ca");
     const maxGlobal =
-      maxAc != null && maxCa != null
-        ? Math.max(maxAc, maxCa)
-        : (maxAc ?? maxCa ?? null);
+      maxAc != null && maxCa != null ? Math.max(maxAc, maxCa) : (maxAc ?? maxCa ?? null);
 
     const unifConforme = maxGlobal == null || maxGlobal <= tolerancia;
     const conforme = unifConforme && !det.pixeles_defectuosos && !det.artefactos;
@@ -2089,11 +2279,12 @@ function render211(ctx: InformeCtx, conv: DatosConvencional): number {
         `En consecuencia, la prueba cumple con el criterio de aceptación.`;
     } else {
       const partes: string[] = [];
-      if (det.pixeles_defectuosos) partes.push("se identificaron píxeles defectuosos en el detector");
+      if (det.pixeles_defectuosos)
+        partes.push("se identificaron píxeles defectuosos en el detector");
       if (det.artefactos) partes.push("se observaron artefactos en la imagen");
       if (!unifConforme && maxGlobal != null)
         partes.push(
-          `el valor máximo de desviación de uniformidad obtenido fue de ${maxGlobal.toFixed(2)} %, superior a la tolerancia establecida de ${tolerancia} %`,
+          `el valor máximo de desviación de uniformidad obtenido fue de ${maxGlobal.toFixed(2)} %, superior a la tolerancia establecida de ${tolerancia} %`
         );
       parrafo =
         `En la evaluación de uniformidad y artefactos del detector, ` +
@@ -2161,7 +2352,7 @@ function render214(ctx: InformeCtx, conv: DatosConvencional): number {
 
   if (noConformes === 0 && conformes > 0) {
     addParagraph(
-      `La inspección visual realizada a los ${totalCassettes} cassette${totalCassettes > 1 ? "s" : ""} y pantalla${totalCassettes > 1 ? "s" : ""} IP evaluado${totalCassettes > 1 ? "s" : ""} no evidenció defectos externos, presencia de polvo ni rayaduras que pudieran afectar la calidad de la imagen. Todos los cassettes inspeccionados cumplen con el criterio de aceptación.`,
+      `La inspección visual realizada a los ${totalCassettes} cassette${totalCassettes > 1 ? "s" : ""} y pantalla${totalCassettes > 1 ? "s" : ""} IP evaluado${totalCassettes > 1 ? "s" : ""} no evidenció defectos externos, presencia de polvo ni rayaduras que pudieran afectar la calidad de la imagen. Todos los cassettes inspeccionados cumplen con el criterio de aceptación.`
     );
   } else if (noConformes > 0) {
     const seriesNC = cassettes
@@ -2169,7 +2360,7 @@ function render214(ctx: InformeCtx, conv: DatosConvencional): number {
       .map((c) => c.serie_detector ?? `cassette ${cassettes.indexOf(c) + 1}`)
       .join(", ");
     addParagraph(
-      `La inspección visual evidenció defectos o condiciones no conformes en ${noConformes} de los ${totalCassettes} cassette${totalCassettes > 1 ? "s" : ""} evaluados (${seriesNC}). Se requiere atención sobre los elementos identificados para garantizar la calidad de la imagen radiográfica.`,
+      `La inspección visual evidenció defectos o condiciones no conformes en ${noConformes} de los ${totalCassettes} cassette${totalCassettes > 1 ? "s" : ""} evaluados (${seriesNC}). Se requiere atención sobre los elementos identificados para garantizar la calidad de la imagen radiográfica.`
     );
   } else {
     addParagraph("Inspección realizada. Se registraron los resultados en la tabla anterior.");
@@ -2230,7 +2421,7 @@ function render216(ctx: InformeCtx, conv: DatosConvencional): number {
   const pixel = m.pixel_size_mm != null ? `${m.pixel_size_mm} mm` : "—";
   const nyquist = m.nyquist_lpmm != null ? `${m.nyquist_lpmm} lp/mm` : "—";
   addParagraph(
-    `La prueba se llevó a cabo bajo las siguientes condiciones de medición: distancia foco-sensor ${sid}, tensión de referencia ${kv}, tamaño de píxel ${pixel} y frecuencia de Nyquist ${nyquist}.`,
+    `La prueba se llevó a cabo bajo las siguientes condiciones de medición: distancia foco-sensor ${sid}, tensión de referencia ${kv}, tamaño de píxel ${pixel} y frecuencia de Nyquist ${nyquist}.`
   );
 
   // Tabla de valores medidos
@@ -2257,13 +2448,11 @@ function render216(ctx: InformeCtx, conv: DatosConvencional): number {
 
   addSubsectionTitle("2.16.5.", "Análisis");
 
-  const tieneBase =
-    m.mtf50_base_horizontal != null ||
-    m.mtf50_base_vertical != null;
+  const tieneBase = m.mtf50_base_horizontal != null || m.mtf50_base_vertical != null;
 
   if (!tieneBase) {
     addParagraph(
-      "Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, lo cual es característico de los sistemas de radiografía digital. Los valores de MTF50 y MTF20 permiten caracterizar la capacidad del detector para reproducir detalles espaciales en las direcciones horizontal y vertical. No se dispone de valores de referencia previos para comparación, por lo que los resultados obtenidos se establecen como valores base para futuras evaluaciones.",
+      "Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, lo cual es característico de los sistemas de radiografía digital. Los valores de MTF50 y MTF20 permiten caracterizar la capacidad del detector para reproducir detalles espaciales en las direcciones horizontal y vertical. No se dispone de valores de referencia previos para comparación, por lo que los resultados obtenidos se establecen como valores base para futuras evaluaciones."
     );
     return 6;
   }
@@ -2284,15 +2473,15 @@ function render216(ctx: InformeCtx, conv: DatosConvencional): number {
 
   if (conforme === true) {
     addParagraph(
-      `Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, consistente con el desempeño esperado para detectores digitales de radiografía. La variación máxima respecto a los valores de referencia fue de ${maxDesv!.toFixed(1)} %, dentro del criterio de aceptación del 10 %. Los valores obtenidos no evidencian degradaciones significativas del sistema.`,
+      `Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, consistente con el desempeño esperado para detectores digitales de radiografía. La variación máxima respecto a los valores de referencia fue de ${maxDesv!.toFixed(1)} %, dentro del criterio de aceptación del 10 %. Los valores obtenidos no evidencian degradaciones significativas del sistema.`
     );
   } else if (conforme === false) {
     addParagraph(
-      `Las curvas de MTF obtenidas presentan variaciones respecto a los valores de referencia que superan el criterio de aceptación del 10 % (variación máxima: ${maxDesv!.toFixed(1)} %). Esto podría indicar una degradación en la capacidad del sistema para reproducir detalles espaciales, requiriendo verificación adicional del detector.`,
+      `Las curvas de MTF obtenidas presentan variaciones respecto a los valores de referencia que superan el criterio de aceptación del 10 % (variación máxima: ${maxDesv!.toFixed(1)} %). Esto podría indicar una degradación en la capacidad del sistema para reproducir detalles espaciales, requiriendo verificación adicional del detector.`
     );
   } else {
     addParagraph(
-      "Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, lo cual es característico de los sistemas de radiografía digital.",
+      "Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, lo cual es característico de los sistemas de radiografía digital."
     );
   }
 
@@ -2352,11 +2541,11 @@ function render215(ctx: InformeCtx, conv: DatosConvencional): number {
 
   if (cv != null && cv <= 10) {
     addParagraph(
-      `El análisis de uniformidad de sensibilidad entre las pantallas IP evaluadas arrojó un índice de exposición promedio de ${promedioStr} (desviación estándar: ${desvStr}), con un coeficiente de variación de ${cvStr}. El valor obtenido se encuentra dentro del criterio de aceptación establecido (CV <= 10 %), por lo que la prueba cumple con los requisitos de uniformidad.`,
+      `El análisis de uniformidad de sensibilidad entre las pantallas IP evaluadas arrojó un índice de exposición promedio de ${promedioStr} (desviación estándar: ${desvStr}), con un coeficiente de variación de ${cvStr}. El valor obtenido se encuentra dentro del criterio de aceptación establecido (CV <= 10 %), por lo que la prueba cumple con los requisitos de uniformidad.`
     );
   } else {
     addParagraph(
-      `El análisis de uniformidad de sensibilidad entre las pantallas IP evaluadas arrojó un índice de exposición promedio de ${promedioStr} (desviación estándar: ${desvStr}), con un coeficiente de variación de ${cvStr}. El valor obtenido supera el criterio de aceptación establecido (CV <= 10 %), indicando diferencias de sensibilidad entre las pantallas que pueden afectar la consistencia de las imágenes.`,
+      `El análisis de uniformidad de sensibilidad entre las pantallas IP evaluadas arrojó un índice de exposición promedio de ${promedioStr} (desviación estándar: ${desvStr}), con un coeficiente de variación de ${cvStr}. El valor obtenido supera el criterio de aceptación establecido (CV <= 10 %), indicando diferencias de sensibilidad entre las pantallas que pueden afectar la consistencia de las imágenes.`
     );
   }
 
@@ -2465,7 +2654,9 @@ function render217(ctx: InformeCtx, conv: DatosConvencional): number {
     head: [["#", "kVp", "Espesor / Atenuador", "Posición Sensor CAE", "mAs", "EI", "D.I."]],
     body: filas217.length > 0 ? filas217 : [["—", "—", "—", "—", "—", "—", "—"]],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2513,7 +2704,9 @@ function render217(ctx: InformeCtx, conv: DatosConvencional): number {
         ],
       ],
       startY: ctx.y,
-      didDrawPage: () => { ctx.y = 30; },
+      didDrawPage: () => {
+        ctx.y = 30;
+      },
     });
     ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2540,9 +2733,7 @@ function render218(ctx: InformeCtx, conv: DatosConvencional): number {
   }
 
   // Tomas 2-8 (7 combinaciones de sensor a 70kVp, Cu 1mm)
-  const tomas218 = conv.caeMediciones.filter(
-    (m) => m.toma_numero >= 2 && m.toma_numero <= 8
-  );
+  const tomas218 = conv.caeMediciones.filter((m) => m.toma_numero >= 2 && m.toma_numero <= 8);
 
   checkPage(30);
   addSubsectionTitle("2.18.4.", "Resultados");
@@ -2561,7 +2752,9 @@ function render218(ctx: InformeCtx, conv: DatosConvencional): number {
     head: [["Posición Sensor CAE", "Carga (mAs)", "EI", "D.I."]],
     body: filas218.length > 0 ? filas218 : [["—", "—", "—", "—"]],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2594,7 +2787,9 @@ function render218(ctx: InformeCtx, conv: DatosConvencional): number {
       ],
     ],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2627,7 +2822,9 @@ function render219(ctx: InformeCtx, conv: DatosConvencional): number {
 
   checkPage(30);
   addSubsectionTitle("2.19.4.", "Resultados");
-  addParagraph("Tensión de referencia: 70 kVp. Espesor/atenuador: Cu 1 mm. Posición sensor: Centro.");
+  addParagraph(
+    "Tensión de referencia: 70 kVp. Espesor/atenuador: Cu 1 mm. Posición sensor: Centro."
+  );
 
   const filas219 = tomasRep.map((m) => [
     m.espesor_cu_mm != null ? `Cu ${m.espesor_cu_mm} mm` : "—",
@@ -2643,7 +2840,9 @@ function render219(ctx: InformeCtx, conv: DatosConvencional): number {
     head: [["Espesor / Atenuador", "Posición Sensor CAE", "Carga (mAs)", "EI", "D.I."]],
     body: filas219.length > 0 ? filas219 : [["—", "—", "—", "—", "—"]],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2680,7 +2879,9 @@ function render219(ctx: InformeCtx, conv: DatosConvencional): number {
       ],
     ],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2720,7 +2921,10 @@ function render220(ctx: InformeCtx, conv: DatosConvencional): number {
 
   checkPage(40);
   addSubsectionTitle("2.20.4.", "Resultados");
-  addParagraph("Tabla 2.20.1. Resultados de mediciones de compensación por kilovoltajes y espesores", 8);
+  addParagraph(
+    "Tabla 2.20.1. Resultados de mediciones de compensación por kilovoltajes y espesores",
+    8
+  );
 
   const todasFilas = [...filasKvp, ...filasEsp.slice(1)].map(({ toma, kv, esp }) => {
     const m = byToma.get(toma);
@@ -2736,18 +2940,25 @@ function render220(ctx: InformeCtx, conv: DatosConvencional): number {
 
   autoTable(doc, {
     ...TABLE_STYLE,
-    head: [["Tensión (kVp)", "Posición Sensor CAE", "Espesor / Atenuador", "Carga (mAs)", "EI", "D.I."]],
+    head: [
+      ["Tensión (kVp)", "Posición Sensor CAE", "Espesor / Atenuador", "Carga (mAs)", "EI", "D.I."],
+    ],
     body: todasFilas.length > 0 ? todasFilas : [["—", "—", "—", "—", "—", "—"]],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
   addSubsectionTitle("2.20.5.", "Análisis");
 
   // Análisis kVp
-  const t1 = byToma.get(1); const t12 = byToma.get(12); const t13 = byToma.get(13);
-  const t14 = byToma.get(14); const t15 = byToma.get(15);
+  const t1 = byToma.get(1);
+  const t12 = byToma.get(12);
+  const t13 = byToma.get(13);
+  const t14 = byToma.get(14);
+  const t15 = byToma.get(15);
 
   addParagraph(
     "Los valores de carga (mAs), indicador de exposición (EI) y desviación del indicador (D.I.) obtenidos para los diferentes valores de kilovoltaje evaluados fueron comparados con los valores iniciales de referencia correspondientes."
@@ -2755,7 +2966,8 @@ function render220(ctx: InformeCtx, conv: DatosConvencional): number {
 
   checkPage(30);
   addParagraph("Tabla 2.20.2. Análisis compensación por kilovoltajes", 8);
-  const hayBaseKvp = s?.mas_base_60kv != null || s?.mas_base_70kv != null || s?.mas_base_81kv != null;
+  const hayBaseKvp =
+    s?.mas_base_60kv != null || s?.mas_base_70kv != null || s?.mas_base_81kv != null;
   autoTable(doc, {
     ...TABLE_STYLE,
     head: [["Parámetro", "% Var. 60 kVp", "% Var. 70 kVp", "% Var. 81 kVp"]],
@@ -2773,14 +2985,13 @@ function render220(ctx: InformeCtx, conv: DatosConvencional): number {
             fmtPct(pv(t12?.ei, s?.ei_base_70kv)),
             fmtPct(pv(t13?.ei, s?.ei_base_81kv)),
           ],
-          [
-            "D.I.",
-            "NA", "NA", "NA",
-          ],
+          ["D.I.", "NA", "NA", "NA"],
         ]
       : [["Sin valores base registrados", "—", "—", "—"]],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2808,14 +3019,13 @@ function render220(ctx: InformeCtx, conv: DatosConvencional): number {
             fmtPct(pv(t14?.ei, s?.ei_base_cu2)),
             fmtPct(pv(t15?.ei, s?.ei_base_cu3)),
           ],
-          [
-            "D.I.",
-            "NA", "NA", "NA",
-          ],
+          ["D.I.", "NA", "NA", "NA"],
         ]
       : [["Sin valores base registrados", "—", "—", "—"]],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2857,10 +3067,21 @@ function render221(ctx: InformeCtx, conv: DatosConvencional): number {
   addParagraph("Tabla 2.21.1. Registro de mediciones de dosis al receptor de imagen", 8);
   autoTable(doc, {
     ...TABLE_STYLE,
-    head: [["Programa", "Tensión (kVp)", "Carga (mAs)", "Dosis medida (mGy)", "TPR", "Dosis al receptor (mGy)"]],
+    head: [
+      [
+        "Programa",
+        "Tensión (kVp)",
+        "Carga (mAs)",
+        "Dosis medida (mGy)",
+        "TPR",
+        "Dosis al receptor (mGy)",
+      ],
+    ],
     body: filas221.length > 0 ? filas221 : [["—", "—", "—", "—", "1", "—"]],
     startY: ctx.y,
-    didDrawPage: () => { ctx.y = 30; },
+    didDrawPage: () => {
+      ctx.y = 30;
+    },
   });
   ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 
@@ -2875,7 +3096,8 @@ function render221(ctx: InformeCtx, conv: DatosConvencional): number {
   } else {
     const filas221Analisis = sinRejilla.map((m) => {
       const dosisR = m.dosis_medida_mgy != null ? m.dosis_medida_mgy * corrGeom : null;
-      const diff = dosisR != null && m.dosis_base_mgy != null ? Math.abs(dosisR - m.dosis_base_mgy) : null;
+      const diff =
+        dosisR != null && m.dosis_base_mgy != null ? Math.abs(dosisR - m.dosis_base_mgy) : null;
       return [
         m.programa_clinico ?? "—",
         dosisR != null ? dosisR.toFixed(5) : "—",
@@ -2889,10 +3111,14 @@ function render221(ctx: InformeCtx, conv: DatosConvencional): number {
     addParagraph("Tabla 2.21.2. Análisis de dosis al receptor de imagen", 8);
     autoTable(doc, {
       ...TABLE_STYLE,
-      head: [["Programa", "Dosis receptor (mGy)", "Dosis base (mGy)", "Diferencia (mGy)", "Cumple"]],
+      head: [
+        ["Programa", "Dosis receptor (mGy)", "Dosis base (mGy)", "Diferencia (mGy)", "Cumple"],
+      ],
       body: filas221Analisis,
       startY: ctx.y,
-      didDrawPage: () => { ctx.y = 30; },
+      didDrawPage: () => {
+        ctx.y = 30;
+      },
     });
     ctx.y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 4;
 

--- a/src/lib/workflow/module-completeness.ts
+++ b/src/lib/workflow/module-completeness.ts
@@ -77,9 +77,7 @@ async function getInfoPercentage(visita: {
     : undefined;
   const solicitud = await db.solicitudes.get(visita.solicitud_id);
   const cliente = solicitud ? await db.clientes.get(solicitud.cliente_id) : undefined;
-  const tubo = equipo?.id
-    ? await db.tubos.where("equipo_id").equals(equipo.id).first()
-    : undefined;
+  const tubo = equipo?.id ? await db.tubos.where("equipo_id").equals(equipo.id).first() : undefined;
 
   return pct([
     visita.fecha_visita,
@@ -134,25 +132,165 @@ async function getConvGrupoAPercentage(visitaId: string): Promise<number> {
   return Math.round(setupFields * 0.2 + medPct * 0.3 + inspeccionPct * 0.4 + elemPct * 0.1);
 }
 
+// ─── Grupo B: RaySafe (pruebas 2.4–2.8, 2.21) ───
+
+async function getConvGrupoBPercentage(visitaId: string): Promise<number> {
+  const [setup, mediciones] = await Promise.all([
+    db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
+    db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).toArray(),
+  ]);
+
+  const setupPct = pct([setup?.distancia_foco_sensor_d1_cm, setup?.distancia_foco_detector_d2_cm]);
+
+  const porTipo = (tipo: string) => mediciones.filter((m) => m.tipo_medicion === tipo);
+  const filledPct = (rows: typeof mediciones, camposClave: (keyof (typeof mediciones)[0])[]) => {
+    if (rows.length === 0) return 0;
+    const filled = rows.filter((r) => camposClave.every((c) => notEmpty(r[c]))).length;
+    return Math.round((filled / rows.length) * 100);
+  };
+
+  const principalesPct = filledPct(porTipo("principal"), [
+    "kv_medido",
+    "tiempo_medido_s",
+    "dosis_medida_mgy",
+  ]);
+  const conRejillaPct = filledPct(porTipo("con_rejilla"), ["kv_medido", "dosis_medida_mgy"]);
+  const sinRejillaPct = filledPct(porTipo("sin_rejilla"), ["kv_medido", "dosis_medida_mgy"]);
+  const kermaPct = filledPct(porTipo("kerma"), ["dosis_medida_mgy", "dap_nominal"]);
+
+  // Pesos: setup 5%, principales 45%, con rejilla 15%, sin rejilla 15%, kerma 20%
+  return Math.round(
+    setupPct * 0.05 +
+      principalesPct * 0.45 +
+      conRejillaPct * 0.15 +
+      sinRejillaPct * 0.15 +
+      kermaPct * 0.2
+  );
+}
+
+// ─── Grupo C: CAE (pruebas 2.17–2.20) ───
+
+async function getConvGrupoCPercentage(visitaId: string): Promise<number> {
+  const [setup, mediciones] = await Promise.all([
+    db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
+    db.conv_cae_mediciones.where("visita_id").equals(visitaId).toArray(),
+  ]);
+
+  const setupPct = pct([
+    setup?.mas_base_217,
+    setup?.mas_base_60kv,
+    setup?.mas_base_70kv,
+    setup?.mas_base_81kv,
+    setup?.mas_base_cu1,
+    setup?.mas_base_cu2,
+    setup?.mas_base_cu3,
+  ]);
+
+  const medFilled = mediciones.filter((m) => notEmpty(m.carga_mas) && notEmpty(m.ei)).length;
+  const medPct = mediciones.length ? Math.round((medFilled / mediciones.length) * 100) : 0;
+
+  // Pesos: base de referencia 15%, disparos 85%
+  return Math.round(setupPct * 0.15 + medPct * 0.85);
+}
+
+// ─── Grupo D: DDI/EI, cassettes, uniformidad CR (pruebas 2.9, 2.10, 2.14, 2.15) ───
+
+async function getConvGrupoDPercentage(visitaId: string): Promise<number> {
+  const [ddi, cassettes, uniformidad] = await Promise.all([
+    db.conv_ddi_mediciones.where("visita_id").equals(visitaId).toArray(),
+    db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).toArray(),
+    db.conv_uniformidad_cr.where("visita_id").equals(visitaId).toArray(),
+  ]);
+
+  const ddiFilled = ddi.filter((m) => notEmpty(m.ei)).length;
+  const ddiPct = ddi.length ? Math.round((ddiFilled / ddi.length) * 100) : 0;
+
+  const cassetteFilled = cassettes.filter((c) => notEmpty(c.concepto)).length;
+  const cassettePct =
+    cassettes.length > 0 ? Math.round((cassetteFilled / cassettes.length) * 100) : 0;
+
+  const uniformidadFilled = uniformidad.filter((u) => notEmpty(u.ei)).length;
+  const uniformidadPct =
+    uniformidad.length > 0 ? Math.round((uniformidadFilled / uniformidad.length) * 100) : 0;
+
+  // Pesos: DDI/EI 50%, cassettes 30%, uniformidad CR 20%
+  return Math.round(ddiPct * 0.5 + cassettePct * 0.3 + uniformidadPct * 0.2);
+}
+
+// ─── Grupo E: colimación, resolución, bajo contraste, MTF (pruebas 2.3, 2.11–2.13, 2.16) ───
+
+async function getConvGrupoEPercentage(visitaId: string): Promise<number> {
+  const [colimacion, resolucion, bajoContraste, mtf, uniformidadDetector] = await Promise.all([
+    db.conv_colimacion.where("visita_id").equals(visitaId).first(),
+    db.conv_resolucion.where("visita_id").equals(visitaId).first(),
+    db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
+    db.conv_mtf.where("visita_id").equals(visitaId).first(),
+    db.conv_uniformidad_detector.where("visita_id").equals(visitaId).toArray(),
+  ]);
+
+  const colimacionPct = pct([
+    colimacion?.anodo_medido,
+    colimacion?.catodo_medido,
+    colimacion?.izquierda_medido,
+    colimacion?.derecha_medido,
+    colimacion?.posicion_esfera,
+  ]);
+
+  const resolucionPct = pct([resolucion?.pares_lineas_plmm]);
+
+  const bajoContrastePct = pct([
+    bajoContraste?.contraste_9_4,
+    bajoContraste?.contraste_8_0,
+    bajoContraste?.contraste_5_6,
+    bajoContraste?.contraste_4_0,
+    bajoContraste?.contraste_2_8,
+    bajoContraste?.contraste_1_8,
+    bajoContraste?.contraste_1_3,
+    bajoContraste?.contraste_0_9,
+  ]);
+
+  const mtfPct = pct([mtf?.mtf50_horizontal, mtf?.mtf50_vertical]);
+
+  const detectorFilled = uniformidadDetector.filter(
+    (d) => notEmpty(d.roi_0_vmp_ac) || notEmpty(d.roi_0_vmp_ca)
+  ).length;
+  const detectorPct =
+    uniformidadDetector.length > 0
+      ? Math.round((detectorFilled / uniformidadDetector.length) * 100)
+      : 0;
+
+  // Pesos: colimación 25%, uniformidad detector 25%, resolución 15%, bajo contraste 20%, MTF 15%
+  return Math.round(
+    colimacionPct * 0.25 +
+      detectorPct * 0.25 +
+      resolucionPct * 0.15 +
+      bajoContrastePct * 0.2 +
+      mtfPct * 0.15
+  );
+}
+
 // ─── Main: getModuleStatuses ───
 
-export async function getModuleStatuses(
-  visitaId: string,
-): Promise<Record<string, ModuleProgress>> {
+export async function getModuleStatuses(visitaId: string): Promise<Record<string, ModuleProgress>> {
   const visita = await db.visitas.get(visitaId);
   if (!visita) return {};
 
-  const infoPct = await getInfoPercentage(visita);
-  const grupoAPct = await getConvGrupoAPercentage(visitaId);
+  const [infoPct, grupoAPct, grupoBPct, grupoCPct, grupoDPct, grupoEPct] = await Promise.all([
+    getInfoPercentage(visita),
+    getConvGrupoAPercentage(visitaId),
+    getConvGrupoBPercentage(visitaId),
+    getConvGrupoCPercentage(visitaId),
+    getConvGrupoDPercentage(visitaId),
+    getConvGrupoEPercentage(visitaId),
+  ]);
 
-  // Los demás grupos se implementan conforme se construyen
   return {
     info: toProgress(infoPct),
     "grupo-a": toProgress(grupoAPct),
-    "grupo-b": toProgress(0),
-    "grupo-c": toProgress(0),
-    "grupo-d": toProgress(0),
-    "grupo-e": toProgress(0),
+    "grupo-b": toProgress(grupoBPct),
+    "grupo-c": toProgress(grupoCPct),
+    "grupo-d": toProgress(grupoDPct),
+    "grupo-e": toProgress(grupoEPct),
     "pre-informe": toProgress(0),
   };
 }
@@ -184,7 +322,7 @@ export async function getVisitCompleteness(visitaId: string): Promise<VisitCompl
 // ─── Bulk (simplificado para listado de visitas) ───
 
 export async function getVisitCompletenessBulk(
-  visitaIds: string[],
+  visitaIds: string[]
 ): Promise<Map<string, VisitCompleteness>> {
   if (visitaIds.length === 0) return new Map();
 

--- a/supabase/migrations/010_fix_conv_schema_drift.sql
+++ b/supabase/migrations/010_fix_conv_schema_drift.sql
@@ -1,0 +1,532 @@
+-- ============================================================
+--  010 — Corrige el desfase de esquema en las tablas conv_*
+--
+--  Diagnóstico: la migración 009 creó las 19 tablas conv_* como
+--  un borrador temprano (columnas genéricas: kv, mas, notas,
+--  JSONB agregados). El módulo Convencional real
+--  (src/lib/equipos/convencional/db/types.ts) se desarrolló
+--  después con un modelo mucho más detallado, pero nunca se
+--  escribió una migración que actualizara el esquema remoto.
+--  Resultado: prácticamente ninguna columna coincide entre lo
+--  que la app envía y lo que Supabase acepta → PGRST204 en cada
+--  push, y 4 tablas además tienen UNIQUE(visita_id) cuando la
+--  app necesita múltiples filas por visita.
+--
+--  Como el push nunca funcionó, no hay datos reales que preservar
+--  en estas 19 tablas remotas — se reconstruyen desde cero para
+--  calcar exactamente los tipos de TypeScript.
+--
+--  IMPORTANTE: ejecutar manualmente en el SQL Editor de Supabase
+--  (igual que las migraciones anteriores — no hay CLI vinculado).
+-- ============================================================
+
+BEGIN;
+
+-- ─── 1. Eliminar las 19 tablas conv_* (CASCADE limpia triggers,
+--         índices y políticas RLS asociadas automáticamente) ───
+
+DROP TABLE IF EXISTS conv_evidencias CASCADE;
+DROP TABLE IF EXISTS conv_resultados_prueba CASCADE;
+DROP TABLE IF EXISTS conv_informe_secciones CASCADE;
+DROP TABLE IF EXISTS conv_mtf CASCADE;
+DROP TABLE IF EXISTS conv_bajo_contraste CASCADE;
+DROP TABLE IF EXISTS conv_resolucion CASCADE;
+DROP TABLE IF EXISTS conv_uniformidad_detector CASCADE;
+DROP TABLE IF EXISTS conv_colimacion CASCADE;
+DROP TABLE IF EXISTS conv_uniformidad_cr CASCADE;
+DROP TABLE IF EXISTS conv_cassette_inspeccion CASCADE;
+DROP TABLE IF EXISTS conv_ddi_mediciones CASCADE;
+DROP TABLE IF EXISTS conv_cae_mediciones CASCADE;
+DROP TABLE IF EXISTS conv_cae_setup CASCADE;
+DROP TABLE IF EXISTS conv_raysafe_mediciones CASCADE;
+DROP TABLE IF EXISTS conv_raysafe_setup CASCADE;
+DROP TABLE IF EXISTS conv_elementos_proteccion CASCADE;
+DROP TABLE IF EXISTS conv_inspeccion_items CASCADE;
+DROP TABLE IF EXISTS conv_mediciones CASCADE;
+DROP TABLE IF EXISTS conv_levantamiento_setup CASCADE;
+
+-- ─── 2. Recrear cada tabla calcada de db/types.ts ───
+
+-- Prueba 2.1 (setup) — 1 fila por visita
+CREATE TABLE conv_levantamiento_setup (
+  id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id                  UUID NOT NULL UNIQUE REFERENCES visitas(id) ON DELETE CASCADE,
+  fondo_natural_usv_h        NUMERIC,
+  distancia_tubo_operario_m  NUMERIC,
+  tecnica_kv                 NUMERIC,
+  tecnica_ma                 NUMERIC,
+  tecnica_tiempo_s           NUMERIC,
+  tecnica_mas                NUMERIC,
+  w_estimada                 NUMERIC,
+  w_estandar                 NUMERIC,
+  factor_uso_u                NUMERIC,
+  semanas_laborales          NUMERIC,
+  sync_status                TEXT NOT NULL DEFAULT 'synced',
+  last_modified              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_levant_setup_sync ON conv_levantamiento_setup(sync_status);
+
+-- Prueba 2.1 (puntos de medición) — N filas por visita
+CREATE TABLE conv_mediciones (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id             UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  punto_numero          INT NOT NULL,
+  ubicacion_descripcion TEXT NOT NULL,
+  tasa_dosis_usv_h      NUMERIC,
+  tasa_dosis_msv_h      NUMERIC,
+  factor_ocupacion_t    NUMERIC,
+  factor_uso_u          NUMERIC,
+  carga_trabajo_w       NUMERIC,
+  corriente_prueba_i    NUMERIC,
+  tipo_area             TEXT CHECK (tipo_area IN ('controlada', 'supervisada')),
+  dosis_anual_msv       NUMERIC,
+  concepto              TEXT CHECK (concepto IN ('Conforme', 'No_conforme')),
+  observacion           TEXT,
+  sync_status           TEXT NOT NULL DEFAULT 'synced',
+  last_modified         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_med_visita ON conv_mediciones(visita_id);
+CREATE INDEX idx_conv_med_sync ON conv_mediciones(sync_status);
+
+-- Prueba 2.2 (checklist inspección) — N filas por visita
+CREATE TABLE conv_inspeccion_items (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id     UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  seccion       TEXT NOT NULL CHECK (seccion IN ('equipo', 'condiciones_operacion')),
+  item_numero   INT NOT NULL,
+  concepto      TEXT CHECK (concepto IN ('Conforme', 'No_conforme', 'No_aplica')),
+  observacion   TEXT,
+  sync_status   TEXT NOT NULL DEFAULT 'synced',
+  last_modified TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_insp_visita ON conv_inspeccion_items(visita_id);
+CREATE INDEX idx_conv_insp_seccion ON conv_inspeccion_items(visita_id, seccion);
+CREATE INDEX idx_conv_insp_sync ON conv_inspeccion_items(sync_status);
+
+-- Prueba 2.2 (elementos de protección) — N filas por visita
+CREATE TABLE conv_elementos_proteccion (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id     UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  descripcion   TEXT NOT NULL,
+  cantidad      INT,
+  tipo_paciente TEXT CHECK (tipo_paciente IN ('adulto', 'pediatrico')),
+  concepto      TEXT CHECK (concepto IN ('Conforme', 'No_conforme', 'No_aplica')),
+  observacion   TEXT,
+  sync_status   TEXT NOT NULL DEFAULT 'synced',
+  last_modified TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_elem_visita ON conv_elementos_proteccion(visita_id);
+CREATE INDEX idx_conv_elem_sync ON conv_elementos_proteccion(sync_status);
+
+-- Grupo B (setup RaySafe) — 1 fila por visita
+CREATE TABLE conv_raysafe_setup (
+  id                             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id                      UUID NOT NULL UNIQUE REFERENCES visitas(id) ON DELETE CASCADE,
+  distancia_foco_sensor_cm       NUMERIC,
+  distancia_foco_sensor_d1_cm    NUMERIC,
+  distancia_foco_detector_d2_cm  NUMERIC,
+  -- archivo_raysafe_blob es local-only, no va a Supabase
+  archivo_raysafe_nombre         TEXT,
+  sync_status                    TEXT NOT NULL DEFAULT 'synced',
+  last_modified                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en                      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_rs_setup_sync ON conv_raysafe_setup(sync_status);
+
+-- Grupo B (disparos: pruebas 2.4–2.8, 2.21) — N filas por visita
+CREATE TABLE conv_raysafe_mediciones (
+  id                            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id                     UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  tipo_medicion                 TEXT NOT NULL CHECK (tipo_medicion IN ('principal', 'con_rejilla', 'sin_rejilla', 'kerma')),
+  grupo_numero                  INT,
+  toma_numero                   INT NOT NULL,
+  programa_clinico              TEXT,
+  kv_nominal                    NUMERIC,
+  ma_nominal                    NUMERIC,
+  tiempo_nominal_s              NUMERIC,
+  mas_nominal                   NUMERIC,
+  kv_medido                     NUMERIC,
+  tiempo_medido_s               NUMERIC,
+  dosis_medida_mgy              NUMERIC,
+  chr_medido_mmal                NUMERIC,
+  dap_medido                    NUMERIC,
+  dosis_base_mgy                NUMERIC,
+  dap_nominal                   NUMERIC,
+  ancho_irradiacion_cm          NUMERIC,
+  largo_irradiacion_cm          NUMERIC,
+  distancia_foco_sensor_cm      NUMERIC,
+  distancia_foco_detector_cm    NUMERIC,
+  sync_status                   TEXT NOT NULL DEFAULT 'synced',
+  last_modified                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en                     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_rs_med_visita ON conv_raysafe_mediciones(visita_id);
+CREATE INDEX idx_conv_rs_med_tipo ON conv_raysafe_mediciones(visita_id, tipo_medicion);
+CREATE INDEX idx_conv_rs_med_sync ON conv_raysafe_mediciones(sync_status);
+
+-- Grupo C (bases CAE: pruebas 2.17, 2.20) — 1 fila por visita
+CREATE TABLE conv_cae_setup (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id     UUID NOT NULL UNIQUE REFERENCES visitas(id) ON DELETE CASCADE,
+  mas_base_217  NUMERIC,
+  ei_base_217   NUMERIC,
+  di_base_217   NUMERIC,
+  mas_base_60kv NUMERIC,
+  ei_base_60kv  NUMERIC,
+  di_base_60kv  NUMERIC,
+  mas_base_70kv NUMERIC,
+  ei_base_70kv  NUMERIC,
+  di_base_70kv  NUMERIC,
+  mas_base_81kv NUMERIC,
+  ei_base_81kv  NUMERIC,
+  di_base_81kv  NUMERIC,
+  mas_base_cu1  NUMERIC,
+  ei_base_cu1   NUMERIC,
+  di_base_cu1   NUMERIC,
+  mas_base_cu2  NUMERIC,
+  ei_base_cu2   NUMERIC,
+  di_base_cu2   NUMERIC,
+  mas_base_cu3  NUMERIC,
+  ei_base_cu3   NUMERIC,
+  di_base_cu3   NUMERIC,
+  sync_status   TEXT NOT NULL DEFAULT 'synced',
+  last_modified TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_cae_setup_sync ON conv_cae_setup(sync_status);
+
+-- Grupo C (mediciones CAE: pruebas 2.17–2.20) — N filas por visita
+CREATE TABLE conv_cae_mediciones (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id       UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  toma_numero     INT NOT NULL,
+  kv_nominal      NUMERIC,
+  espesor_cu_mm   NUMERIC,
+  posicion_sensor TEXT,
+  carga_mas       NUMERIC,
+  ei              NUMERIC,
+  di              NUMERIC,
+  tei             NUMERIC,
+  dap             NUMERIC,
+  sync_status     TEXT NOT NULL DEFAULT 'synced',
+  last_modified   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_cae_med_visita ON conv_cae_mediciones(visita_id);
+CREATE INDEX idx_conv_cae_med_toma ON conv_cae_mediciones(visita_id, toma_numero);
+CREATE INDEX idx_conv_cae_med_sync ON conv_cae_mediciones(sync_status);
+
+-- Grupo D (DDI/EI: pruebas 2.9, 2.10) — N filas por visita
+CREATE TABLE conv_ddi_mediciones (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id       UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  grupo           INT NOT NULL,
+  toma_numero     INT NOT NULL,
+  serie_detector  TEXT,
+  kv_nominal      NUMERIC,
+  carga_mas       NUMERIC,
+  ei              NUMERIC,
+  di              NUMERIC,
+  tei             NUMERIC,
+  ei_base         NUMERIC,
+  di_base         NUMERIC,
+  sync_status     TEXT NOT NULL DEFAULT 'synced',
+  last_modified   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_ddi_visita ON conv_ddi_mediciones(visita_id);
+CREATE INDEX idx_conv_ddi_grupo_toma ON conv_ddi_mediciones(visita_id, grupo, toma_numero);
+CREATE INDEX idx_conv_ddi_sync ON conv_ddi_mediciones(sync_status);
+
+-- Prueba 2.14 (cassettes/pantallas IP) — N filas por visita (¡antes 1!)
+CREATE TABLE conv_cassette_inspeccion (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id             UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  item_numero           INT NOT NULL,
+  serie_detector        TEXT,
+  integridad_externa    TEXT CHECK (integridad_externa IN ('Conforme', 'No_conforme')),
+  estado_interno        TEXT CHECK (estado_interno IN ('Conforme', 'No_conforme')),
+  polvo_suciedad        TEXT CHECK (polvo_suciedad IN ('Conforme', 'No_conforme')),
+  rayones_defectos      TEXT CHECK (rayones_defectos IN ('Conforme', 'No_conforme')),
+  limpieza_realizada    TEXT CHECK (limpieza_realizada IN ('Conforme', 'No_conforme')),
+  concepto              TEXT CHECK (concepto IN ('Conforme', 'No_conforme')),
+  observacion           TEXT,
+  sync_status           TEXT NOT NULL DEFAULT 'synced',
+  last_modified         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (visita_id, item_numero)
+);
+CREATE INDEX idx_conv_cass_visita ON conv_cassette_inspeccion(visita_id);
+CREATE INDEX idx_conv_cass_sync ON conv_cassette_inspeccion(sync_status);
+
+-- Prueba 2.15 (uniformidad IP CR) — N filas por visita (¡antes 1!)
+CREATE TABLE conv_uniformidad_cr (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id     UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  item_numero   INT NOT NULL,
+  serie_cassette TEXT,
+  carga_mas     NUMERIC,
+  ei            NUMERIC,
+  di            NUMERIC,
+  tei           NUMERIC,
+  sync_status   TEXT NOT NULL DEFAULT 'synced',
+  last_modified TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (visita_id, item_numero)
+);
+CREATE INDEX idx_conv_ucr_visita ON conv_uniformidad_cr(visita_id);
+CREATE INDEX idx_conv_ucr_sync ON conv_uniformidad_cr(sync_status);
+
+-- Prueba 2.3 (colimación y perpendicularidad) — 1 fila por visita
+CREATE TABLE conv_colimacion (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id         UUID NOT NULL UNIQUE REFERENCES visitas(id) ON DELETE CASCADE,
+  sid_cm            NUMERIC,
+  tecnica_kv        NUMERIC,
+  tecnica_ma        NUMERIC,
+  tecnica_tiempo_s  NUMERIC,
+  tecnica_mas       NUMERIC,
+  anodo_nominal     NUMERIC,
+  anodo_medido      NUMERIC,
+  catodo_nominal    NUMERIC,
+  catodo_medido     NUMERIC,
+  izquierda_nominal NUMERIC,
+  izquierda_medido  NUMERIC,
+  derecha_nominal   NUMERIC,
+  derecha_medido    NUMERIC,
+  posicion_esfera   TEXT CHECK (posicion_esfera IN ('Centro', 'Primer circulo', 'Segundo circulo', 'Fuera del circulo externo')),
+  sync_status       TEXT NOT NULL DEFAULT 'synced',
+  last_modified     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_col_sync ON conv_colimacion(sync_status);
+
+-- Prueba 2.11 (uniformidad y artefactos del detector) — N filas por visita (¡antes 1!)
+CREATE TABLE conv_uniformidad_detector (
+  id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id              UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  item_numero            INT NOT NULL,
+  serie_detector         TEXT,
+  roi_0_vmp_ac           NUMERIC,
+  roi_1_vmp_ac           NUMERIC,
+  roi_2_vmp_ac           NUMERIC,
+  roi_3_vmp_ac           NUMERIC,
+  roi_4_vmp_ac           NUMERIC,
+  roi_0_desv_ac          NUMERIC,
+  roi_1_desv_ac          NUMERIC,
+  roi_2_desv_ac          NUMERIC,
+  roi_3_desv_ac          NUMERIC,
+  roi_4_desv_ac          NUMERIC,
+  roi_0_vmp_ca           NUMERIC,
+  roi_1_vmp_ca           NUMERIC,
+  roi_2_vmp_ca           NUMERIC,
+  roi_3_vmp_ca           NUMERIC,
+  roi_4_vmp_ca           NUMERIC,
+  roi_0_desv_ca          NUMERIC,
+  roi_1_desv_ca          NUMERIC,
+  roi_2_desv_ca          NUMERIC,
+  roi_3_desv_ca          NUMERIC,
+  roi_4_desv_ca          NUMERIC,
+  tolerancia_pct         NUMERIC,
+  pixeles_defectuosos    BOOLEAN,
+  artefactos             BOOLEAN,
+  artefactos_descripcion TEXT,
+  sync_status            TEXT NOT NULL DEFAULT 'synced',
+  last_modified          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (visita_id, item_numero)
+);
+CREATE INDEX idx_conv_udet_visita ON conv_uniformidad_detector(visita_id);
+CREATE INDEX idx_conv_udet_sync ON conv_uniformidad_detector(sync_status);
+
+-- Prueba 2.12 (resolución espacial) — 1 fila por visita
+CREATE TABLE conv_resolucion (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id         UUID NOT NULL UNIQUE REFERENCES visitas(id) ON DELETE CASCADE,
+  sid_cm            NUMERIC,
+  tecnica_kv        NUMERIC,
+  tecnica_ma        NUMERIC,
+  tecnica_tiempo_s  NUMERIC,
+  tecnica_mas       NUMERIC,
+  pares_lineas_plmm NUMERIC,
+  concepto          TEXT CHECK (concepto IN ('Conforme', 'No_conforme')),
+  sync_status       TEXT NOT NULL DEFAULT 'synced',
+  last_modified     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_res_sync ON conv_resolucion(sync_status);
+
+-- Prueba 2.13 (bajo contraste) — 1 fila por visita
+CREATE TABLE conv_bajo_contraste (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id         UUID NOT NULL UNIQUE REFERENCES visitas(id) ON DELETE CASCADE,
+  sid_cm            NUMERIC,
+  tecnica_kv        NUMERIC,
+  tecnica_ma        NUMERIC,
+  tecnica_tiempo_s  NUMERIC,
+  tecnica_mas       NUMERIC,
+  contraste_9_4     BOOLEAN,
+  contraste_8_0     BOOLEAN,
+  contraste_5_6     BOOLEAN,
+  contraste_4_0     BOOLEAN,
+  contraste_2_8     BOOLEAN,
+  contraste_1_8     BOOLEAN,
+  contraste_1_3     BOOLEAN,
+  contraste_0_9     BOOLEAN,
+  concepto          TEXT CHECK (concepto IN ('Conforme', 'No_conforme')),
+  sync_status       TEXT NOT NULL DEFAULT 'synced',
+  last_modified     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_bc_sync ON conv_bajo_contraste(sync_status);
+
+-- Prueba 2.16 (MTF) — 1 fila por visita
+CREATE TABLE conv_mtf (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id                UUID NOT NULL UNIQUE REFERENCES visitas(id) ON DELETE CASCADE,
+  distancia_foco_sensor_cm NUMERIC,
+  tecnica_kv               NUMERIC,
+  tecnica_ma               NUMERIC,
+  tecnica_tiempo_s         NUMERIC,
+  tecnica_mas              NUMERIC,
+  pixel_size_mm            NUMERIC,
+  nyquist_lpmm             NUMERIC,
+  mtf50_horizontal         NUMERIC,
+  mtf20_horizontal         NUMERIC,
+  mtf50_vertical           NUMERIC,
+  mtf20_vertical           NUMERIC,
+  mtf50_base_horizontal    NUMERIC,
+  mtf20_base_horizontal    NUMERIC,
+  mtf50_base_vertical      NUMERIC,
+  mtf20_base_vertical      NUMERIC,
+  concepto                 TEXT CHECK (concepto IN ('Conforme', 'No_conforme')),
+  sync_status              TEXT NOT NULL DEFAULT 'synced',
+  last_modified            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_mtf_sync ON conv_mtf(sync_status);
+
+-- Editor de pre-informe: 1 fila por prueba (2.1..2.21) por visita (¡antes 1 por visita!)
+CREATE TABLE conv_informe_secciones (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id             UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  prueba_codigo         TEXT NOT NULL,
+  orden                 INT NOT NULL,
+  incluida              BOOLEAN NOT NULL DEFAULT TRUE,
+  concepto              TEXT CHECK (concepto IN ('Conforme', 'No_conforme', 'No_aplica')),
+  acciones_correctivas  TEXT,
+  observaciones         TEXT,
+  sync_status           TEXT NOT NULL DEFAULT 'synced',
+  last_modified         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (visita_id, prueba_codigo)
+);
+CREATE INDEX idx_conv_inf_sec_visita ON conv_informe_secciones(visita_id);
+CREATE INDEX idx_conv_inf_sec_sync ON conv_informe_secciones(sync_status);
+
+-- Resultado calculado por prueba — 1 fila por prueba por visita (cardinalidad ya era correcta)
+CREATE TABLE conv_resultados_prueba (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id            UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  prueba_codigo        TEXT NOT NULL,
+  resultado_principal  NUMERIC,
+  resultado_secundario NUMERIC,
+  datos_calculados     JSONB,
+  concepto             TEXT CHECK (concepto IN ('Conforme', 'No_conforme', 'No_aplica')),
+  acciones_correctivas TEXT,
+  completado           BOOLEAN NOT NULL DEFAULT FALSE,
+  fecha_ejecucion      DATE,
+  sync_status          TEXT NOT NULL DEFAULT 'synced',
+  last_modified        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (visita_id, prueba_codigo)
+);
+CREATE INDEX idx_conv_res_prueba_visita ON conv_resultados_prueba(visita_id);
+CREATE INDEX idx_conv_res_prueba_sync ON conv_resultados_prueba(sync_status);
+
+-- Evidencias fotográficas por prueba/slot — N filas por visita
+CREATE TABLE conv_evidencias (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  visita_id     UUID NOT NULL REFERENCES visitas(id) ON DELETE CASCADE,
+  prueba_codigo TEXT NOT NULL,
+  slot          TEXT NOT NULL,
+  descripcion   TEXT,
+  -- blob_local es local-only, no va a Supabase
+  url_storage   TEXT,
+  fecha_captura TIMESTAMPTZ,
+  sync_status   TEXT NOT NULL DEFAULT 'synced',
+  last_modified TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  creado_en     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_conv_ev_visita ON conv_evidencias(visita_id);
+CREATE INDEX idx_conv_ev_prueba ON conv_evidencias(visita_id, prueba_codigo);
+CREATE INDEX idx_conv_ev_sync ON conv_evidencias(sync_status);
+
+-- ─── 3. Trigger de last_modified (mismo patrón que 009) ───
+
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'conv_levantamiento_setup','conv_mediciones','conv_inspeccion_items',
+    'conv_elementos_proteccion','conv_raysafe_setup','conv_raysafe_mediciones',
+    'conv_cae_setup','conv_cae_mediciones','conv_ddi_mediciones',
+    'conv_cassette_inspeccion','conv_uniformidad_cr','conv_colimacion',
+    'conv_uniformidad_detector','conv_resolucion','conv_bajo_contraste',
+    'conv_mtf','conv_informe_secciones','conv_resultados_prueba','conv_evidencias'
+  ] LOOP
+    EXECUTE format('
+      CREATE TRIGGER trg_%s_modified BEFORE UPDATE ON %I
+        FOR EACH ROW EXECUTE FUNCTION update_last_modified();
+    ', replace(t, '_', ''), t);
+  END LOOP;
+END $$;
+
+-- ─── 4. RLS (mismo patrón que 009: lectura autenticada,
+--         escritura del técnico asignado a la visita o admin) ───
+
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'conv_levantamiento_setup','conv_mediciones','conv_inspeccion_items',
+    'conv_elementos_proteccion','conv_raysafe_setup','conv_raysafe_mediciones',
+    'conv_cae_setup','conv_cae_mediciones','conv_ddi_mediciones',
+    'conv_cassette_inspeccion','conv_uniformidad_cr','conv_colimacion',
+    'conv_uniformidad_detector','conv_resolucion','conv_bajo_contraste',
+    'conv_mtf','conv_informe_secciones','conv_resultados_prueba','conv_evidencias'
+  ] LOOP
+    EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY;', t);
+    EXECUTE format('
+      CREATE POLICY "Lectura autenticada" ON %I
+        FOR SELECT TO authenticated USING (true);
+    ', t);
+    EXECUTE format('
+      CREATE POLICY "Escritura propio o admin" ON %I
+        FOR ALL TO authenticated
+        USING (
+          EXISTS (
+            SELECT 1 FROM visitas
+            WHERE visitas.id = %I.visita_id
+              AND (visitas.tecnico_id = public.get_usuario_id() OR public.is_admin())
+          )
+        )
+        WITH CHECK (
+          EXISTS (
+            SELECT 1 FROM visitas
+            WHERE visitas.id = %I.visita_id
+              AND (visitas.tecnico_id = public.get_usuario_id() OR public.is_admin())
+          )
+        );
+    ', t, t, t);
+  END LOOP;
+END $$;
+
+-- ─── 5. Refrescar el schema cache de PostgREST ───
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Corrige desfase de esquema en las 19 tablas `conv_*` de Supabase (migración 010) que causaba 0% de sincronización histórica en el módulo Convencional
- Corrige duplicación de filas en el informe PDF (prueba 2.2) causada por una condición de carrera en los efectos de inicialización de grupo-a a grupo-e; agrega guards con `useRef` y deduplicación defensiva al armar los datos del PDF
- Implementa el cálculo real de porcentaje de llenado para los grupos B, C, D y E (antes hardcodeados a 0%)
- Agrega acciones correctivas editables con texto predeterminado (Conforme/No conforme) para las pruebas 2.1, 2.2 y 2.13, y corrige que el PDF ignoraba las ediciones guardadas en esas 3 pruebas
- Agrega "Delantal con cuello incluido" al catálogo de protección (2.2), ordenado alfabéticamente
- Espeja la técnica nominal entre "Con rejilla", "Sin rejilla" y "Kerma" en Grupo B para evitar captura triplicada

## Test plan
- [x] `npx tsc --noEmit`
- [x] ESLint y Prettier sobre archivos modificados
- [x] Migración 010 ya aplicada manualmente en Supabase por el usuario, sincronización confirmada funcionando
- [x] Verificar visualmente que el PDF regenerado ya no duplica filas en 2.2.2
- [x] Confirmar en el editor que Acciones correctivas de 2.1/2.2/2.13 muestra el predeterminado correcto y es editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)