### PR TITLE
fix(sync): paginar descarga de tablas maestras para evitar truncamiento

### DIFF
--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -433,12 +433,32 @@ async function pullMasterTable(
   const dexieTable = getDexieTable(tableName);
   if (!dexieTable) return 0;
 
-  const { data, error } = await supabase.from(tableName).select("*");
-  if (error) throw error;
-  if (!data || data.length === 0) return 0;
+  // PostgREST trunca silenciosamente las respuestas a `max_rows` (config.toml)
+  // sin devolver error, asi que paginamos con .range() ordenando por id para
+  // garantizar cobertura completa y determinista entre paginas.
+  const PAGE_SIZE = 500;
+  const allData: SyncableRecord[] = [];
+  let offset = 0;
 
-  await dexieTable.bulkPut(data);
-  return data.length;
+  for (;;) {
+    const { data, error } = await supabase
+      .from(tableName)
+      .select("*")
+      .order("id", { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1);
+
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+
+    allData.push(...data);
+    if (data.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+
+  if (allData.length === 0) return 0;
+
+  await dexieTable.bulkPut(allData);
+  return allData.length;
 }
 
 /**


### PR DESCRIPTION
## Summary
- El select de municipios quedaba vacio al elegir "Valle del Cauca" al crear una sede. Causa raiz: PostgREST trunca silenciosamente las respuestas a `max_rows` (1000, ver `supabase/config.toml`) sin devolver error, y `pullMasterTable()` en `sync-engine.ts` hacia un unico `select("*")` sin paginar. La tabla `municipios` tiene 1122 filas; todo lo que cae despues del corte de 1000 (departamento_id >= 76: Valle del Cauca y los siguientes) nunca llegaba al IndexedDB local.
- Se pagino `pullMasterTable()` con `.range()` en bloques de 500, ordenando explicitamente por `id` (PostgREST no garantiza orden estable entre requests sin `ORDER BY`), acumulando en memoria antes del `bulkPut` para no dejar una escritura parcial si una pagina falla.
- El fix es generico: cubre las 12 `MASTER_TABLES`, no solo `municipios`, por si otra tabla supera 1000 filas en el futuro.

## Changes
| File | Change |
|------|--------|
| `src/lib/supabase/sync-engine.ts` | `pullMasterTable()` pagina con `.range()` en vez de un `select("*")` sin limite |

## Test plan
- [x] `npx tsc --noEmit` sin errores
- [x] `npx prettier --check src/lib/supabase/sync-engine.ts`
- [x] Lint del repo revisado — sin hallazgos nuevos en el archivo modificado (los errores/warnings existentes son de otros archivos, preexistentes)
- [x] Verificacion manual pendiente: correr sync completo y confirmar `await db.municipios.count()` === 1122, y que el formulario de sede muestra los 42 municipios de Valle del Cauca

🤖 Generated with [Claude Code](https://claude.com/claude-code)