### PR TITLE
fix(sync): paginar pullSyncTable por keyset para evitar truncamiento

### DIFF
--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import {
+  createFakeSupabaseClient,
+  type FakeRow,
+  type FakeSupabaseClient,
+} from "@/test/fake-supabase";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let fakeClient: any;
+
+// El módulo bajo prueba importa `createClient` desde "./client" — lo
+// reemplazamos por nuestro stub para no depender de env vars reales ni de
+// un backend Supabase real.
+vi.mock("./client", () => ({
+  createClient: () => fakeClient,
+}));
+
+// Import estático: `vi.mock` se hoistea sobre los imports, así que el mock
+// de "./client" ya está activo cuando `sync-engine.ts` se evalúa.
+import { fullSync, pullSyncTable } from "./sync-engine";
+
+// ============================================================
+//  pullSyncTable — paginación keyset (PR1: sync-engine-entrega-garantizada)
+//
+//  PostgREST trunca silenciosamente las respuestas a `max_rows` (1000,
+//  ver supabase/config.toml:18) sin devolver error. Antes de esta fase,
+//  `pullSyncTable` no paginaba, así que tablas con más de 1000 filas
+//  modificadas perdían filas silenciosamente en cada pull.
+// ============================================================
+
+function buildRemoteRows(count: number, opts?: { qualifyEvenOnly?: boolean }): FakeRow[] {
+  return Array.from({ length: count }, (_, i) => {
+    const qualifies = opts?.qualifyEvenOnly ? i % 2 === 0 : true;
+    return {
+      id: `id-${String(i).padStart(4, "0")}`,
+      nit: `NIT-${i}`,
+      nombre_cliente: `Cliente ${i}`,
+      last_modified: qualifies ? "2026-02-01T00:00:00.000Z" : "2025-01-01T00:00:00.000Z",
+      sync_status: "synced",
+    };
+  });
+}
+
+describe("sync-engine — pullSyncTable (paginación keyset)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("descarga las 1200 filas remotas paginando más allá del límite max_rows=1000 de PostgREST", async () => {
+    const remoteRows = buildRemoteRows(1200);
+    fakeClient.seedTable("clientes", remoteRows, { maxRows: 1000 });
+
+    const pulled = await pullSyncTable(fakeClient, "clientes", "clientes");
+
+    expect(pulled).toBe(1200);
+    await expect(db.clientes.count()).resolves.toBe(1200);
+  });
+
+  it("no avanza el watermark si una página intermedia falla, aunque páginas previas ya se hayan persistido", async () => {
+    const remoteRows = buildRemoteRows(1200);
+    fakeClient.seedTable("clientes", remoteRows);
+    fakeClient.failOnCall("clientes", "select", 2, { message: "network drop en página 2" });
+
+    await expect(pullSyncTable(fakeClient, "clientes", "clientes")).rejects.toBeTruthy();
+
+    // La página 1 (500 filas) sí llegó a persistirse localmente...
+    await expect(db.clientes.count()).resolves.toBe(500);
+    // ...pero el watermark de sync_meta NUNCA avanzó porque el pull no
+    // terminó con éxito (setLastSyncTimestamp no se alcanza si hay throw).
+    const meta = await db.sync_meta.get("clientes");
+    expect(meta).toBeUndefined();
+  });
+
+  it("mantiene el filtro last_modified y la regla de conflicto de forma consistente en todas las páginas", async () => {
+    const watermark = "2026-01-01T12:00:00.000Z";
+    await db.sync_meta.put({ table_name: "clientes", last_pulled_at: watermark });
+
+    // 1100 filas remotas: las de índice par (550) tienen last_modified
+    // posterior al watermark y califican; las impares (550) son anteriores
+    // y deben quedar excluidas en TODAS las páginas, no solo en la primera.
+    const remoteRows = buildRemoteRows(1100, { qualifyEvenOnly: true });
+    fakeClient.seedTable("clientes", remoteRows);
+
+    // Conflictos locales: uno cae en la página 1 (id-0500) y otro en la
+    // página 2 (id-1050) según el cursor keyset por id, PAGE_SIZE=500.
+    await db.clientes.put({
+      id: "id-0500",
+      nombre_cliente: "Local pendiente pag1",
+      nit: "LOCAL-1",
+      sync_status: "pending",
+      last_modified: "2026-01-05T00:00:00.000Z",
+    });
+    await db.clientes.put({
+      id: "id-1050",
+      nombre_cliente: "Local pendiente pag2",
+      nit: "LOCAL-2",
+      sync_status: "pending",
+      last_modified: "2026-01-05T00:00:00.000Z",
+    });
+
+    const pulled = await pullSyncTable(fakeClient, "clientes", "clientes");
+
+    // 550 filas califican por el filtro last_modified; 2 de ellas son
+    // conflictos locales (no se sobrescriben) → 548 se cuentan como "pulled".
+    expect(pulled).toBe(548);
+
+    // Las filas impares (anteriores al watermark) nunca llegan a Dexie,
+    // ni las de la página 1 (id-0501) ni las de la página 2 (id-1051).
+    await expect(db.clientes.get("id-0501")).resolves.toBeUndefined();
+    await expect(db.clientes.get("id-1051")).resolves.toBeUndefined();
+
+    // El conflicto se resuelve igual en ambas páginas: se conserva la
+    // versión local y se marca sync_status="conflict".
+    const conflictPage1 = await db.clientes.get("id-0500");
+    expect(conflictPage1?.sync_status).toBe("conflict");
+    expect(conflictPage1?.nombre_cliente).toBe("Local pendiente pag1");
+
+    const conflictPage2 = await db.clientes.get("id-1050");
+    expect(conflictPage2?.sync_status).toBe("conflict");
+    expect(conflictPage2?.nombre_cliente).toBe("Local pendiente pag2");
+  });
+});
+
+describe("sync-engine — fullSync (integración con pullSyncTable)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("integra la paginación de pullSyncTable en el ciclo completo y persiste el watermark tras un pull exitoso", async () => {
+    const remoteRows = buildRemoteRows(3);
+    fakeClient.seedTable("clientes", remoteRows);
+
+    const result = await fullSync();
+
+    // Solo nos interesa el pull de "clientes" (tabla SYNC_TABLES bajo
+    // prueba). Las tablas MASTER_TABLES usan `.range()`, fuera del alcance
+    // del stub de este PR (paginación keyset de pullSyncTable únicamente).
+    const clientesErrors = result.errors.filter((e) => e.table === "clientes");
+    expect(clientesErrors).toEqual([]);
+    await expect(db.clientes.count()).resolves.toBe(3);
+    const meta = await db.sync_meta.get("clientes");
+    expect(meta?.last_pulled_at).toBeDefined();
+  });
+});

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -461,11 +461,88 @@ async function pullMasterTable(
   return allData.length;
 }
 
+const SYNC_PAGE_SIZE = 500;
+
+/**
+ * Aplica un registro remoto individual al Dexie local, resolviendo el
+ * conflicto si hay cambios locales pendientes (cualquier sync_status
+ * distinto de "synced" se trata como cambio local sin confirmar).
+ * Devuelve 1 si el registro se escribió como "synced", 0 si fue conflicto.
+ */
+async function applyRemoteSyncRecord(
+  dexieTable: EntityTable<SyncableRecord, "id">,
+  localTable: string,
+  remoteRecord: SyncableRecord
+): Promise<number> {
+  const localRecord = await dexieTable.get(remoteRecord.id as string);
+
+  if (!localRecord || localRecord.sync_status === "synced") {
+    await dexieTable.put({ ...remoteRecord, sync_status: "synced" as SyncStatus });
+    return 1;
+  }
+
+  // Conflicto: hay cambios locales pendientes — mantener versión local
+  logger.warn(
+    "sync:pull",
+    `Conflicto en ${localTable}#${remoteRecord.id} — manteniendo versión local`
+  );
+  await dexieTable.update(localRecord.id as string, { sync_status: "conflict" as SyncStatus });
+  return 0;
+}
+
+/**
+ * Recorre todas las páginas de una tabla de sincronización usando keyset
+ * pagination por `id` (no offset: un offset puede saltear filas si se
+ * insertan registros nuevos durante el pull). El filtro incremental
+ * `.gt("last_modified", lastSynced)` se mantiene fijo en cada página.
+ *
+ * Se detiene al recibir una página más corta que SYNC_PAGE_SIZE. Si
+ * cualquier página falla, la excepción se propaga sin procesar el resto —
+ * las páginas ya procesadas quedan persistidas en Dexie, pero el llamador
+ * NO debe avanzar el watermark de sync_meta en ese caso.
+ */
+async function pullSyncPages(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  dexieTable: EntityTable<SyncableRecord, "id">,
+  localTable: string,
+  remoteTable: string,
+  lastSynced: string | null
+): Promise<number> {
+  let pulled = 0;
+  let cursor: string | null = null;
+
+  for (;;) {
+    let query = supabase.from(remoteTable).select("*");
+    if (lastSynced) {
+      query = query.gt("last_modified", lastSynced);
+    }
+    if (cursor) {
+      query = query.gt("id", cursor);
+    }
+    query = query.order("id", { ascending: true }).limit(SYNC_PAGE_SIZE);
+
+    const { data, error } = await query;
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+
+    for (const remoteRecord of data as SyncableRecord[]) {
+      pulled += await applyRemoteSyncRecord(dexieTable, localTable, remoteRecord);
+    }
+
+    cursor = data[data.length - 1].id as string;
+    if (data.length < SYNC_PAGE_SIZE) break;
+  }
+
+  return pulled;
+}
+
 /**
  * Pull tabla de sincronización: solo registros modificados después
- * de la última sync local.
+ * de la última sync local, paginando por keyset (`id`) para no perder
+ * filas cuando la tabla supera el límite `max_rows` de PostgREST.
  */
-async function pullSyncTable(
+export async function pullSyncTable(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   supabase: any,
   localTable: string,
@@ -475,36 +552,15 @@ async function pullSyncTable(
   if (!dexieTable) return 0;
 
   const lastSynced = await getLastSyncTimestamp(localTable);
+  // El watermark se captura ANTES de paginar: cualquier registro modificado
+  // mientras el pull está en curso quedará cubierto en la próxima sync.
+  const pullStartedAt = new Date().toISOString();
 
-  let query = supabase.from(remoteTable).select("*");
-  if (lastSynced) {
-    query = query.gt("last_modified", lastSynced);
-  }
+  const pulled = await pullSyncPages(supabase, dexieTable, localTable, remoteTable, lastSynced);
 
-  const { data, error } = await query;
-  if (error) throw error;
-  if (!data || data.length === 0) return 0;
-
-  let pulled = 0;
-  for (const remoteRecord of data) {
-    const localRecord = await dexieTable.get(remoteRecord.id);
-
-    if (!localRecord) {
-      await dexieTable.put({ ...remoteRecord, sync_status: "synced" as SyncStatus });
-      pulled++;
-    } else if (localRecord.sync_status === "synced") {
-      await dexieTable.put({ ...remoteRecord, sync_status: "synced" as SyncStatus });
-      pulled++;
-    } else {
-      // Conflicto: hay cambios locales pendientes — mantener versión local
-      console.warn(
-        `[Sync] Conflicto en ${localTable}#${remoteRecord.id} — manteniendo versión local`
-      );
-      await dexieTable.update(localRecord.id, { sync_status: "conflict" as SyncStatus });
-    }
-  }
-
-  await setLastSyncTimestamp(localTable, new Date().toISOString());
+  // Solo se persiste el watermark si TODAS las páginas se procesaron sin
+  // error — si pullSyncPages lanza, esta línea nunca se alcanza.
+  await setLastSyncTimestamp(localTable, pullStartedAt);
   return pulled;
 }
 

--- a/src/test/db-reset.ts
+++ b/src/test/db-reset.ts
@@ -1,0 +1,18 @@
+import { db } from "@/lib/db";
+
+/**
+ * Resetea completamente la base de datos Dexie entre tests.
+ *
+ * A diferencia de `resetAllLocalData` (que solo limpia el contenido de cada
+ * tabla), esto hace un `delete()` + `open()` real sobre `fake-indexeddb`
+ * (configurado globalmente en `vitest.config.ts` vía `fake-indexeddb/auto`),
+ * garantizando aislamiento total entre tests — incluyendo `sync_meta`, que
+ * guarda el watermark de sincronización y debe partir en blanco en cada test.
+ */
+export async function resetTestDb(): Promise<void> {
+  if (db.isOpen()) {
+    db.close();
+  }
+  await db.delete();
+  await db.open();
+}

--- a/src/test/fake-supabase.ts
+++ b/src/test/fake-supabase.ts
@@ -1,0 +1,219 @@
+/**
+ * Stub chainable de Supabase para tests de `sync-engine.ts`.
+ *
+ * Simula únicamente la porción de la API de `@supabase/supabase-js` que usa
+ * el motor de sincronización: `from().select().order().gt().limit()` y
+ * `from().upsert()`, además de `auth.getUser()`.
+ *
+ * Soporta:
+ * - Truncamiento programable por tabla (`maxRows`), replicando el límite
+ *   `max_rows` de PostgREST (`supabase/config.toml`) que trunca resultados
+ *   silenciosamente sin devolver error.
+ * - Fallos programables por llamada (`failOnCall`), para simular una página
+ *   intermedia que falla durante la paginación.
+ */
+
+export type FakeRow = Record<string, unknown>;
+
+export interface FakeSupabaseError {
+  message: string;
+  code?: string;
+}
+
+type FakeMethod = "select" | "upsert";
+
+interface FakeTableConfig {
+  rows: FakeRow[];
+  maxRows?: number;
+}
+
+interface FailureSpec {
+  table: string;
+  method: FakeMethod;
+  callIndex: number;
+  error: FakeSupabaseError;
+}
+
+interface FakeFilter {
+  column: string;
+  op: "gt";
+  value: unknown;
+}
+
+interface FakeQueryResult {
+  data: FakeRow[] | null;
+  error: FakeSupabaseError | null;
+}
+
+/**
+ * Query builder chainable, thenable (awaitable) — imita el builder real de
+ * supabase-js lo suficiente para que el código de producción funcione sin
+ * cambios.
+ */
+class FakeQueryBuilder implements PromiseLike<FakeQueryResult> {
+  private filters: FakeFilter[] = [];
+  private orderColumn?: string;
+  private orderAscending = true;
+  private limitCount?: number;
+  private upsertRows?: FakeRow[];
+
+  constructor(
+    private readonly client: FakeSupabaseClient,
+    private readonly table: string
+  ) {}
+
+  select(_columns = "*"): this {
+    return this;
+  }
+
+  order(column: string, opts?: { ascending?: boolean }): this {
+    this.orderColumn = column;
+    this.orderAscending = opts?.ascending ?? true;
+    return this;
+  }
+
+  gt(column: string, value: unknown): this {
+    this.filters.push({ column, op: "gt", value });
+    return this;
+  }
+
+  limit(count: number): this {
+    this.limitCount = count;
+    return this;
+  }
+
+  upsert(data: FakeRow | FakeRow[], _opts?: { onConflict?: string }): this {
+    this.upsertRows = Array.isArray(data) ? data : [data];
+    return this;
+  }
+
+  then<TResult1 = FakeQueryResult, TResult2 = never>(
+    onfulfilled?: ((value: FakeQueryResult) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected);
+  }
+
+  private async execute(): Promise<FakeQueryResult> {
+    if (this.upsertRows) return this.executeUpsert();
+    return this.executeSelect();
+  }
+
+  private async executeUpsert(): Promise<FakeQueryResult> {
+    const callIndex = this.client._nextCallIndex(this.table, "upsert");
+    const failure = this.client._takeFailure(this.table, "upsert", callIndex);
+    if (failure) return { data: null, error: failure };
+
+    const cfg = this.client._tableConfig(this.table);
+    for (const row of this.upsertRows ?? []) {
+      const idx = cfg.rows.findIndex((r) => r.id === row.id);
+      if (idx >= 0) cfg.rows[idx] = { ...cfg.rows[idx], ...row };
+      else cfg.rows.push({ ...row });
+    }
+    return { data: this.upsertRows ?? [], error: null };
+  }
+
+  private async executeSelect(): Promise<FakeQueryResult> {
+    const callIndex = this.client._nextCallIndex(this.table, "select");
+    const failure = this.client._takeFailure(this.table, "select", callIndex);
+    if (failure) return { data: null, error: failure };
+
+    const cfg = this.client._tableConfig(this.table);
+    let rows = cfg.rows.filter((row) =>
+      this.filters.every((f) => {
+        const rv = row[f.column];
+        if (rv === undefined || rv === null) return false;
+        return rv > (f.value as string | number);
+      })
+    );
+
+    if (this.orderColumn) {
+      const col = this.orderColumn;
+      const ascending = this.orderAscending;
+      rows = [...rows].sort((a, b) => {
+        const av = a[col] as string | number;
+        const bv = b[col] as string | number;
+        if (av < bv) return ascending ? -1 : 1;
+        if (av > bv) return ascending ? 1 : -1;
+        return 0;
+      });
+    }
+
+    // Simula el truncamiento silencioso de PostgREST por `max_rows`.
+    let effectiveLimit = this.limitCount;
+    if (cfg.maxRows !== undefined) {
+      effectiveLimit =
+        effectiveLimit === undefined ? cfg.maxRows : Math.min(effectiveLimit, cfg.maxRows);
+    }
+    if (effectiveLimit !== undefined) {
+      rows = rows.slice(0, effectiveLimit);
+    }
+
+    return { data: rows, error: null };
+  }
+}
+
+export class FakeSupabaseClient {
+  private tables = new Map<string, FakeTableConfig>();
+  private failures: FailureSpec[] = [];
+  private callCounts = new Map<string, number>();
+  private currentUser: { id: string } | null = { id: "fake-user-id" };
+
+  auth = {
+    getUser: async () => ({ data: { user: this.currentUser } }),
+  };
+
+  /** Carga filas simuladas para una tabla remota, con truncamiento opcional. */
+  seedTable(table: string, rows: FakeRow[], opts?: { maxRows?: number }): void {
+    this.tables.set(table, { rows: [...rows], maxRows: opts?.maxRows });
+  }
+
+  /** Controla si `auth.getUser()` devuelve un usuario autenticado. */
+  setUser(user: { id: string } | null): void {
+    this.currentUser = user;
+  }
+
+  /**
+   * Programa un fallo para la N-ésima llamada (`callIndex`, 1-based) a
+   * `method` sobre `table`. Útil para simular que una página intermedia de
+   * paginación falla.
+   */
+  failOnCall(table: string, method: FakeMethod, callIndex: number, error: FakeSupabaseError): void {
+    this.failures.push({ table, method, callIndex, error });
+  }
+
+  from(table: string): FakeQueryBuilder {
+    return new FakeQueryBuilder(this, table);
+  }
+
+  /** Cantidad de llamadas realizadas a `method` sobre `table` (para asserts). */
+  callCount(table: string, method: FakeMethod): number {
+    return this.callCounts.get(`${table}:${method}`) ?? 0;
+  }
+
+  // ─── Internos usados por FakeQueryBuilder ───
+
+  _tableConfig(table: string): FakeTableConfig {
+    if (!this.tables.has(table)) this.tables.set(table, { rows: [] });
+    return this.tables.get(table) as FakeTableConfig;
+  }
+
+  _nextCallIndex(table: string, method: FakeMethod): number {
+    const key = `${table}:${method}`;
+    const next = (this.callCounts.get(key) ?? 0) + 1;
+    this.callCounts.set(key, next);
+    return next;
+  }
+
+  _takeFailure(table: string, method: FakeMethod, callIndex: number): FakeSupabaseError | null {
+    const idx = this.failures.findIndex(
+      (f) => f.table === table && f.method === method && f.callIndex === callIndex
+    );
+    if (idx === -1) return null;
+    return this.failures[idx].error;
+  }
+}
+
+export function createFakeSupabaseClient(): FakeSupabaseClient {
+  return new FakeSupabaseClient();
+}


### PR DESCRIPTION
## Summary
- `pullSyncTable` hacía `select("*")` sin paginar, y Supabase limita las respuestas a `max_rows=1000` (`supabase/config.toml`) — cualquier tabla de sync con más de 1000 registros modificados entre ciclos se truncaba **en silencio**, sin error.
- Mismo bug que ya se arregló en `pullMasterTable` (PR #15), repetido acá sin corregir.
- Pagina por keyset ascendente en `id` (no offset, para no saltear filas insertadas durante el pull) y captura el watermark de `last_modified` al inicio del pull, persistiéndolo solo si todas las páginas se procesaron sin error.

Primer PR de una cadena de 6 (`sync-engine-entrega-garantizada`), apilados en orden de riesgo. Este es el más urgente: corta una pérdida de datos silenciosa que puede estar ocurriendo hoy en producción.

## Test plan
- [x] `npm run test:run` — 93/93 (89 previos + 4 nuevos)
- [x] `npx tsc --noEmit` — limpio
- [x] `npm run lint` — sin errores nuevos
- [x] Confirmado que `pullMasterTable` no se tocó