### PR TITLE
feat(sync): reintentos con backoff exponencial y estado failed terminal

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -30,6 +30,7 @@ import type {
   InformeVersion,
   ChangeLog,
   SyncMeta,
+  SyncRetry,
 } from "./types";
 import type {
   ConvLevantamientoSetup,
@@ -84,6 +85,8 @@ class EyCDatabase extends Dexie {
   informe_versiones!: EntityTable<InformeVersion, "id">;
   change_logs!: EntityTable<ChangeLog, "id">;
   sync_meta!: EntityTable<SyncMeta, "table_name">;
+  /** Clave compuesta `[table_name+record_id]` — Dexie no soporta EntityTable con PK compuesta */
+  sync_retry!: Dexie.Table<SyncRetry, [string, string]>;
 
   // ─── Convencional (tablas dedicadas) ───
   conv_levantamiento_setup!: EntityTable<ConvLevantamientoSetup, "id">;
@@ -311,6 +314,14 @@ class EyCDatabase extends Dexie {
     // ─────────────────────────────────────────────────────────────
     this.version(14).stores({
       equipo_movimientos: "id, equipo_id, ubicacion_nueva_id, sync_status",
+    });
+
+    // ─────────────────────────────────────────────────────────────
+    //  v15 — retry con backoff exponencial para push fallido.
+    //  Tabla nueva, aditiva — no migra ni toca tablas existentes.
+    // ─────────────────────────────────────────────────────────────
+    this.version(15).stores({
+      sync_retry: "&[table_name+record_id], table_name, next_attempt_at",
     });
   }
 }

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -4,12 +4,34 @@
 // ============================================================
 
 /** Estado de sincronización para registros offline */
-export type SyncStatus = "pending" | "synced" | "conflict" | "error";
+export type SyncStatus = "pending" | "synced" | "conflict" | "error" | "failed";
 
 /** Campos comunes de sincronización */
 export interface SyncFields {
   sync_status: SyncStatus;
   last_modified: string; // ISO timestamp
+}
+
+// ─── Retry con backoff exponencial ───
+
+/**
+ * Estado de reintento de un registro que falló al pushear a Supabase.
+ * Clave compuesta `[table_name+record_id]` — una fila por registro con
+ * push pendiente/fallido. Se borra al lograr un push exitoso.
+ */
+export interface SyncRetry {
+  table_name: string;
+  record_id: string;
+  /** Número de intentos consumidos, 1..MAX_ATTEMPTS (ver sync-retry.ts) */
+  attempts: number;
+  /** ISO timestamp — no reintentar automáticamente antes de esta hora */
+  next_attempt_at: string;
+  /** "retrying" mientras queden intentos disponibles; "failed" cuando se agotan o el error es permanente */
+  status: "retrying" | "failed";
+  last_error: string;
+  /** Código de error de Postgres/PostgREST, si está disponible */
+  last_error_code?: string;
+  updated_at: string;
 }
 
 // ─── Tipos de equipo ───

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -19,7 +19,7 @@ vi.mock("./client", () => ({
 
 // Import estático: `vi.mock` se hoistea sobre los imports, así que el mock
 // de "./client" ya está activo cuando `sync-engine.ts` se evalúa.
-import { fullSync, pullSyncTable } from "./sync-engine";
+import { fullSync, pullSyncTable, pushAllPending, retryRecord } from "./sync-engine";
 
 // ============================================================
 //  pullSyncTable — paginación keyset (PR1: sync-engine-entrega-garantizada)
@@ -144,5 +144,75 @@ describe("sync-engine — fullSync (integración con pullSyncTable)", () => {
     await expect(db.clientes.count()).resolves.toBe(3);
     const meta = await db.sync_meta.get("clientes");
     expect(meta?.last_pulled_at).toBeDefined();
+  });
+});
+
+// ============================================================
+//  Push con schedule de retry (PR2: sync-engine-entrega-garantizada)
+//
+//  Un registro con una fila en `sync_retry` cuyo `next_attempt_at` está
+//  en el futuro no debe volver a pushearse en el ciclo automático hasta
+//  que llegue esa hora. `retryRecord` permite al técnico saltarse ese
+//  schedule y forzar el push inmediato de un registro puntual.
+// ============================================================
+
+describe("sync-engine — push respeta el schedule de sync_retry", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("no vuelve a pushear un registro con next_attempt_at en el futuro", async () => {
+    await db.clientes.put({
+      id: "id-pending",
+      nombre_cliente: "Cliente pendiente",
+      nit: "NIT-1",
+      sync_status: "pending",
+    });
+
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    await db.sync_retry.put({
+      table_name: "clientes",
+      record_id: "id-pending",
+      attempts: 2,
+      next_attempt_at: futureIso,
+      status: "retrying",
+      last_error: "network error",
+      updated_at: new Date().toISOString(),
+    });
+
+    const { pushed } = await pushAllPending();
+
+    expect(pushed).toBe(0);
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(0);
+    const record = await db.clientes.get("id-pending");
+    expect(record?.sync_status).toBe("pending");
+  });
+
+  it("retryRecord pushea inmediatamente saltándose el schedule de next_attempt_at futuro", async () => {
+    await db.clientes.put({
+      id: "id-pending",
+      nombre_cliente: "Cliente pendiente",
+      nit: "NIT-1",
+      sync_status: "pending",
+    });
+
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    await db.sync_retry.put({
+      table_name: "clientes",
+      record_id: "id-pending",
+      attempts: 2,
+      next_attempt_at: futureIso,
+      status: "retrying",
+      last_error: "network error",
+      updated_at: new Date().toISOString(),
+    });
+
+    await retryRecord("clientes", "id-pending");
+
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(1);
+    const record = await db.clientes.get("id-pending");
+    expect(record?.sync_status).toBe("synced");
+    await expect(db.sync_retry.get(["clientes", "id-pending"])).resolves.toBeUndefined();
   });
 });

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -3,6 +3,7 @@ import { createClient } from "./client";
 import type { SyncStatus } from "@/lib/db/types";
 import { logger } from "@/lib/logger";
 import type { EntityTable } from "dexie";
+import { isDue, recordFailure, recordSuccess } from "./sync-retry";
 
 type SyncableRecord = { id?: string; sync_status?: SyncStatus; [key: string]: unknown };
 
@@ -316,6 +317,13 @@ async function pushTable(
 
   for (const record of pending) {
     const localId = record.id as string;
+
+    // Un registro con retry programado no se vuelve a pushear en el
+    // ciclo automático hasta que llegue su `next_attempt_at` — evita
+    // martillar el backend con el mismo error en cada ciclo de sync.
+    const retry = await db.sync_retry.get([localTable, localId]);
+    if (retry && !isDue(retry)) continue;
+
     const data = prepareForRemote(record as Record<string, unknown>, localTable);
 
     try {
@@ -327,10 +335,14 @@ async function pushTable(
         sync_status: "synced" as SyncStatus,
         last_modified: new Date().toISOString(),
       });
+      await recordSuccess(localTable, localId);
 
       pushed++;
     } catch (err) {
-      await dexieTable.update(localId, { sync_status: "error" as SyncStatus });
+      const finalStatus = await recordFailure(localTable, localId, err);
+      if (finalStatus === "failed") {
+        await dexieTable.update(localId, { sync_status: "failed" as SyncStatus });
+      }
 
       const { message, detail } = describeError(err);
       errors.push({
@@ -373,6 +385,11 @@ export async function pushSingle(localTable: string, localId: string): Promise<b
     const record = await dexieTable.get(localId);
     if (!record || record.sync_status !== "pending") return false;
 
+    // Igual que en pushTable: si hay un retry programado en el futuro,
+    // no reintentar todavía — el técnico puede forzarlo con retryRecord.
+    const retry = await db.sync_retry.get([localTable, localId]);
+    if (retry && !isDue(retry)) return false;
+
     const data = prepareForRemote(record as Record<string, unknown>, localTable);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -384,12 +401,62 @@ export async function pushSingle(localTable: string, localId: string): Promise<b
       sync_status: "synced" as SyncStatus,
       last_modified: new Date().toISOString(),
     });
+    await recordSuccess(localTable, localId);
 
     logger.info("sync:push-single", `${localTable}#${localId.slice(0, 8)} synced`);
     return true;
   } catch (err) {
+    const finalStatus = await recordFailure(localTable, localId, err);
+    if (finalStatus === "failed") {
+      const dexieTable = getDexieTable(localTable);
+      if (dexieTable) await dexieTable.update(localId, { sync_status: "failed" as SyncStatus });
+    }
     logger.warn("sync:push-single", `${localTable}#${localId} failed (will retry)`, err);
     return false;
+  }
+}
+
+/**
+ * Reintento manual de un registro puntual — se salta el schedule de
+ * backoff de `sync_retry` y fuerza el push inmediato. Pensado para que
+ * el técnico de campo pueda reintentar un registro "failed" sin esperar
+ * al próximo ciclo automático ni depender de un rol de coordinador.
+ */
+export async function retryRecord(localTable: string, localId: string): Promise<void> {
+  const remote = SYNC_TABLES.find((t) => t.local === localTable)?.remote;
+  if (!remote) return;
+
+  const dexieTable = getDexieTable(localTable);
+  if (!dexieTable) return;
+
+  const record = await dexieTable.get(localId);
+  if (!record) return;
+
+  try {
+    const supabase = createClient();
+    const data = prepareForRemote(record as Record<string, unknown>, localTable);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (supabase.from(remote) as any).upsert(data, { onConflict: "id" });
+
+    if (error) throw error;
+
+    await dexieTable.update(localId, {
+      sync_status: "synced" as SyncStatus,
+      last_modified: new Date().toISOString(),
+    });
+    await recordSuccess(localTable, localId);
+
+    logger.info(
+      "sync:retry-record",
+      `${localTable}#${localId.slice(0, 8)} synced (reintento manual)`
+    );
+  } catch (err) {
+    const finalStatus = await recordFailure(localTable, localId, err);
+    if (finalStatus === "failed") {
+      await dexieTable.update(localId, { sync_status: "failed" as SyncStatus });
+    }
+    logger.warn("sync:retry-record", `${localTable}#${localId} reintento manual falló`, err);
   }
 }
 

--- a/src/lib/supabase/sync-retry.test.ts
+++ b/src/lib/supabase/sync-retry.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import {
+  computeBackoffDelayMs,
+  isDue,
+  isPermanent,
+  MAX_ATTEMPTS,
+  recordFailure,
+  recordSuccess,
+} from "./sync-retry";
+
+// ============================================================
+//  sync-retry — backoff exponencial + clasificación de errores
+//  (PR2: sync-engine-entrega-garantizada)
+// ============================================================
+
+const TABLE = "clientes";
+const RECORD_ID = "id-0001";
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+function setOnline(online: boolean): void {
+  vi.spyOn(navigator, "onLine", "get").mockReturnValue(online);
+}
+
+function expectWithinJitter(actualMs: number, baseMs: number): void {
+  expect(actualMs).toBeGreaterThanOrEqual(Math.floor(baseMs * 0.8));
+  expect(actualMs).toBeLessThanOrEqual(Math.ceil(baseMs * 1.2));
+}
+
+describe("sync-retry", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    // Solo se mockea `Date` — fake-indexeddb depende de macrotasks reales
+    // (setTimeout/queueMicrotask) para resolver sus transacciones, así
+    // que faltear el reloj completo (`vi.useFakeTimers()`) cuelga los
+    // tests que tocan Dexie.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(NOW);
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("backoff exacto", () => {
+    it("intento 1 falla → próximo intento en ~1min (±20% jitter)", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(1);
+      expect(retry?.status).toBe("retrying");
+
+      const deltaMs = new Date(retry!.next_attempt_at).getTime() - NOW.getTime();
+      expectWithinJitter(deltaMs, 60_000);
+    });
+
+    it("intento 2 falla → próximo intento en ~4min (±20% jitter)", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(2);
+      expect(retry?.status).toBe("retrying");
+
+      const deltaMs = new Date(retry!.next_attempt_at).getTime() - NOW.getTime();
+      expectWithinJitter(deltaMs, 240_000);
+    });
+
+    it("intento 3 falla → próximo intento en ~16min (±20% jitter)", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(3);
+      expect(retry?.status).toBe("retrying");
+
+      const deltaMs = new Date(retry!.next_attempt_at).getTime() - NOW.getTime();
+      expectWithinJitter(deltaMs, 960_000);
+    });
+
+    it("intento 4 falla → próximo intento en ~60min (tope, ±20% jitter)", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(4);
+      expect(retry?.status).toBe("retrying");
+
+      const deltaMs = new Date(retry!.next_attempt_at).getTime() - NOW.getTime();
+      expectWithinJitter(deltaMs, 3_600_000);
+    });
+
+    it("intento 5 falla → sync_status pasa a 'failed', sin más reintentos automáticos", async () => {
+      for (let i = 0; i < MAX_ATTEMPTS; i++) {
+        await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      }
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(MAX_ATTEMPTS);
+      expect(retry?.status).toBe("failed");
+    });
+  });
+
+  describe("clasificación de códigos de error", () => {
+    const PERMANENT_CODES = ["23505", "23502", "22P02", "42703", "PGRST204", "42501"];
+
+    it.each(PERMANENT_CODES)(
+      "código permanente %s → 'failed' directo en el intento 1",
+      async (code) => {
+        expect(isPermanent(code)).toBe(true);
+
+        await recordFailure(TABLE, RECORD_ID, { message: "constraint violation", code });
+
+        const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+        expect(retry?.attempts).toBe(1);
+        expect(retry?.status).toBe("failed");
+      }
+    );
+
+    const TRANSIENT_CODES = ["fetch failed", "500", "503", "429", "PGRST301", "23503"];
+
+    it.each(TRANSIENT_CODES)(
+      "código transitorio %s → consume un intento y programa retry",
+      async (code) => {
+        expect(isPermanent(code)).toBe(false);
+
+        await recordFailure(TABLE, RECORD_ID, { message: "transient error", code });
+
+        const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+        expect(retry?.attempts).toBe(1);
+        expect(retry?.status).toBe("retrying");
+      }
+    );
+
+    it("código desconocido/no mapeado → se trata como transitorio por defecto", async () => {
+      expect(isPermanent("XX999")).toBe(false);
+
+      await recordFailure(TABLE, RECORD_ID, { message: "unknown error", code: "XX999" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(1);
+      expect(retry?.status).toBe("retrying");
+    });
+
+    it("error sin código → se trata como transitorio por defecto", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network drop" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(1);
+      expect(retry?.status).toBe("retrying");
+    });
+  });
+
+  describe("éxito", () => {
+    it("recordSuccess borra la fila correspondiente de sync_retry", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await expect(db.sync_retry.get([TABLE, RECORD_ID])).resolves.toBeDefined();
+
+      await recordSuccess(TABLE, RECORD_ID);
+
+      await expect(db.sync_retry.get([TABLE, RECORD_ID])).resolves.toBeUndefined();
+    });
+
+    it("recordSuccess sobre un registro sin fila de retry no falla", async () => {
+      await expect(recordSuccess(TABLE, RECORD_ID)).resolves.not.toThrow();
+    });
+  });
+
+  describe("offline", () => {
+    it("no incrementa el contador de intentos cuando navigator.onLine es false", async () => {
+      setOnline(false);
+
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry).toBeUndefined();
+    });
+
+    it("no incrementa el contador de intentos si ya existía una fila y se cae offline", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      const before = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(before?.attempts).toBe(1);
+
+      setOnline(false);
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const after = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(after?.attempts).toBe(1);
+    });
+  });
+
+  describe("isDue", () => {
+    it("retorna true cuando next_attempt_at ya pasó", () => {
+      const past = new Date(NOW.getTime() - 1000).toISOString();
+      expect(isDue({ next_attempt_at: past })).toBe(true);
+    });
+
+    it("retorna false cuando next_attempt_at está en el futuro", () => {
+      const future = new Date(NOW.getTime() + 60_000).toISOString();
+      expect(isDue({ next_attempt_at: future })).toBe(false);
+    });
+  });
+
+  describe("computeBackoffDelayMs", () => {
+    it("respeta el tope de 60 minutos incluso en intentos altos", () => {
+      const delay = computeBackoffDelayMs(10);
+      expectWithinJitter(delay, 3_600_000);
+    });
+  });
+});

--- a/src/lib/supabase/sync-retry.ts
+++ b/src/lib/supabase/sync-retry.ts
@@ -1,0 +1,136 @@
+import { db } from "@/lib/db";
+import type { SyncRetry } from "@/lib/db/types";
+import { logger } from "@/lib/logger";
+
+// ============================================================
+//  Retry con backoff exponencial para push fallido a Supabase.
+//
+//  delay(n) = min(60_000 * 4^(n-1), 3_600_000) ms, ±20% jitter aleatorio.
+//  1 → ~1min, 2 → ~4min, 3 → ~16min, 4 → ~60min (tope), 5 → agota
+//  el ciclo y el registro pasa a sync_status="failed" (terminal, sin
+//  más reintentos automáticos — el técnico puede forzar uno manual
+//  con `retryRecord`, ver sync-engine.ts).
+// ============================================================
+
+export const MAX_ATTEMPTS = 5;
+
+const BASE_DELAY_MS = 60_000;
+const MAX_DELAY_MS = 3_600_000;
+const JITTER_RATIO = 0.2;
+
+/** Códigos de error de Postgres/PostgREST que nunca se resuelven reintentando. */
+const PERMANENT_ERROR_CODES = new Set([
+  "23505", // unique_violation
+  "23502", // not_null_violation
+  "22P02", // invalid_text_representation (invalid input syntax)
+  "42703", // undefined_column (schema mismatch)
+  "PGRST204", // PostgREST: columna no encontrada en el schema cache
+  "42501", // insufficient_privilege (RLS)
+]);
+
+/**
+ * Un código de error se considera permanente solo si está en la lista
+ * explícita. Cualquier código desconocido/no mapeado, o la ausencia de
+ * código, se trata como transitorio por defecto — preferimos reintentar
+ * de más a fallar de más.
+ */
+export function isPermanent(code?: string): boolean {
+  if (!code) return false;
+  return PERMANENT_ERROR_CODES.has(code);
+}
+
+/**
+ * Calcula el delay en ms para el intento `attempt` (1-based) con jitter
+ * aleatorio de ±20% para evitar reintentos sincronizados entre clientes.
+ */
+export function computeBackoffDelayMs(attempt: number): number {
+  const base = Math.min(BASE_DELAY_MS * 4 ** (attempt - 1), MAX_DELAY_MS);
+  const jitterFactor = 1 + (Math.random() * 2 - 1) * JITTER_RATIO;
+  return Math.round(base * jitterFactor);
+}
+
+function extractErrorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}
+
+function extractErrorMessage(err: unknown): string {
+  if (err && typeof err === "object" && "message" in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(err);
+}
+
+/**
+ * Registra un intento de push fallido para `table`#`id`.
+ *
+ * - Si está offline (`!navigator.onLine`), NO consume un intento — el
+ *   fallo es de conectividad, no del registro, así que no debe gastar
+ *   el presupuesto de reintentos.
+ * - Si el código de error es permanente, marca "failed" directo en el
+ *   intento 1 sin agotar el ciclo completo.
+ * - Si se alcanza `MAX_ATTEMPTS`, marca "failed".
+ * - En cualquier otro caso, programa el próximo intento con backoff
+ *   exponencial + jitter y deja el status en "retrying".
+ *
+ * Devuelve el status final ("retrying" | "failed") para que el llamador
+ * decida si debe reflejar sync_status="failed" en la tabla Dexie local.
+ */
+export async function recordFailure(
+  table: string,
+  id: string,
+  error: unknown
+): Promise<SyncRetry["status"]> {
+  if (!navigator.onLine) {
+    logger.warn("sync:retry", `Fallo offline en ${table}#${id} — no se cuenta como intento`, error);
+    return "retrying";
+  }
+
+  const code = extractErrorCode(error);
+  const message = extractErrorMessage(error);
+  const now = new Date();
+
+  const existing = await db.sync_retry.get([table, id]);
+  const attempts = (existing?.attempts ?? 0) + 1;
+  const permanent = isPermanent(code);
+  const exhausted = attempts >= MAX_ATTEMPTS;
+  const status: SyncRetry["status"] = permanent || exhausted ? "failed" : "retrying";
+
+  const nextAttemptAt =
+    status === "failed"
+      ? now.toISOString()
+      : new Date(now.getTime() + computeBackoffDelayMs(attempts)).toISOString();
+
+  await db.sync_retry.put({
+    table_name: table,
+    record_id: id,
+    attempts,
+    next_attempt_at: nextAttemptAt,
+    status,
+    last_error: message,
+    last_error_code: code,
+    updated_at: now.toISOString(),
+  });
+
+  logger.warn(
+    "sync:retry",
+    `${table}#${id.slice(0, 8)} intento ${attempts}/${MAX_ATTEMPTS} — ${status}`,
+    { code, message }
+  );
+
+  return status;
+}
+
+/** Push exitoso — borra la fila de seguimiento de reintentos, si existe. */
+export async function recordSuccess(table: string, id: string): Promise<void> {
+  await db.sync_retry.delete([table, id]);
+}
+
+/** Verdadero si ya llegó la hora programada del próximo intento. */
+export function isDue(retry: Pick<SyncRetry, "next_attempt_at">): boolean {
+  return new Date(retry.next_attempt_at).getTime() <= Date.now();
+}


### PR DESCRIPTION
Segundo PR de la cadena (`sync-engine-entrega-garantizada`), apilado sobre #17.

## Summary
- `pushSingle`/`pushTable` dejaban un registro en `sync_status="pending"` indefinidamente si el push fallaba, reintentando cada 5 min para siempre sin distinguir un fallo transitorio de uno permanente.
- Agrega tabla `sync_retry` (Dexie v15, aditiva) que trackea intentos y programa el próximo reintento con backoff exponencial (1m/4m/16m/60m, ±20% jitter). Al 5° intento fallido, o ante un código de error permanente (constraint, RLS, schema mismatch), el registro pasa a `sync_status="failed"`. Offline no consume intentos.
- Agrega `retryRecord()` para que el técnico de campo pueda forzar el reintento de un registro `failed` sin pasar por un coordinador.

## Test plan
- [x] `npm run test:run` — 121/121
- [x] `npx tsc --noEmit` — limpio
- [x] Auditados los 37 call sites de `pushSingle`: ninguno depende del valor de retorno