### PR TITLE
fix(sync): lock single-flight para evitar syncs concurrentes

### DIFF
--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -216,3 +216,52 @@ describe("sync-engine — push respeta el schedule de sync_retry", () => {
     await expect(db.sync_retry.get(["clientes", "id-pending"])).resolves.toBeUndefined();
   });
 });
+
+// ============================================================
+//  Lock de concurrencia (PR3: sync-engine-entrega-garantizada)
+//
+//  fullSync/pushAllPending están envueltos con withSyncLock (ver
+//  sync-lock.ts) para que solo un ciclo de sync corra a la vez —
+//  necesario porque el Service Worker dispara SYNC_REQUESTED a cada
+//  tab abierta (sw-register.tsx) y cada una corre fullSync() en su
+//  propio contexto.
+// ============================================================
+
+describe("sync-engine — lock de concurrencia", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("fullSync: una segunda llamada concurrente se omite con un error _lock, sin duplicar el ciclo", async () => {
+    const [first, second] = await Promise.all([fullSync(), fullSync()]);
+
+    expect(first.errors.find((e) => e.table === "_lock")).toBeUndefined();
+    expect(second.pushed).toBe(0);
+    expect(second.pulled).toBe(0);
+    expect(second.errors).toEqual([
+      {
+        table: "_lock",
+        recordId: "0",
+        error: "Sincronización omitida: ya hay otra sincronización en curso",
+        action: "push",
+      },
+    ]);
+  });
+
+  it("pushAllPending: la segunda llamada concurrente se omite y no duplica el push del mismo registro pendiente", async () => {
+    await db.clientes.put({
+      id: "id-concurrent",
+      nombre_cliente: "Cliente concurrente",
+      nit: "NIT-CONC",
+      sync_status: "pending",
+    });
+
+    const [first, second] = await Promise.all([pushAllPending(), pushAllPending()]);
+
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(1);
+    expect(first.pushed + second.pushed).toBe(1);
+    const record = await db.clientes.get("id-concurrent");
+    expect(record?.sync_status).toBe("synced");
+  });
+});

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -4,6 +4,7 @@ import type { SyncStatus } from "@/lib/db/types";
 import { logger } from "@/lib/logger";
 import type { EntityTable } from "dexie";
 import { isDue, recordFailure, recordSuccess } from "./sync-retry";
+import { withSyncLock } from "./sync-lock";
 
 type SyncableRecord = { id?: string; sync_status?: SyncStatus; [key: string]: unknown };
 
@@ -210,10 +211,38 @@ const MASTER_TABLES = [
 ] as const;
 
 /**
- * Ejecuta un ciclo completo de sincronización.
- * Push primero (para no perder cambios locales), luego Pull.
+ * Ejecuta un ciclo completo de sincronización, protegido por
+ * `withSyncLock` (single-flight — ver sync-lock.ts) para evitar que
+ * dos disparadores (botón manual, auto-sync, mensaje del Service
+ * Worker a otra pestaña) corran fullSync al mismo tiempo.
+ *
+ * Si ya hay una sincronización en curso, el ciclo se omite y se
+ * refleja como un error `_lock` en `result.errors` — mismo patrón que
+ * el error `_auth` cuando no hay sesión — sin romper el contrato de
+ * retorno `SyncResult` que ya consumen los callers existentes.
  */
 export async function fullSync(): Promise<SyncResult> {
+  const lockResult = await withSyncLock(runFullSync);
+  if (!lockResult.ran) {
+    logger.info("sync:lock", "fullSync omitido: ya hay una sincronización en curso");
+    return {
+      pushed: 0,
+      pulled: 0,
+      errors: [
+        {
+          table: "_lock",
+          recordId: "0",
+          error: "Sincronización omitida: ya hay otra sincronización en curso",
+          action: "push",
+        },
+      ],
+      timestamp: new Date().toISOString(),
+    };
+  }
+  return lockResult.value;
+}
+
+async function runFullSync(): Promise<SyncResult> {
   const result: SyncResult = {
     pushed: 0,
     pulled: 0,
@@ -463,8 +492,23 @@ export async function retryRecord(localTable: string, localId: string): Promise<
 /**
  * Push de todos los registros pendientes (sin pull).
  * Usado por el auto-sync periódico — más liviano que fullSync.
+ *
+ * Protegido por `withSyncLock` (single-flight — ver sync-lock.ts) para
+ * no correr en paralelo con otro pushAllPending o con fullSync. Si ya
+ * hay una sincronización en curso, se omite este ciclo — mismo shape
+ * de retorno que el caso offline (`{ pushed: 0, errors: 0 }`), solo
+ * distinguible por el log emitido.
  */
 export async function pushAllPending(): Promise<{ pushed: number; errors: number }> {
+  const lockResult = await withSyncLock(runPushAllPending);
+  if (!lockResult.ran) {
+    logger.info("sync:lock", "pushAllPending omitido: ya hay una sincronización en curso");
+    return { pushed: 0, errors: 0 };
+  }
+  return lockResult.value;
+}
+
+async function runPushAllPending(): Promise<{ pushed: number; errors: number }> {
   if (!navigator.onLine) return { pushed: 0, errors: 0 };
 
   const supabase = createClient();

--- a/src/lib/supabase/sync-lock.test.ts
+++ b/src/lib/supabase/sync-lock.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withSyncLock } from "./sync-lock";
+
+// ============================================================
+//  withSyncLock — lock de concurrencia (PR3: sync-engine-entrega-garantizada)
+//
+//  happy-dom (entorno de test de Vitest, ver vitest.config.ts) NO
+//  implementa la Web Locks API — `navigator.locks` es falsy (`null` en
+//  happy-dom) en todos estos tests, así que ejercitan el fallback en
+//  memoria del módulo, no `navigator.locks.request`. Ver sync-lock.ts
+//  para el camino real usado en navegadores que sí la soportan.
+// ============================================================
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("sync-lock — withSyncLock", () => {
+  beforeEach(() => {
+    expect(navigator.locks).toBeFalsy();
+  });
+
+  it("ejecuta el spy una sola vez con dos llamadas concurrentes; la segunda queda locked sin ejecutar el spy", async () => {
+    const spy = vi.fn(async () => {
+      await delay(20);
+      return "ok";
+    });
+
+    const [first, second] = await Promise.all([withSyncLock(spy), withSyncLock(spy)]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ ran: true, value: "ok" });
+    expect(second).toEqual({ ran: false, reason: "locked" });
+  });
+
+  it("libera el lock si la función protegida lanza una excepción — un intento posterior puede correr", async () => {
+    const failing = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(withSyncLock(failing)).rejects.toThrow("boom");
+
+    const recovering = vi.fn(async () => "recovered");
+    const result = await withSyncLock(recovering);
+
+    expect(recovering).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ran: true, value: "recovered" });
+  });
+
+  it("da single-flight vía el fallback en memoria cuando navigator.locks es undefined (happy-dom)", async () => {
+    expect(navigator.locks).toBeFalsy();
+
+    const spy = vi.fn(async () => {
+      await delay(10);
+      return "fallback-ok";
+    });
+
+    const results = await Promise.all([withSyncLock(spy), withSyncLock(spy), withSyncLock(spy)]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(results.filter((r) => r.ran)).toHaveLength(1);
+    expect(results.filter((r) => !r.ran)).toHaveLength(2);
+  });
+});

--- a/src/lib/supabase/sync-lock.ts
+++ b/src/lib/supabase/sync-lock.ts
@@ -1,0 +1,64 @@
+// ============================================================
+//  Lock de concurrencia para evitar sincronizaciones simultáneas.
+//
+//  Usa la Web Locks API (`navigator.locks`) cuando el navegador la
+//  soporta: el lock "eyc-sync" es efectivo ENTRE PESTAÑAS del mismo
+//  origen, lo cual es necesario porque el Service Worker dispara
+//  "SYNC_REQUESTED" a cada tab abierta (ver sw-register.tsx) y cada
+//  una corre fullSync()/pushAllPending() en su propio contexto JS —
+//  sin este lock, dos tabs podrían pushear/pullear al mismo tiempo.
+//
+//  Fallback en memoria: si `navigator.locks` no existe (navegadores
+//  viejos, o el entorno de test happy-dom, que no implementa Web
+//  Locks), se usa un guard a nivel de módulo. Este fallback SOLO
+//  protege single-flight DENTRO de la misma pestaña/proceso — NO
+//  evita que dos pestañas distintas corran el sync a la vez — pero
+//  es mejor que nada para navegadores sin soporte de Web Locks.
+// ============================================================
+
+const LOCK_NAME = "eyc-sync";
+
+export type SyncLockResult<T> = { ran: true; value: T } | { ran: false; reason: "locked" };
+
+let inMemoryLocked = false;
+
+async function withInMemoryLock<T>(fn: () => Promise<T>): Promise<SyncLockResult<T>> {
+  if (inMemoryLocked) {
+    return { ran: false, reason: "locked" };
+  }
+
+  inMemoryLocked = true;
+  try {
+    const value = await fn();
+    return { ran: true, value };
+  } finally {
+    inMemoryLocked = false;
+  }
+}
+
+/**
+ * Ejecuta `fn` protegida por un lock exclusivo de sync (single-flight).
+ * Si ya hay una sincronización en curso, `fn` NO se ejecuta y se
+ * devuelve `{ ran: false, reason: "locked" }` en su lugar.
+ *
+ * El lock se libera automáticamente (Web Locks o fallback en memoria)
+ * cuando `fn` termina, ya sea con éxito o con excepción — un intento
+ * posterior siempre puede volver a adquirirlo.
+ */
+export async function withSyncLock<T>(fn: () => Promise<T>): Promise<SyncLockResult<T>> {
+  if (typeof navigator === "undefined" || !navigator.locks) {
+    return withInMemoryLock(fn);
+  }
+
+  return navigator.locks.request(
+    LOCK_NAME,
+    { ifAvailable: true, mode: "exclusive" },
+    async (lock) => {
+      if (!lock) {
+        return { ran: false, reason: "locked" };
+      }
+      const value = await fn();
+      return { ran: true, value };
+    }
+  );
+}


### PR DESCRIPTION
Tercer PR de la cadena (`sync-engine-entrega-garantizada`), apilado sobre el PR de retry/backoff.

## Summary
- `fullSync`/`pushAllPending` podían correr en paralelo desde sus 3 disparadores independientes (botón manual, auto-sync periódico, Service Worker vía `postMessage` a cada tab abierta), sin ninguna coordinación entre ellos.
- Envuelve ambas funciones con `withSyncLock`, que usa la Web Locks API (cross-tab, same-origin) cuando el navegador la soporta, con fallback a un guard en memoria (solo same-tab) para navegadores sin soporte. Un sync bloqueado se salta en vez de encolarse o fallar.

## Test plan
- [x] `npm run test:run` — 126/126
- [x] `npx tsc --noEmit` — limpio
- [x] Confirmado que los 3 disparadores pasan por el lock