### PR TITLE
feat(sync): indicador global de pendientes/errores y reintento manual

### DIFF
--- a/src/app/dashboard/sync/page.tsx
+++ b/src/app/dashboard/sync/page.tsx
@@ -23,6 +23,7 @@ import {
   checkSyncStatus,
   getErrorRecords,
   retryErrorRecords,
+  retryRecord,
   type SyncResult,
   type ErrorRecord,
 } from "@/lib/supabase/sync-engine";
@@ -40,6 +41,7 @@ export default function SyncPage() {
   const [lastResult, setLastResult] = useState<SyncResult | null>(null);
   const [errorRecords, setErrorRecords] = useState<ErrorRecord[]>([]);
   const [errorsExpanded, setErrorsExpanded] = useState(false);
+  const [retryingRecordId, setRetryingRecordId] = useState<string | null>(null);
 
   const refreshStatus = useCallback(async () => {
     const s = await checkSyncStatus();
@@ -88,6 +90,22 @@ export default function SyncPage() {
       await refreshStatus();
     } finally {
       setRetrying(false);
+    }
+  }
+
+  /**
+   * Reintento manual de un registro puntual con sync_status="failed" —
+   * terminal, no lo toca `retryErrorRecords()` (solo mueve "error" a
+   * "pending"). El técnico de campo puede forzarlo libremente, sin
+   * gate de rol (ver retryRecord en sync-engine.ts).
+   */
+  async function handleRetryRecord(rec: ErrorRecord) {
+    setRetryingRecordId(`${rec.table}-${rec.id}`);
+    try {
+      await retryRecord(rec.table, rec.id);
+      await refreshStatus();
+    } finally {
+      setRetryingRecordId(null);
     }
   }
 
@@ -232,21 +250,53 @@ export default function SyncPage() {
 
             {errorsExpanded && (
               <div className="space-y-2">
-                {errorRecords.map((rec) => (
-                  <div
-                    key={`${rec.table}-${rec.id}`}
-                    className="p-3 bg-white border border-red-200 rounded-xl text-sm font-medium flex items-center gap-3"
-                  >
-                    <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
-                    <div className="min-w-0 flex-1">
-                      <span className="text-red-700 font-black">{rec.tableLabel}</span>
-                      <span className="text-red-500 ml-2 truncate">{rec.preview}</span>
+                {errorRecords.map((rec) => {
+                  const recordKey = `${rec.table}-${rec.id}`;
+                  return (
+                    <div
+                      key={recordKey}
+                      className="p-3 bg-white border border-red-200 rounded-xl text-sm font-medium flex items-center gap-3"
+                    >
+                      <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <div>
+                          <span className="text-red-700 font-black">{rec.tableLabel}</span>
+                          <span className="text-red-500 ml-2 truncate">{rec.preview}</span>
+                          {rec.status === "failed" && (
+                            <span className="ml-2 text-[10px] font-black uppercase tracking-widest text-red-400">
+                              Fallido
+                            </span>
+                          )}
+                        </div>
+                        {typeof rec.attempts === "number" && (
+                          <p className="text-[11px] text-red-400 font-mono mt-0.5">
+                            {rec.attempts} intento{rec.attempts !== 1 ? "s" : ""}
+                            {rec.nextAttemptAt &&
+                              ` — próximo: ${new Date(rec.nextAttemptAt).toLocaleString("es-CO")}`}
+                          </p>
+                        )}
+                      </div>
+                      <span className="text-[10px] text-red-300 font-mono flex-shrink-0">
+                        #{rec.id}
+                      </span>
+                      {rec.status === "failed" && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="rounded-lg font-black text-red-700 hover:bg-red-100 h-8 px-3 flex-shrink-0"
+                          disabled={retryingRecordId === recordKey || !status?.online}
+                          onClick={() => handleRetryRecord(rec)}
+                        >
+                          {retryingRecordId === recordKey ? (
+                            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                          ) : (
+                            <RotateCcw className="w-3.5 h-3.5" />
+                          )}
+                        </Button>
+                      )}
                     </div>
-                    <span className="text-[10px] text-red-300 font-mono flex-shrink-0">
-                      #{rec.id}
-                    </span>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
 

--- a/src/components/connection-badge.tsx
+++ b/src/components/connection-badge.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { Wifi, WifiOff } from "lucide-react";
+import { Wifi, WifiOff, CloudUpload, AlertTriangle } from "lucide-react";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import { useDb } from "@/components/db-provider";
+import { useSyncCounters } from "@/hooks/use-sync-counters";
 
 /**
- * Badge que muestra el estado de conexión y de la base de datos local.
+ * Badge que muestra el estado de conexión, de la base de datos local y
+ * el indicador global de registros pendientes/con error de sincronizar.
  */
 export function ConnectionBadge() {
   const isOnline = useOnlineStatus();
   const { isReady, error } = useDb();
+  const { pendingCount, errorCount } = useSyncCounters();
 
   return (
     <div className="flex items-center gap-2 flex-wrap" role="status" aria-live="polite">
@@ -47,6 +50,26 @@ export function ConnectionBadge() {
         <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-100 border border-slate-200">
           <span className="text-[10px] font-black uppercase tracking-widest text-slate-500">
             Cargando DB...
+          </span>
+        </div>
+      )}
+
+      {/* Pendientes de sincronizar */}
+      {pendingCount > 0 && (
+        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-100 border border-amber-200">
+          <CloudUpload className="w-3 h-3 text-amber-700" />
+          <span className="text-[10px] font-black uppercase tracking-widest text-amber-700">
+            {pendingCount} pendiente{pendingCount !== 1 ? "s" : ""}
+          </span>
+        </div>
+      )}
+
+      {/* Con error de sincronización */}
+      {errorCount > 0 && (
+        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-red-100 border border-red-200">
+          <AlertTriangle className="w-3 h-3 text-red-600" />
+          <span className="text-[10px] font-black uppercase tracking-widest text-red-600">
+            {errorCount} con error
           </span>
         </div>
       )}

--- a/src/hooks/use-sync-counters.test.tsx
+++ b/src/hooks/use-sync-counters.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+
+// `sync-engine.ts` importa `createClient` desde "@/lib/supabase/client",
+// que valida variables de entorno de Supabase al cargarse — no relevante
+// para estos tests (solo se ejercitan los contadores locales de Dexie),
+// así que se stubea igual que en sync-engine.test.ts.
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({}),
+}));
+
+import { countSyncStatuses } from "@/lib/supabase/sync-engine";
+import { useSyncCounters } from "./use-sync-counters";
+
+// ============================================================
+//  Indicador global de pendientes/errores (PR4: sync-engine-entrega-garantizada)
+//
+//  countSyncStatuses() debe sumar "pending" en un contador y "error"+
+//  "failed" juntos en otro, usando .count() indexado de Dexie (nunca
+//  .toArray().length) sobre las mismas SYNC_TABLES que ya usa el motor.
+// ============================================================
+
+describe("countSyncStatuses", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("suma los registros pending en pendingCount", async () => {
+    await db.clientes.put({
+      id: "id-1",
+      nombre_cliente: "Cliente 1",
+      nit: "NIT-1",
+      sync_status: "pending",
+    });
+    await db.sedes.put({
+      id: "id-2",
+      cliente_id: "id-1",
+      nombre_sede: "Sede 1",
+      sync_status: "pending",
+    });
+    await db.clientes.put({
+      id: "id-3",
+      nombre_cliente: "Cliente 3",
+      nit: "NIT-3",
+      sync_status: "synced",
+    });
+
+    const { pendingCount } = await countSyncStatuses();
+
+    expect(pendingCount).toBe(2);
+  });
+
+  it("suma juntos los registros error y failed en errorCount", async () => {
+    await db.clientes.put({
+      id: "id-1",
+      nombre_cliente: "Cliente 1",
+      nit: "NIT-1",
+      sync_status: "error",
+    });
+    await db.clientes.put({
+      id: "id-2",
+      nombre_cliente: "Cliente 2",
+      nit: "NIT-2",
+      sync_status: "failed",
+    });
+    await db.sedes.put({
+      id: "id-3",
+      cliente_id: "id-1",
+      nombre_sede: "Sede 3",
+      sync_status: "error",
+    });
+    await db.clientes.put({
+      id: "id-4",
+      nombre_cliente: "Cliente 4",
+      nit: "NIT-4",
+      sync_status: "synced",
+    });
+
+    const { errorCount } = await countSyncStatuses();
+
+    expect(errorCount).toBe(3);
+  });
+
+  it("devuelve 0/0 cuando no hay registros pending/error/failed", async () => {
+    await db.clientes.put({
+      id: "id-1",
+      nombre_cliente: "Cliente 1",
+      nit: "NIT-1",
+      sync_status: "synced",
+    });
+
+    const { pendingCount, errorCount } = await countSyncStatuses();
+
+    expect(pendingCount).toBe(0);
+    expect(errorCount).toBe(0);
+  });
+});
+
+// ============================================================
+//  useSyncCounters — expone {pendingCount, errorCount} reactivamente
+//  vía useLiveQuery (dexie-react-hooks).
+// ============================================================
+
+function TestComponent() {
+  const { pendingCount, errorCount } = useSyncCounters();
+  return (
+    <div>
+      <span data-testid="pending-count">{pendingCount}</span>
+      <span data-testid="error-count">{errorCount}</span>
+    </div>
+  );
+}
+
+describe("useSyncCounters", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("expone pendingCount y errorCount reactivamente tras sembrar datos", async () => {
+    await db.clientes.put({
+      id: "id-1",
+      nombre_cliente: "Cliente 1",
+      nit: "NIT-1",
+      sync_status: "pending",
+    });
+    await db.clientes.put({
+      id: "id-2",
+      nombre_cliente: "Cliente 2",
+      nit: "NIT-2",
+      sync_status: "failed",
+    });
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pending-count").textContent).toBe("1");
+      expect(screen.getByTestId("error-count").textContent).toBe("1");
+    });
+  });
+});

--- a/src/hooks/use-sync-counters.ts
+++ b/src/hooks/use-sync-counters.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useLiveQuery } from "dexie-react-hooks";
+import { countSyncStatuses } from "@/lib/supabase/sync-engine";
+
+/**
+ * Hook reactivo que expone el indicador global de pendientes/errores
+ * de sincronización. Envuelve `countSyncStatuses()` en `useLiveQuery`
+ * para recalcularse automáticamente cuando cambian las tablas de Dexie
+ * subyacentes (nuevo registro pending, push fallido marcado como error
+ * o failed, reintento exitoso, etc.) sin necesidad de refrescar manual.
+ */
+export function useSyncCounters(): { pendingCount: number; errorCount: number } {
+  const counters = useLiveQuery(() => countSyncStatuses(), []);
+
+  return {
+    pendingCount: counters?.pendingCount ?? 0,
+    errorCount: counters?.errorCount ?? 0,
+  };
+}

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -702,6 +702,17 @@ export interface ErrorRecord {
   tableLabel: string;
   id: string;
   preview: string;
+  /**
+   * "error": recuperable por el ciclo automático — `retryErrorRecords()`
+   * lo vuelve a poner en "pending". "failed": agotó `MAX_ATTEMPTS` o tuvo
+   * un error permanente (ver sync-retry.ts) — es terminal, solo se
+   * reintenta manualmente con `retryRecord(table, id)`.
+   */
+  status: "error" | "failed";
+  /** Intentos consumidos, si el registro tiene fila en `sync_retry` */
+  attempts?: number;
+  /** Próximo intento automático programado, si aplica */
+  nextAttemptAt?: string;
 }
 
 export async function getErrorRecords(): Promise<ErrorRecord[]> {
@@ -712,9 +723,10 @@ export async function getErrorRecords(): Promise<ErrorRecord[]> {
       const dexieTable = getDexieTable(table.local);
       if (!dexieTable) continue;
 
-      const errored = await dexieTable.where("sync_status").equals("error").toArray();
+      const errored = await dexieTable.where("sync_status").anyOf(["error", "failed"]).toArray();
       for (const rec of errored) {
         const id = (rec.id as string) ?? "";
+        const retry = await db.sync_retry.get([table.local, id]);
         results.push({
           table: table.local,
           tableLabel: tableLabel(table.local),
@@ -722,6 +734,9 @@ export async function getErrorRecords(): Promise<ErrorRecord[]> {
           preview: String(
             rec.nombre_cliente ?? rec.nombre ?? rec.nombre_sede ?? rec.codigo ?? id.slice(0, 8)
           ),
+          status: rec.sync_status as "error" | "failed",
+          attempts: retry?.attempts,
+          nextAttemptAt: retry?.next_attempt_at,
         });
       }
     } catch {
@@ -751,6 +766,36 @@ export async function retryErrorRecords(): Promise<number> {
   return count;
 }
 
+// ─── Contadores globales de pendientes/errores ───
+
+/**
+ * Cuenta, entre todas las `SYNC_TABLES`, cuántos registros están en
+ * `sync_status="pending"` y cuántos en `"error"` o `"failed"` (juntos,
+ * en `errorCount`). Usa `.count()` indexado de Dexie — nunca
+ * `.toArray().length` — para no traer los registros completos solo
+ * para contarlos. Base de `useSyncCounters()` (indicador global en la
+ * UI) y reutilizable para diagnóstico fuera de React.
+ */
+export async function countSyncStatuses(): Promise<{ pendingCount: number; errorCount: number }> {
+  let pendingCount = 0;
+  let errorCount = 0;
+
+  for (const table of SYNC_TABLES) {
+    try {
+      const dexieTable = getDexieTable(table.local);
+      if (!dexieTable) continue;
+
+      pendingCount += await dexieTable.where("sync_status").equals("pending").count();
+      errorCount += await dexieTable.where("sync_status").equals("error").count();
+      errorCount += await dexieTable.where("sync_status").equals("failed").count();
+    } catch (err) {
+      logger.error("sync:counters", `Error contando registros en ${table.local}`, err);
+    }
+  }
+
+  return { pendingCount, errorCount };
+}
+
 // ─── Estado de conectividad ───
 
 export async function checkSyncStatus(): Promise<{
@@ -774,19 +819,7 @@ export async function checkSyncStatus(): Promise<{
     }
   }
 
-  let pendingCount = 0;
-  let errorCount = 0;
-  for (const table of SYNC_TABLES) {
-    try {
-      const dexieTable = getDexieTable(table.local);
-      if (dexieTable) {
-        pendingCount += await dexieTable.where("sync_status").equals("pending").count();
-        errorCount += await dexieTable.where("sync_status").equals("error").count();
-      }
-    } catch (err) {
-      logger.error("sync:status", `Error contando registros en ${table.local}`, err);
-    }
-  }
+  const { pendingCount, errorCount } = await countSyncStatuses();
 
   return { online, authenticated, pendingCount, errorCount };
 }


### PR DESCRIPTION
Cuarto PR de la cadena (`sync-engine-entrega-garantizada`), apilado sobre el PR del lock.

## Summary
- El técnico solo veía registros con error de sync visitando `/dashboard/sync` — un fallo podía quedar invisible indefinidamente si nadie entraba ahí.
- Agrega `countSyncStatuses()` (conteo indexado sobre `SYNC_TABLES`) y el hook `useSyncCounters()` (reactivo vía `useLiveQuery`), mostrados como chips en el badge de conexión.
- En `/dashboard/sync`, cada registro `"failed"` ahora muestra sus intentos y próximo reintento, con un botón para forzar el reintento individual sin gate de rol.

## Test plan
- [x] `npm run test:run` — 130/130
- [x] `npx tsc --noEmit` — limpio
- [x] Verificado: 0 hits de `useSyncCounters`/`countSyncStatuses` en `src/lib/workflow` (la visita nunca se bloquea)
- [x] Verificado: 0 `hasPermission` cerca de `retryRecord`