### PR TITLE
docs(sync): corregir estado de las tablas conv_* en el sync bidireccional

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,8 @@
 - **module-completeness.ts**: consulta tablas `conv_*`, no las genericas
 - **module-nav.tsx**: sin modulos viejos hardcodeados
 - **Limpieza**: eliminadas paginas viejas, rutas prefijadas por equipo (`conv/grupo-*`)
+- **Sync bidireccional de tablas `conv_*`**: las 21 tablas ya estan en `SYNC_TABLES` (`lib/supabase/sync-engine.ts`)
+- **Entrega garantizada del sync**: paginacion por keyset en `pullSyncTable` (evita truncamiento silencioso de PostgREST), reintentos con backoff exponencial y estado `failed` terminal, lock single-flight entre disparadores, indicador global de pendientes/errores
 
 ### 🔲 Pendiente — Infraestructura
 
@@ -63,8 +65,7 @@
 - Redimensionamiento y compresion para PDF
 
 #### Sync engine
-- Agregar tablas `conv_*` al sync bidireccional (`lib/supabase/sync-engine.ts`)
-- Crear tablas correspondientes en Supabase (PostgreSQL)
+- Crear tablas correspondientes en Supabase (PostgreSQL) para las 21 `conv_*` — confirmar que existen con el mismo esquema, si no, los push/pull van a fallar en silencio
 - Actualizar `lib/supabase/types.ts` con los tipos de las tablas nuevas
 
 #### Control de cambios (trackChange)

--- a/docs/06-sincronizacion-offline.md
+++ b/docs/06-sincronizacion-offline.md
@@ -15,11 +15,12 @@ Motor: [`src/lib/supabase/sync-engine.ts`](../src/lib/supabase/sync-engine.ts).
 
 | Grupo | Ejemplos | Dirección |
 |-------|----------|-----------|
-| **SYNC_TABLES** (bidireccional) | `clientes`, `sedes`, `equipos`, `solicitudes`, `visitas`, datos de campo | Push + Pull |
+| **SYNC_TABLES** (bidireccional) | `clientes`, `sedes`, `equipos`, `solicitudes`, `visitas`, datos de campo, las 21 tablas `conv_*` | Push + Pull |
 | **MASTER_TABLES** (solo descarga) | `departamentos`, `municipios`, `usuarios`, `prueba_definiciones`, `informes`, `rol_permisos`… | Pull (reemplazo total) |
 
-> **Pendiente:** las tablas `conv_*` aún **no** están en `SYNC_TABLES` ni existen sus tablas en
-> Supabase. Es una tarea abierta en [`../TODO.md`](../TODO.md).
+> **Pendiente:** confirmar que las tablas `conv_*` existen en Supabase con el mismo esquema —
+> el código ya las incluye en `SYNC_TABLES`, pero si la tabla remota no existe el push/pull
+> falla en silencio. Es una tarea abierta en [`../TODO.md`](../TODO.md).
 
 ## 6.3 Ciclo `fullSync()`
 


### PR DESCRIPTION
Quinto PR de la cadena (`sync-engine-entrega-garantizada`), apilado sobre el PR del indicador global.

## Summary
- `TODO.md` y `docs/06-sincronizacion-offline.md` decían que las tablas `conv_*` no estaban en `SYNC_TABLES`, pero ya lo están.
- Documenta las garantías de entrega agregadas en esta cadena de PRs (paginación, retry/backoff, lock, indicador global).
- Deja como pendiente real: confirmar que las 21 tablas `conv_*` existen en Supabase con el mismo esquema.

## Test plan
- [x] `npm run format:check` — sin cambios en el resto del repo