### PR TITLE
fix(sync): cerrar warnings de sdd-verify sobre entrega garantizada

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppSidebar } from "@/components/app-sidebar";
 import { DbProvider } from "@/components/db-provider";
 import { RoleProvider } from "@/components/role-provider";
+import { ConnectionBadge } from "@/components/connection-badge";
 import Image from "next/image";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -35,8 +36,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
               {/* Contenido principal */}
               <main
                 id="main-content"
-                className="flex-1 p-4 sm:p-6 md:p-8 lg:p-10 gradient-bg min-h-screen"
+                className="flex-1 p-4 sm:p-6 md:p-8 lg:p-10 gradient-bg min-h-screen space-y-6"
               >
+                {/* Estado de conexión — visible en todas las pantallas del dashboard */}
+                <ConnectionBadge />
+
                 {children}
               </main>
             </SidebarInset>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,7 +16,6 @@ import {
   Loader2,
 } from "lucide-react";
 import Link from "next/link";
-import { ConnectionBadge } from "@/components/connection-badge";
 
 export default function DashboardPage() {
   const { isReady } = useDb();
@@ -57,9 +56,6 @@ export default function DashboardPage() {
           Resumen general de operaciones
         </p>
       </div>
-
-      {/* Estado de conexión */}
-      <ConnectionBadge />
 
       {/* KPI Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 md:gap-5 lg:gap-6">

--- a/src/components/connection-badge.tsx
+++ b/src/components/connection-badge.tsx
@@ -25,9 +25,9 @@ export function ConnectionBadge() {
           </span>
         </div>
       ) : (
-        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-100 border border-amber-200">
-          <WifiOff className="w-3 h-3 text-amber-700" />
-          <span className="text-[10px] font-black uppercase tracking-widest text-amber-700">
+        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-red-100 border border-red-200">
+          <WifiOff className="w-3 h-3 text-red-600" />
+          <span className="text-[10px] font-black uppercase tracking-widest text-red-600">
             Sin conexión
           </span>
         </div>

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -215,6 +215,27 @@ describe("sync-engine — push respeta el schedule de sync_retry", () => {
     expect(record?.sync_status).toBe("synced");
     await expect(db.sync_retry.get(["clientes", "id-pending"])).resolves.toBeUndefined();
   });
+
+  it("retryRecord pasa por el lock de concurrencia: dos reintentos simultáneos del mismo registro pushean una sola vez", async () => {
+    await db.clientes.put({
+      id: "id-concurrent-retry",
+      nombre_cliente: "Cliente reintento concurrente",
+      nit: "NIT-CR",
+      sync_status: "failed",
+    });
+
+    // Reintento manual del técnico "al mismo tiempo" que un reintento
+    // automático de backoff sobre el mismo registro: el lock permite solo
+    // un intento, el perdedor se salta sin lanzar error.
+    await Promise.all([
+      retryRecord("clientes", "id-concurrent-retry"),
+      retryRecord("clientes", "id-concurrent-retry"),
+    ]);
+
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(1);
+    const record = await db.clientes.get("id-concurrent-retry");
+    expect(record?.sync_status).toBe("synced");
+  });
 });
 
 // ============================================================

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -452,6 +452,21 @@ export async function pushSingle(localTable: string, localId: string): Promise<b
  * al próximo ciclo automático ni depender de un rol de coordinador.
  */
 export async function retryRecord(localTable: string, localId: string): Promise<void> {
+  const result = await withSyncLock(() => retryRecordUnlocked(localTable, localId));
+
+  if (!result.ran) {
+    // Ya hay otra sincronización en curso (reintento automático de backoff,
+    // fullSync o pushAllPending) — el técnico puede volver a tocar el botón
+    // si hace falta. No es un error: el lock permite solo un intento, este
+    // se salta.
+    logger.info(
+      "sync:retry-record",
+      `${localTable}#${localId.slice(0, 8)} reintento manual omitido (sync en curso)`
+    );
+  }
+}
+
+async function retryRecordUnlocked(localTable: string, localId: string): Promise<void> {
   const remote = SYNC_TABLES.find((t) => t.local === localTable)?.remote;
   if (!remote) return;
 


### PR DESCRIPTION
Sexto y último PR de la cadena (`sync-engine-entrega-garantizada`), apilado sobre el PR de docs.

## Summary
- `retryRecord` no pasaba por el lock de concurrencia: un reintento manual del técnico podía correr en paralelo con un reintento automático de backoff sobre el mismo registro. Ahora usa `withSyncLock` (mismo lock que `fullSync`/`pushAllPending`); si hay un sync en curso, se salta sin error.
- `ConnectionBadge` solo se mostraba en `/dashboard` (home). Se mueve al layout compartido de `/dashboard/*`, visible en cualquier pantalla.
- Chip "sin conexión" pasa de ámbar a rojo, para diferenciarse de un simple pendiente.

Cierra los 2 warnings (sin críticos) encontrados por `sdd-verify` sobre esta cadena.

## Test plan
- [x] `npm run test:run` — 131/131
- [x] `npx tsc --noEmit` — limpio
- [x] `npm run lint` / `npm run format:check` — sin cambios respecto al baseline
- [x] Probado manualmente por el usuario (paginación, retry/backoff, reintento manual, lock, indicador global)