### PR TITLE
fix(sync): llevar el resto de la cadena de entrega garantizada a main

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,8 @@
 - **module-completeness.ts**: consulta tablas `conv_*`, no las genericas
 - **module-nav.tsx**: sin modulos viejos hardcodeados
 - **Limpieza**: eliminadas paginas viejas, rutas prefijadas por equipo (`conv/grupo-*`)
+- **Sync bidireccional de tablas `conv_*`**: las 21 tablas ya estan en `SYNC_TABLES` (`lib/supabase/sync-engine.ts`)
+- **Entrega garantizada del sync**: paginacion por keyset en `pullSyncTable` (evita truncamiento silencioso de PostgREST), reintentos con backoff exponencial y estado `failed` terminal, lock single-flight entre disparadores, indicador global de pendientes/errores
 
 ### 🔲 Pendiente — Infraestructura
 
@@ -63,8 +65,7 @@
 - Redimensionamiento y compresion para PDF
 
 #### Sync engine
-- Agregar tablas `conv_*` al sync bidireccional (`lib/supabase/sync-engine.ts`)
-- Crear tablas correspondientes en Supabase (PostgreSQL)
+- Crear tablas correspondientes en Supabase (PostgreSQL) para las 21 `conv_*` — confirmar que existen con el mismo esquema, si no, los push/pull van a fallar en silencio
 - Actualizar `lib/supabase/types.ts` con los tipos de las tablas nuevas
 
 #### Control de cambios (trackChange)

--- a/docs/06-sincronizacion-offline.md
+++ b/docs/06-sincronizacion-offline.md
@@ -15,11 +15,12 @@ Motor: [`src/lib/supabase/sync-engine.ts`](../src/lib/supabase/sync-engine.ts).
 
 | Grupo | Ejemplos | Dirección |
 |-------|----------|-----------|
-| **SYNC_TABLES** (bidireccional) | `clientes`, `sedes`, `equipos`, `solicitudes`, `visitas`, datos de campo | Push + Pull |
+| **SYNC_TABLES** (bidireccional) | `clientes`, `sedes`, `equipos`, `solicitudes`, `visitas`, datos de campo, las 21 tablas `conv_*` | Push + Pull |
 | **MASTER_TABLES** (solo descarga) | `departamentos`, `municipios`, `usuarios`, `prueba_definiciones`, `informes`, `rol_permisos`… | Pull (reemplazo total) |
 
-> **Pendiente:** las tablas `conv_*` aún **no** están en `SYNC_TABLES` ni existen sus tablas en
-> Supabase. Es una tarea abierta en [`../TODO.md`](../TODO.md).
+> **Pendiente:** confirmar que las tablas `conv_*` existen en Supabase con el mismo esquema —
+> el código ya las incluye en `SYNC_TABLES`, pero si la tabla remota no existe el push/pull
+> falla en silencio. Es una tarea abierta en [`../TODO.md`](../TODO.md).
 
 ## 6.3 Ciclo `fullSync()`
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppSidebar } from "@/components/app-sidebar";
 import { DbProvider } from "@/components/db-provider";
 import { RoleProvider } from "@/components/role-provider";
+import { ConnectionBadge } from "@/components/connection-badge";
 import Image from "next/image";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -35,8 +36,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
               {/* Contenido principal */}
               <main
                 id="main-content"
-                className="flex-1 p-4 sm:p-6 md:p-8 lg:p-10 gradient-bg min-h-screen"
+                className="flex-1 p-4 sm:p-6 md:p-8 lg:p-10 gradient-bg min-h-screen space-y-6"
               >
+                {/* Estado de conexión — visible en todas las pantallas del dashboard */}
+                <ConnectionBadge />
+
                 {children}
               </main>
             </SidebarInset>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,7 +16,6 @@ import {
   Loader2,
 } from "lucide-react";
 import Link from "next/link";
-import { ConnectionBadge } from "@/components/connection-badge";
 
 export default function DashboardPage() {
   const { isReady } = useDb();
@@ -57,9 +56,6 @@ export default function DashboardPage() {
           Resumen general de operaciones
         </p>
       </div>
-
-      {/* Estado de conexión */}
-      <ConnectionBadge />
 
       {/* KPI Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 md:gap-5 lg:gap-6">

--- a/src/app/dashboard/sync/page.tsx
+++ b/src/app/dashboard/sync/page.tsx
@@ -23,6 +23,7 @@ import {
   checkSyncStatus,
   getErrorRecords,
   retryErrorRecords,
+  retryRecord,
   type SyncResult,
   type ErrorRecord,
 } from "@/lib/supabase/sync-engine";
@@ -40,6 +41,7 @@ export default function SyncPage() {
   const [lastResult, setLastResult] = useState<SyncResult | null>(null);
   const [errorRecords, setErrorRecords] = useState<ErrorRecord[]>([]);
   const [errorsExpanded, setErrorsExpanded] = useState(false);
+  const [retryingRecordId, setRetryingRecordId] = useState<string | null>(null);
 
   const refreshStatus = useCallback(async () => {
     const s = await checkSyncStatus();
@@ -88,6 +90,22 @@ export default function SyncPage() {
       await refreshStatus();
     } finally {
       setRetrying(false);
+    }
+  }
+
+  /**
+   * Reintento manual de un registro puntual con sync_status="failed" —
+   * terminal, no lo toca `retryErrorRecords()` (solo mueve "error" a
+   * "pending"). El técnico de campo puede forzarlo libremente, sin
+   * gate de rol (ver retryRecord en sync-engine.ts).
+   */
+  async function handleRetryRecord(rec: ErrorRecord) {
+    setRetryingRecordId(`${rec.table}-${rec.id}`);
+    try {
+      await retryRecord(rec.table, rec.id);
+      await refreshStatus();
+    } finally {
+      setRetryingRecordId(null);
     }
   }
 
@@ -232,21 +250,53 @@ export default function SyncPage() {
 
             {errorsExpanded && (
               <div className="space-y-2">
-                {errorRecords.map((rec) => (
-                  <div
-                    key={`${rec.table}-${rec.id}`}
-                    className="p-3 bg-white border border-red-200 rounded-xl text-sm font-medium flex items-center gap-3"
-                  >
-                    <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
-                    <div className="min-w-0 flex-1">
-                      <span className="text-red-700 font-black">{rec.tableLabel}</span>
-                      <span className="text-red-500 ml-2 truncate">{rec.preview}</span>
+                {errorRecords.map((rec) => {
+                  const recordKey = `${rec.table}-${rec.id}`;
+                  return (
+                    <div
+                      key={recordKey}
+                      className="p-3 bg-white border border-red-200 rounded-xl text-sm font-medium flex items-center gap-3"
+                    >
+                      <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <div>
+                          <span className="text-red-700 font-black">{rec.tableLabel}</span>
+                          <span className="text-red-500 ml-2 truncate">{rec.preview}</span>
+                          {rec.status === "failed" && (
+                            <span className="ml-2 text-[10px] font-black uppercase tracking-widest text-red-400">
+                              Fallido
+                            </span>
+                          )}
+                        </div>
+                        {typeof rec.attempts === "number" && (
+                          <p className="text-[11px] text-red-400 font-mono mt-0.5">
+                            {rec.attempts} intento{rec.attempts !== 1 ? "s" : ""}
+                            {rec.nextAttemptAt &&
+                              ` — próximo: ${new Date(rec.nextAttemptAt).toLocaleString("es-CO")}`}
+                          </p>
+                        )}
+                      </div>
+                      <span className="text-[10px] text-red-300 font-mono flex-shrink-0">
+                        #{rec.id}
+                      </span>
+                      {rec.status === "failed" && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="rounded-lg font-black text-red-700 hover:bg-red-100 h-8 px-3 flex-shrink-0"
+                          disabled={retryingRecordId === recordKey || !status?.online}
+                          onClick={() => handleRetryRecord(rec)}
+                        >
+                          {retryingRecordId === recordKey ? (
+                            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                          ) : (
+                            <RotateCcw className="w-3.5 h-3.5" />
+                          )}
+                        </Button>
+                      )}
                     </div>
-                    <span className="text-[10px] text-red-300 font-mono flex-shrink-0">
-                      #{rec.id}
-                    </span>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
 

--- a/src/components/connection-badge.tsx
+++ b/src/components/connection-badge.tsx
@@ -25,9 +25,9 @@ export function ConnectionBadge() {
           </span>
         </div>
       ) : (
-        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-100 border border-amber-200">
-          <WifiOff className="w-3 h-3 text-amber-700" />
-          <span className="text-[10px] font-black uppercase tracking-widest text-amber-700">
+        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-red-100 border border-red-200">
+          <WifiOff className="w-3 h-3 text-red-600" />
+          <span className="text-[10px] font-black uppercase tracking-widest text-red-600">
             Sin conexión
           </span>
         </div>

--- a/src/components/connection-badge.tsx
+++ b/src/components/connection-badge.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { Wifi, WifiOff } from "lucide-react";
+import { Wifi, WifiOff, CloudUpload, AlertTriangle } from "lucide-react";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import { useDb } from "@/components/db-provider";
+import { useSyncCounters } from "@/hooks/use-sync-counters";
 
 /**
- * Badge que muestra el estado de conexión y de la base de datos local.
+ * Badge que muestra el estado de conexión, de la base de datos local y
+ * el indicador global de registros pendientes/con error de sincronizar.
  */
 export function ConnectionBadge() {
   const isOnline = useOnlineStatus();
   const { isReady, error } = useDb();
+  const { pendingCount, errorCount } = useSyncCounters();
 
   return (
     <div className="flex items-center gap-2 flex-wrap" role="status" aria-live="polite">
@@ -47,6 +50,26 @@ export function ConnectionBadge() {
         <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-100 border border-slate-200">
           <span className="text-[10px] font-black uppercase tracking-widest text-slate-500">
             Cargando DB...
+          </span>
+        </div>
+      )}
+
+      {/* Pendientes de sincronizar */}
+      {pendingCount > 0 && (
+        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-100 border border-amber-200">
+          <CloudUpload className="w-3 h-3 text-amber-700" />
+          <span className="text-[10px] font-black uppercase tracking-widest text-amber-700">
+            {pendingCount} pendiente{pendingCount !== 1 ? "s" : ""}
+          </span>
+        </div>
+      )}
+
+      {/* Con error de sincronización */}
+      {errorCount > 0 && (
+        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-red-100 border border-red-200">
+          <AlertTriangle className="w-3 h-3 text-red-600" />
+          <span className="text-[10px] font-black uppercase tracking-widest text-red-600">
+            {errorCount} con error
           </span>
         </div>
       )}

--- a/src/hooks/use-sync-counters.test.tsx
+++ b/src/hooks/use-sync-counters.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+
+// `sync-engine.ts` importa `createClient` desde "@/lib/supabase/client",
+// que valida variables de entorno de Supabase al cargarse — no relevante
+// para estos tests (solo se ejercitan los contadores locales de Dexie),
+// así que se stubea igual que en sync-engine.test.ts.
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({}),
+}));
+
+import { countSyncStatuses } from "@/lib/supabase/sync-engine";
+import { useSyncCounters } from "./use-sync-counters";
+
+// ============================================================
+//  Indicador global de pendientes/errores (PR4: sync-engine-entrega-garantizada)
+//
+//  countSyncStatuses() debe sumar "pending" en un contador y "error"+
+//  "failed" juntos en otro, usando .count() indexado de Dexie (nunca
+//  .toArray().length) sobre las mismas SYNC_TABLES que ya usa el motor.
+// ============================================================
+
+describe("countSyncStatuses", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("suma los registros pending en pendingCount", async () => {
+    await db.clientes.put({
+      id: "id-1",
+      nombre_cliente: "Cliente 1",
+      nit: "NIT-1",
+      sync_status: "pending",
+    });
+    await db.sedes.put({
+      id: "id-2",
+      cliente_id: "id-1",
+      nombre_sede: "Sede 1",
+      sync_status: "pending",
+    });
+    await db.clientes.put({
+      id: "id-3",
+      nombre_cliente: "Cliente 3",
+      nit: "NIT-3",
+      sync_status: "synced",
+    });
+
+    const { pendingCount } = await countSyncStatuses();
+
+    expect(pendingCount).toBe(2);
+  });
+
+  it("suma juntos los registros error y failed en errorCount", async () => {
+    await db.clientes.put({
+      id: "id-1",
+      nombre_cliente: "Cliente 1",
+      nit: "NIT-1",
+      sync_status: "error",
+    });
+    await db.clientes.put({
+      id: "id-2",
+      nombre_cliente: "Cliente 2",
+      nit: "NIT-2",
+      sync_status: "failed",
+    });
+    await db.sedes.put({
+      id: "id-3",
+      cliente_id: "id-1",
+      nombre_sede: "Sede 3",
+      sync_status: "error",
+    });
+    await db.clientes.put({
+      id: "id-4",
+      nombre_cliente: "Cliente 4",
+      nit: "NIT-4",
+      sync_status: "synced",
+    });
+
+    const { errorCount } = await countSyncStatuses();
+
+    expect(errorCount).toBe(3);
+  });
+
+  it("devuelve 0/0 cuando no hay registros pending/error/failed", async () => {
+    await db.clientes.put({
+      id: "id-1",
+      nombre_cliente: "Cliente 1",
+      nit: "NIT-1",
+      sync_status: "synced",
+    });
+
+    const { pendingCount, errorCount } = await countSyncStatuses();
+
+    expect(pendingCount).toBe(0);
+    expect(errorCount).toBe(0);
+  });
+});
+
+// ============================================================
+//  useSyncCounters — expone {pendingCount, errorCount} reactivamente
+//  vía useLiveQuery (dexie-react-hooks).
+// ============================================================
+
+function TestComponent() {
+  const { pendingCount, errorCount } = useSyncCounters();
+  return (
+    <div>
+      <span data-testid="pending-count">{pendingCount}</span>
+      <span data-testid="error-count">{errorCount}</span>
+    </div>
+  );
+}
+
+describe("useSyncCounters", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("expone pendingCount y errorCount reactivamente tras sembrar datos", async () => {
+    await db.clientes.put({
+      id: "id-1",
+      nombre_cliente: "Cliente 1",
+      nit: "NIT-1",
+      sync_status: "pending",
+    });
+    await db.clientes.put({
+      id: "id-2",
+      nombre_cliente: "Cliente 2",
+      nit: "NIT-2",
+      sync_status: "failed",
+    });
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pending-count").textContent).toBe("1");
+      expect(screen.getByTestId("error-count").textContent).toBe("1");
+    });
+  });
+});

--- a/src/hooks/use-sync-counters.ts
+++ b/src/hooks/use-sync-counters.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useLiveQuery } from "dexie-react-hooks";
+import { countSyncStatuses } from "@/lib/supabase/sync-engine";
+
+/**
+ * Hook reactivo que expone el indicador global de pendientes/errores
+ * de sincronización. Envuelve `countSyncStatuses()` en `useLiveQuery`
+ * para recalcularse automáticamente cuando cambian las tablas de Dexie
+ * subyacentes (nuevo registro pending, push fallido marcado como error
+ * o failed, reintento exitoso, etc.) sin necesidad de refrescar manual.
+ */
+export function useSyncCounters(): { pendingCount: number; errorCount: number } {
+  const counters = useLiveQuery(() => countSyncStatuses(), []);
+
+  return {
+    pendingCount: counters?.pendingCount ?? 0,
+    errorCount: counters?.errorCount ?? 0,
+  };
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -30,6 +30,7 @@ import type {
   InformeVersion,
   ChangeLog,
   SyncMeta,
+  SyncRetry,
 } from "./types";
 import type {
   ConvLevantamientoSetup,
@@ -84,6 +85,8 @@ class EyCDatabase extends Dexie {
   informe_versiones!: EntityTable<InformeVersion, "id">;
   change_logs!: EntityTable<ChangeLog, "id">;
   sync_meta!: EntityTable<SyncMeta, "table_name">;
+  /** Clave compuesta `[table_name+record_id]` — Dexie no soporta EntityTable con PK compuesta */
+  sync_retry!: Dexie.Table<SyncRetry, [string, string]>;
 
   // ─── Convencional (tablas dedicadas) ───
   conv_levantamiento_setup!: EntityTable<ConvLevantamientoSetup, "id">;
@@ -311,6 +314,14 @@ class EyCDatabase extends Dexie {
     // ─────────────────────────────────────────────────────────────
     this.version(14).stores({
       equipo_movimientos: "id, equipo_id, ubicacion_nueva_id, sync_status",
+    });
+
+    // ─────────────────────────────────────────────────────────────
+    //  v15 — retry con backoff exponencial para push fallido.
+    //  Tabla nueva, aditiva — no migra ni toca tablas existentes.
+    // ─────────────────────────────────────────────────────────────
+    this.version(15).stores({
+      sync_retry: "&[table_name+record_id], table_name, next_attempt_at",
     });
   }
 }

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -4,12 +4,34 @@
 // ============================================================
 
 /** Estado de sincronización para registros offline */
-export type SyncStatus = "pending" | "synced" | "conflict" | "error";
+export type SyncStatus = "pending" | "synced" | "conflict" | "error" | "failed";
 
 /** Campos comunes de sincronización */
 export interface SyncFields {
   sync_status: SyncStatus;
   last_modified: string; // ISO timestamp
+}
+
+// ─── Retry con backoff exponencial ───
+
+/**
+ * Estado de reintento de un registro que falló al pushear a Supabase.
+ * Clave compuesta `[table_name+record_id]` — una fila por registro con
+ * push pendiente/fallido. Se borra al lograr un push exitoso.
+ */
+export interface SyncRetry {
+  table_name: string;
+  record_id: string;
+  /** Número de intentos consumidos, 1..MAX_ATTEMPTS (ver sync-retry.ts) */
+  attempts: number;
+  /** ISO timestamp — no reintentar automáticamente antes de esta hora */
+  next_attempt_at: string;
+  /** "retrying" mientras queden intentos disponibles; "failed" cuando se agotan o el error es permanente */
+  status: "retrying" | "failed";
+  last_error: string;
+  /** Código de error de Postgres/PostgREST, si está disponible */
+  last_error_code?: string;
+  updated_at: string;
 }
 
 // ─── Tipos de equipo ───

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -19,7 +19,7 @@ vi.mock("./client", () => ({
 
 // Import estático: `vi.mock` se hoistea sobre los imports, así que el mock
 // de "./client" ya está activo cuando `sync-engine.ts` se evalúa.
-import { fullSync, pullSyncTable } from "./sync-engine";
+import { fullSync, pullSyncTable, pushAllPending, retryRecord } from "./sync-engine";
 
 // ============================================================
 //  pullSyncTable — paginación keyset (PR1: sync-engine-entrega-garantizada)
@@ -144,5 +144,75 @@ describe("sync-engine — fullSync (integración con pullSyncTable)", () => {
     await expect(db.clientes.count()).resolves.toBe(3);
     const meta = await db.sync_meta.get("clientes");
     expect(meta?.last_pulled_at).toBeDefined();
+  });
+});
+
+// ============================================================
+//  Push con schedule de retry (PR2: sync-engine-entrega-garantizada)
+//
+//  Un registro con una fila en `sync_retry` cuyo `next_attempt_at` está
+//  en el futuro no debe volver a pushearse en el ciclo automático hasta
+//  que llegue esa hora. `retryRecord` permite al técnico saltarse ese
+//  schedule y forzar el push inmediato de un registro puntual.
+// ============================================================
+
+describe("sync-engine — push respeta el schedule de sync_retry", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("no vuelve a pushear un registro con next_attempt_at en el futuro", async () => {
+    await db.clientes.put({
+      id: "id-pending",
+      nombre_cliente: "Cliente pendiente",
+      nit: "NIT-1",
+      sync_status: "pending",
+    });
+
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    await db.sync_retry.put({
+      table_name: "clientes",
+      record_id: "id-pending",
+      attempts: 2,
+      next_attempt_at: futureIso,
+      status: "retrying",
+      last_error: "network error",
+      updated_at: new Date().toISOString(),
+    });
+
+    const { pushed } = await pushAllPending();
+
+    expect(pushed).toBe(0);
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(0);
+    const record = await db.clientes.get("id-pending");
+    expect(record?.sync_status).toBe("pending");
+  });
+
+  it("retryRecord pushea inmediatamente saltándose el schedule de next_attempt_at futuro", async () => {
+    await db.clientes.put({
+      id: "id-pending",
+      nombre_cliente: "Cliente pendiente",
+      nit: "NIT-1",
+      sync_status: "pending",
+    });
+
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    await db.sync_retry.put({
+      table_name: "clientes",
+      record_id: "id-pending",
+      attempts: 2,
+      next_attempt_at: futureIso,
+      status: "retrying",
+      last_error: "network error",
+      updated_at: new Date().toISOString(),
+    });
+
+    await retryRecord("clientes", "id-pending");
+
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(1);
+    const record = await db.clientes.get("id-pending");
+    expect(record?.sync_status).toBe("synced");
+    await expect(db.sync_retry.get(["clientes", "id-pending"])).resolves.toBeUndefined();
   });
 });

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -216,3 +216,52 @@ describe("sync-engine — push respeta el schedule de sync_retry", () => {
     await expect(db.sync_retry.get(["clientes", "id-pending"])).resolves.toBeUndefined();
   });
 });
+
+// ============================================================
+//  Lock de concurrencia (PR3: sync-engine-entrega-garantizada)
+//
+//  fullSync/pushAllPending están envueltos con withSyncLock (ver
+//  sync-lock.ts) para que solo un ciclo de sync corra a la vez —
+//  necesario porque el Service Worker dispara SYNC_REQUESTED a cada
+//  tab abierta (sw-register.tsx) y cada una corre fullSync() en su
+//  propio contexto.
+// ============================================================
+
+describe("sync-engine — lock de concurrencia", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("fullSync: una segunda llamada concurrente se omite con un error _lock, sin duplicar el ciclo", async () => {
+    const [first, second] = await Promise.all([fullSync(), fullSync()]);
+
+    expect(first.errors.find((e) => e.table === "_lock")).toBeUndefined();
+    expect(second.pushed).toBe(0);
+    expect(second.pulled).toBe(0);
+    expect(second.errors).toEqual([
+      {
+        table: "_lock",
+        recordId: "0",
+        error: "Sincronización omitida: ya hay otra sincronización en curso",
+        action: "push",
+      },
+    ]);
+  });
+
+  it("pushAllPending: la segunda llamada concurrente se omite y no duplica el push del mismo registro pendiente", async () => {
+    await db.clientes.put({
+      id: "id-concurrent",
+      nombre_cliente: "Cliente concurrente",
+      nit: "NIT-CONC",
+      sync_status: "pending",
+    });
+
+    const [first, second] = await Promise.all([pushAllPending(), pushAllPending()]);
+
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(1);
+    expect(first.pushed + second.pushed).toBe(1);
+    const record = await db.clientes.get("id-concurrent");
+    expect(record?.sync_status).toBe("synced");
+  });
+});

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -215,6 +215,27 @@ describe("sync-engine — push respeta el schedule de sync_retry", () => {
     expect(record?.sync_status).toBe("synced");
     await expect(db.sync_retry.get(["clientes", "id-pending"])).resolves.toBeUndefined();
   });
+
+  it("retryRecord pasa por el lock de concurrencia: dos reintentos simultáneos del mismo registro pushean una sola vez", async () => {
+    await db.clientes.put({
+      id: "id-concurrent-retry",
+      nombre_cliente: "Cliente reintento concurrente",
+      nit: "NIT-CR",
+      sync_status: "failed",
+    });
+
+    // Reintento manual del técnico "al mismo tiempo" que un reintento
+    // automático de backoff sobre el mismo registro: el lock permite solo
+    // un intento, el perdedor se salta sin lanzar error.
+    await Promise.all([
+      retryRecord("clientes", "id-concurrent-retry"),
+      retryRecord("clientes", "id-concurrent-retry"),
+    ]);
+
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(1);
+    const record = await db.clientes.get("id-concurrent-retry");
+    expect(record?.sync_status).toBe("synced");
+  });
 });
 
 // ============================================================

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -3,6 +3,7 @@ import { createClient } from "./client";
 import type { SyncStatus } from "@/lib/db/types";
 import { logger } from "@/lib/logger";
 import type { EntityTable } from "dexie";
+import { isDue, recordFailure, recordSuccess } from "./sync-retry";
 
 type SyncableRecord = { id?: string; sync_status?: SyncStatus; [key: string]: unknown };
 
@@ -316,6 +317,13 @@ async function pushTable(
 
   for (const record of pending) {
     const localId = record.id as string;
+
+    // Un registro con retry programado no se vuelve a pushear en el
+    // ciclo automático hasta que llegue su `next_attempt_at` — evita
+    // martillar el backend con el mismo error en cada ciclo de sync.
+    const retry = await db.sync_retry.get([localTable, localId]);
+    if (retry && !isDue(retry)) continue;
+
     const data = prepareForRemote(record as Record<string, unknown>, localTable);
 
     try {
@@ -327,10 +335,14 @@ async function pushTable(
         sync_status: "synced" as SyncStatus,
         last_modified: new Date().toISOString(),
       });
+      await recordSuccess(localTable, localId);
 
       pushed++;
     } catch (err) {
-      await dexieTable.update(localId, { sync_status: "error" as SyncStatus });
+      const finalStatus = await recordFailure(localTable, localId, err);
+      if (finalStatus === "failed") {
+        await dexieTable.update(localId, { sync_status: "failed" as SyncStatus });
+      }
 
       const { message, detail } = describeError(err);
       errors.push({
@@ -373,6 +385,11 @@ export async function pushSingle(localTable: string, localId: string): Promise<b
     const record = await dexieTable.get(localId);
     if (!record || record.sync_status !== "pending") return false;
 
+    // Igual que en pushTable: si hay un retry programado en el futuro,
+    // no reintentar todavía — el técnico puede forzarlo con retryRecord.
+    const retry = await db.sync_retry.get([localTable, localId]);
+    if (retry && !isDue(retry)) return false;
+
     const data = prepareForRemote(record as Record<string, unknown>, localTable);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -384,12 +401,62 @@ export async function pushSingle(localTable: string, localId: string): Promise<b
       sync_status: "synced" as SyncStatus,
       last_modified: new Date().toISOString(),
     });
+    await recordSuccess(localTable, localId);
 
     logger.info("sync:push-single", `${localTable}#${localId.slice(0, 8)} synced`);
     return true;
   } catch (err) {
+    const finalStatus = await recordFailure(localTable, localId, err);
+    if (finalStatus === "failed") {
+      const dexieTable = getDexieTable(localTable);
+      if (dexieTable) await dexieTable.update(localId, { sync_status: "failed" as SyncStatus });
+    }
     logger.warn("sync:push-single", `${localTable}#${localId} failed (will retry)`, err);
     return false;
+  }
+}
+
+/**
+ * Reintento manual de un registro puntual — se salta el schedule de
+ * backoff de `sync_retry` y fuerza el push inmediato. Pensado para que
+ * el técnico de campo pueda reintentar un registro "failed" sin esperar
+ * al próximo ciclo automático ni depender de un rol de coordinador.
+ */
+export async function retryRecord(localTable: string, localId: string): Promise<void> {
+  const remote = SYNC_TABLES.find((t) => t.local === localTable)?.remote;
+  if (!remote) return;
+
+  const dexieTable = getDexieTable(localTable);
+  if (!dexieTable) return;
+
+  const record = await dexieTable.get(localId);
+  if (!record) return;
+
+  try {
+    const supabase = createClient();
+    const data = prepareForRemote(record as Record<string, unknown>, localTable);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (supabase.from(remote) as any).upsert(data, { onConflict: "id" });
+
+    if (error) throw error;
+
+    await dexieTable.update(localId, {
+      sync_status: "synced" as SyncStatus,
+      last_modified: new Date().toISOString(),
+    });
+    await recordSuccess(localTable, localId);
+
+    logger.info(
+      "sync:retry-record",
+      `${localTable}#${localId.slice(0, 8)} synced (reintento manual)`
+    );
+  } catch (err) {
+    const finalStatus = await recordFailure(localTable, localId, err);
+    if (finalStatus === "failed") {
+      await dexieTable.update(localId, { sync_status: "failed" as SyncStatus });
+    }
+    logger.warn("sync:retry-record", `${localTable}#${localId} reintento manual falló`, err);
   }
 }
 

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -702,6 +702,17 @@ export interface ErrorRecord {
   tableLabel: string;
   id: string;
   preview: string;
+  /**
+   * "error": recuperable por el ciclo automático — `retryErrorRecords()`
+   * lo vuelve a poner en "pending". "failed": agotó `MAX_ATTEMPTS` o tuvo
+   * un error permanente (ver sync-retry.ts) — es terminal, solo se
+   * reintenta manualmente con `retryRecord(table, id)`.
+   */
+  status: "error" | "failed";
+  /** Intentos consumidos, si el registro tiene fila en `sync_retry` */
+  attempts?: number;
+  /** Próximo intento automático programado, si aplica */
+  nextAttemptAt?: string;
 }
 
 export async function getErrorRecords(): Promise<ErrorRecord[]> {
@@ -712,9 +723,10 @@ export async function getErrorRecords(): Promise<ErrorRecord[]> {
       const dexieTable = getDexieTable(table.local);
       if (!dexieTable) continue;
 
-      const errored = await dexieTable.where("sync_status").equals("error").toArray();
+      const errored = await dexieTable.where("sync_status").anyOf(["error", "failed"]).toArray();
       for (const rec of errored) {
         const id = (rec.id as string) ?? "";
+        const retry = await db.sync_retry.get([table.local, id]);
         results.push({
           table: table.local,
           tableLabel: tableLabel(table.local),
@@ -722,6 +734,9 @@ export async function getErrorRecords(): Promise<ErrorRecord[]> {
           preview: String(
             rec.nombre_cliente ?? rec.nombre ?? rec.nombre_sede ?? rec.codigo ?? id.slice(0, 8)
           ),
+          status: rec.sync_status as "error" | "failed",
+          attempts: retry?.attempts,
+          nextAttemptAt: retry?.next_attempt_at,
         });
       }
     } catch {
@@ -751,6 +766,36 @@ export async function retryErrorRecords(): Promise<number> {
   return count;
 }
 
+// ─── Contadores globales de pendientes/errores ───
+
+/**
+ * Cuenta, entre todas las `SYNC_TABLES`, cuántos registros están en
+ * `sync_status="pending"` y cuántos en `"error"` o `"failed"` (juntos,
+ * en `errorCount`). Usa `.count()` indexado de Dexie — nunca
+ * `.toArray().length` — para no traer los registros completos solo
+ * para contarlos. Base de `useSyncCounters()` (indicador global en la
+ * UI) y reutilizable para diagnóstico fuera de React.
+ */
+export async function countSyncStatuses(): Promise<{ pendingCount: number; errorCount: number }> {
+  let pendingCount = 0;
+  let errorCount = 0;
+
+  for (const table of SYNC_TABLES) {
+    try {
+      const dexieTable = getDexieTable(table.local);
+      if (!dexieTable) continue;
+
+      pendingCount += await dexieTable.where("sync_status").equals("pending").count();
+      errorCount += await dexieTable.where("sync_status").equals("error").count();
+      errorCount += await dexieTable.where("sync_status").equals("failed").count();
+    } catch (err) {
+      logger.error("sync:counters", `Error contando registros en ${table.local}`, err);
+    }
+  }
+
+  return { pendingCount, errorCount };
+}
+
 // ─── Estado de conectividad ───
 
 export async function checkSyncStatus(): Promise<{
@@ -774,19 +819,7 @@ export async function checkSyncStatus(): Promise<{
     }
   }
 
-  let pendingCount = 0;
-  let errorCount = 0;
-  for (const table of SYNC_TABLES) {
-    try {
-      const dexieTable = getDexieTable(table.local);
-      if (dexieTable) {
-        pendingCount += await dexieTable.where("sync_status").equals("pending").count();
-        errorCount += await dexieTable.where("sync_status").equals("error").count();
-      }
-    } catch (err) {
-      logger.error("sync:status", `Error contando registros en ${table.local}`, err);
-    }
-  }
+  const { pendingCount, errorCount } = await countSyncStatuses();
 
   return { online, authenticated, pendingCount, errorCount };
 }

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -452,6 +452,21 @@ export async function pushSingle(localTable: string, localId: string): Promise<b
  * al próximo ciclo automático ni depender de un rol de coordinador.
  */
 export async function retryRecord(localTable: string, localId: string): Promise<void> {
+  const result = await withSyncLock(() => retryRecordUnlocked(localTable, localId));
+
+  if (!result.ran) {
+    // Ya hay otra sincronización en curso (reintento automático de backoff,
+    // fullSync o pushAllPending) — el técnico puede volver a tocar el botón
+    // si hace falta. No es un error: el lock permite solo un intento, este
+    // se salta.
+    logger.info(
+      "sync:retry-record",
+      `${localTable}#${localId.slice(0, 8)} reintento manual omitido (sync en curso)`
+    );
+  }
+}
+
+async function retryRecordUnlocked(localTable: string, localId: string): Promise<void> {
   const remote = SYNC_TABLES.find((t) => t.local === localTable)?.remote;
   if (!remote) return;
 

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -4,6 +4,7 @@ import type { SyncStatus } from "@/lib/db/types";
 import { logger } from "@/lib/logger";
 import type { EntityTable } from "dexie";
 import { isDue, recordFailure, recordSuccess } from "./sync-retry";
+import { withSyncLock } from "./sync-lock";
 
 type SyncableRecord = { id?: string; sync_status?: SyncStatus; [key: string]: unknown };
 
@@ -210,10 +211,38 @@ const MASTER_TABLES = [
 ] as const;
 
 /**
- * Ejecuta un ciclo completo de sincronización.
- * Push primero (para no perder cambios locales), luego Pull.
+ * Ejecuta un ciclo completo de sincronización, protegido por
+ * `withSyncLock` (single-flight — ver sync-lock.ts) para evitar que
+ * dos disparadores (botón manual, auto-sync, mensaje del Service
+ * Worker a otra pestaña) corran fullSync al mismo tiempo.
+ *
+ * Si ya hay una sincronización en curso, el ciclo se omite y se
+ * refleja como un error `_lock` en `result.errors` — mismo patrón que
+ * el error `_auth` cuando no hay sesión — sin romper el contrato de
+ * retorno `SyncResult` que ya consumen los callers existentes.
  */
 export async function fullSync(): Promise<SyncResult> {
+  const lockResult = await withSyncLock(runFullSync);
+  if (!lockResult.ran) {
+    logger.info("sync:lock", "fullSync omitido: ya hay una sincronización en curso");
+    return {
+      pushed: 0,
+      pulled: 0,
+      errors: [
+        {
+          table: "_lock",
+          recordId: "0",
+          error: "Sincronización omitida: ya hay otra sincronización en curso",
+          action: "push",
+        },
+      ],
+      timestamp: new Date().toISOString(),
+    };
+  }
+  return lockResult.value;
+}
+
+async function runFullSync(): Promise<SyncResult> {
   const result: SyncResult = {
     pushed: 0,
     pulled: 0,
@@ -463,8 +492,23 @@ export async function retryRecord(localTable: string, localId: string): Promise<
 /**
  * Push de todos los registros pendientes (sin pull).
  * Usado por el auto-sync periódico — más liviano que fullSync.
+ *
+ * Protegido por `withSyncLock` (single-flight — ver sync-lock.ts) para
+ * no correr en paralelo con otro pushAllPending o con fullSync. Si ya
+ * hay una sincronización en curso, se omite este ciclo — mismo shape
+ * de retorno que el caso offline (`{ pushed: 0, errors: 0 }`), solo
+ * distinguible por el log emitido.
  */
 export async function pushAllPending(): Promise<{ pushed: number; errors: number }> {
+  const lockResult = await withSyncLock(runPushAllPending);
+  if (!lockResult.ran) {
+    logger.info("sync:lock", "pushAllPending omitido: ya hay una sincronización en curso");
+    return { pushed: 0, errors: 0 };
+  }
+  return lockResult.value;
+}
+
+async function runPushAllPending(): Promise<{ pushed: number; errors: number }> {
   if (!navigator.onLine) return { pushed: 0, errors: 0 };
 
   const supabase = createClient();

--- a/src/lib/supabase/sync-lock.test.ts
+++ b/src/lib/supabase/sync-lock.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withSyncLock } from "./sync-lock";
+
+// ============================================================
+//  withSyncLock — lock de concurrencia (PR3: sync-engine-entrega-garantizada)
+//
+//  happy-dom (entorno de test de Vitest, ver vitest.config.ts) NO
+//  implementa la Web Locks API — `navigator.locks` es falsy (`null` en
+//  happy-dom) en todos estos tests, así que ejercitan el fallback en
+//  memoria del módulo, no `navigator.locks.request`. Ver sync-lock.ts
+//  para el camino real usado en navegadores que sí la soportan.
+// ============================================================
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("sync-lock — withSyncLock", () => {
+  beforeEach(() => {
+    expect(navigator.locks).toBeFalsy();
+  });
+
+  it("ejecuta el spy una sola vez con dos llamadas concurrentes; la segunda queda locked sin ejecutar el spy", async () => {
+    const spy = vi.fn(async () => {
+      await delay(20);
+      return "ok";
+    });
+
+    const [first, second] = await Promise.all([withSyncLock(spy), withSyncLock(spy)]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ ran: true, value: "ok" });
+    expect(second).toEqual({ ran: false, reason: "locked" });
+  });
+
+  it("libera el lock si la función protegida lanza una excepción — un intento posterior puede correr", async () => {
+    const failing = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(withSyncLock(failing)).rejects.toThrow("boom");
+
+    const recovering = vi.fn(async () => "recovered");
+    const result = await withSyncLock(recovering);
+
+    expect(recovering).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ran: true, value: "recovered" });
+  });
+
+  it("da single-flight vía el fallback en memoria cuando navigator.locks es undefined (happy-dom)", async () => {
+    expect(navigator.locks).toBeFalsy();
+
+    const spy = vi.fn(async () => {
+      await delay(10);
+      return "fallback-ok";
+    });
+
+    const results = await Promise.all([withSyncLock(spy), withSyncLock(spy), withSyncLock(spy)]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(results.filter((r) => r.ran)).toHaveLength(1);
+    expect(results.filter((r) => !r.ran)).toHaveLength(2);
+  });
+});

--- a/src/lib/supabase/sync-lock.ts
+++ b/src/lib/supabase/sync-lock.ts
@@ -1,0 +1,64 @@
+// ============================================================
+//  Lock de concurrencia para evitar sincronizaciones simultáneas.
+//
+//  Usa la Web Locks API (`navigator.locks`) cuando el navegador la
+//  soporta: el lock "eyc-sync" es efectivo ENTRE PESTAÑAS del mismo
+//  origen, lo cual es necesario porque el Service Worker dispara
+//  "SYNC_REQUESTED" a cada tab abierta (ver sw-register.tsx) y cada
+//  una corre fullSync()/pushAllPending() en su propio contexto JS —
+//  sin este lock, dos tabs podrían pushear/pullear al mismo tiempo.
+//
+//  Fallback en memoria: si `navigator.locks` no existe (navegadores
+//  viejos, o el entorno de test happy-dom, que no implementa Web
+//  Locks), se usa un guard a nivel de módulo. Este fallback SOLO
+//  protege single-flight DENTRO de la misma pestaña/proceso — NO
+//  evita que dos pestañas distintas corran el sync a la vez — pero
+//  es mejor que nada para navegadores sin soporte de Web Locks.
+// ============================================================
+
+const LOCK_NAME = "eyc-sync";
+
+export type SyncLockResult<T> = { ran: true; value: T } | { ran: false; reason: "locked" };
+
+let inMemoryLocked = false;
+
+async function withInMemoryLock<T>(fn: () => Promise<T>): Promise<SyncLockResult<T>> {
+  if (inMemoryLocked) {
+    return { ran: false, reason: "locked" };
+  }
+
+  inMemoryLocked = true;
+  try {
+    const value = await fn();
+    return { ran: true, value };
+  } finally {
+    inMemoryLocked = false;
+  }
+}
+
+/**
+ * Ejecuta `fn` protegida por un lock exclusivo de sync (single-flight).
+ * Si ya hay una sincronización en curso, `fn` NO se ejecuta y se
+ * devuelve `{ ran: false, reason: "locked" }` en su lugar.
+ *
+ * El lock se libera automáticamente (Web Locks o fallback en memoria)
+ * cuando `fn` termina, ya sea con éxito o con excepción — un intento
+ * posterior siempre puede volver a adquirirlo.
+ */
+export async function withSyncLock<T>(fn: () => Promise<T>): Promise<SyncLockResult<T>> {
+  if (typeof navigator === "undefined" || !navigator.locks) {
+    return withInMemoryLock(fn);
+  }
+
+  return navigator.locks.request(
+    LOCK_NAME,
+    { ifAvailable: true, mode: "exclusive" },
+    async (lock) => {
+      if (!lock) {
+        return { ran: false, reason: "locked" };
+      }
+      const value = await fn();
+      return { ran: true, value };
+    }
+  );
+}

--- a/src/lib/supabase/sync-retry.test.ts
+++ b/src/lib/supabase/sync-retry.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import {
+  computeBackoffDelayMs,
+  isDue,
+  isPermanent,
+  MAX_ATTEMPTS,
+  recordFailure,
+  recordSuccess,
+} from "./sync-retry";
+
+// ============================================================
+//  sync-retry — backoff exponencial + clasificación de errores
+//  (PR2: sync-engine-entrega-garantizada)
+// ============================================================
+
+const TABLE = "clientes";
+const RECORD_ID = "id-0001";
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+function setOnline(online: boolean): void {
+  vi.spyOn(navigator, "onLine", "get").mockReturnValue(online);
+}
+
+function expectWithinJitter(actualMs: number, baseMs: number): void {
+  expect(actualMs).toBeGreaterThanOrEqual(Math.floor(baseMs * 0.8));
+  expect(actualMs).toBeLessThanOrEqual(Math.ceil(baseMs * 1.2));
+}
+
+describe("sync-retry", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    // Solo se mockea `Date` — fake-indexeddb depende de macrotasks reales
+    // (setTimeout/queueMicrotask) para resolver sus transacciones, así
+    // que faltear el reloj completo (`vi.useFakeTimers()`) cuelga los
+    // tests que tocan Dexie.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(NOW);
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("backoff exacto", () => {
+    it("intento 1 falla → próximo intento en ~1min (±20% jitter)", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(1);
+      expect(retry?.status).toBe("retrying");
+
+      const deltaMs = new Date(retry!.next_attempt_at).getTime() - NOW.getTime();
+      expectWithinJitter(deltaMs, 60_000);
+    });
+
+    it("intento 2 falla → próximo intento en ~4min (±20% jitter)", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(2);
+      expect(retry?.status).toBe("retrying");
+
+      const deltaMs = new Date(retry!.next_attempt_at).getTime() - NOW.getTime();
+      expectWithinJitter(deltaMs, 240_000);
+    });
+
+    it("intento 3 falla → próximo intento en ~16min (±20% jitter)", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(3);
+      expect(retry?.status).toBe("retrying");
+
+      const deltaMs = new Date(retry!.next_attempt_at).getTime() - NOW.getTime();
+      expectWithinJitter(deltaMs, 960_000);
+    });
+
+    it("intento 4 falla → próximo intento en ~60min (tope, ±20% jitter)", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(4);
+      expect(retry?.status).toBe("retrying");
+
+      const deltaMs = new Date(retry!.next_attempt_at).getTime() - NOW.getTime();
+      expectWithinJitter(deltaMs, 3_600_000);
+    });
+
+    it("intento 5 falla → sync_status pasa a 'failed', sin más reintentos automáticos", async () => {
+      for (let i = 0; i < MAX_ATTEMPTS; i++) {
+        await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      }
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(MAX_ATTEMPTS);
+      expect(retry?.status).toBe("failed");
+    });
+  });
+
+  describe("clasificación de códigos de error", () => {
+    const PERMANENT_CODES = ["23505", "23502", "22P02", "42703", "PGRST204", "42501"];
+
+    it.each(PERMANENT_CODES)(
+      "código permanente %s → 'failed' directo en el intento 1",
+      async (code) => {
+        expect(isPermanent(code)).toBe(true);
+
+        await recordFailure(TABLE, RECORD_ID, { message: "constraint violation", code });
+
+        const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+        expect(retry?.attempts).toBe(1);
+        expect(retry?.status).toBe("failed");
+      }
+    );
+
+    const TRANSIENT_CODES = ["fetch failed", "500", "503", "429", "PGRST301", "23503"];
+
+    it.each(TRANSIENT_CODES)(
+      "código transitorio %s → consume un intento y programa retry",
+      async (code) => {
+        expect(isPermanent(code)).toBe(false);
+
+        await recordFailure(TABLE, RECORD_ID, { message: "transient error", code });
+
+        const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+        expect(retry?.attempts).toBe(1);
+        expect(retry?.status).toBe("retrying");
+      }
+    );
+
+    it("código desconocido/no mapeado → se trata como transitorio por defecto", async () => {
+      expect(isPermanent("XX999")).toBe(false);
+
+      await recordFailure(TABLE, RECORD_ID, { message: "unknown error", code: "XX999" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(1);
+      expect(retry?.status).toBe("retrying");
+    });
+
+    it("error sin código → se trata como transitorio por defecto", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network drop" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry?.attempts).toBe(1);
+      expect(retry?.status).toBe("retrying");
+    });
+  });
+
+  describe("éxito", () => {
+    it("recordSuccess borra la fila correspondiente de sync_retry", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await expect(db.sync_retry.get([TABLE, RECORD_ID])).resolves.toBeDefined();
+
+      await recordSuccess(TABLE, RECORD_ID);
+
+      await expect(db.sync_retry.get([TABLE, RECORD_ID])).resolves.toBeUndefined();
+    });
+
+    it("recordSuccess sobre un registro sin fila de retry no falla", async () => {
+      await expect(recordSuccess(TABLE, RECORD_ID)).resolves.not.toThrow();
+    });
+  });
+
+  describe("offline", () => {
+    it("no incrementa el contador de intentos cuando navigator.onLine es false", async () => {
+      setOnline(false);
+
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const retry = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(retry).toBeUndefined();
+    });
+
+    it("no incrementa el contador de intentos si ya existía una fila y se cae offline", async () => {
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+      const before = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(before?.attempts).toBe(1);
+
+      setOnline(false);
+      await recordFailure(TABLE, RECORD_ID, { message: "network error" });
+
+      const after = await db.sync_retry.get([TABLE, RECORD_ID]);
+      expect(after?.attempts).toBe(1);
+    });
+  });
+
+  describe("isDue", () => {
+    it("retorna true cuando next_attempt_at ya pasó", () => {
+      const past = new Date(NOW.getTime() - 1000).toISOString();
+      expect(isDue({ next_attempt_at: past })).toBe(true);
+    });
+
+    it("retorna false cuando next_attempt_at está en el futuro", () => {
+      const future = new Date(NOW.getTime() + 60_000).toISOString();
+      expect(isDue({ next_attempt_at: future })).toBe(false);
+    });
+  });
+
+  describe("computeBackoffDelayMs", () => {
+    it("respeta el tope de 60 minutos incluso en intentos altos", () => {
+      const delay = computeBackoffDelayMs(10);
+      expectWithinJitter(delay, 3_600_000);
+    });
+  });
+});

--- a/src/lib/supabase/sync-retry.ts
+++ b/src/lib/supabase/sync-retry.ts
@@ -1,0 +1,136 @@
+import { db } from "@/lib/db";
+import type { SyncRetry } from "@/lib/db/types";
+import { logger } from "@/lib/logger";
+
+// ============================================================
+//  Retry con backoff exponencial para push fallido a Supabase.
+//
+//  delay(n) = min(60_000 * 4^(n-1), 3_600_000) ms, ±20% jitter aleatorio.
+//  1 → ~1min, 2 → ~4min, 3 → ~16min, 4 → ~60min (tope), 5 → agota
+//  el ciclo y el registro pasa a sync_status="failed" (terminal, sin
+//  más reintentos automáticos — el técnico puede forzar uno manual
+//  con `retryRecord`, ver sync-engine.ts).
+// ============================================================
+
+export const MAX_ATTEMPTS = 5;
+
+const BASE_DELAY_MS = 60_000;
+const MAX_DELAY_MS = 3_600_000;
+const JITTER_RATIO = 0.2;
+
+/** Códigos de error de Postgres/PostgREST que nunca se resuelven reintentando. */
+const PERMANENT_ERROR_CODES = new Set([
+  "23505", // unique_violation
+  "23502", // not_null_violation
+  "22P02", // invalid_text_representation (invalid input syntax)
+  "42703", // undefined_column (schema mismatch)
+  "PGRST204", // PostgREST: columna no encontrada en el schema cache
+  "42501", // insufficient_privilege (RLS)
+]);
+
+/**
+ * Un código de error se considera permanente solo si está en la lista
+ * explícita. Cualquier código desconocido/no mapeado, o la ausencia de
+ * código, se trata como transitorio por defecto — preferimos reintentar
+ * de más a fallar de más.
+ */
+export function isPermanent(code?: string): boolean {
+  if (!code) return false;
+  return PERMANENT_ERROR_CODES.has(code);
+}
+
+/**
+ * Calcula el delay en ms para el intento `attempt` (1-based) con jitter
+ * aleatorio de ±20% para evitar reintentos sincronizados entre clientes.
+ */
+export function computeBackoffDelayMs(attempt: number): number {
+  const base = Math.min(BASE_DELAY_MS * 4 ** (attempt - 1), MAX_DELAY_MS);
+  const jitterFactor = 1 + (Math.random() * 2 - 1) * JITTER_RATIO;
+  return Math.round(base * jitterFactor);
+}
+
+function extractErrorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}
+
+function extractErrorMessage(err: unknown): string {
+  if (err && typeof err === "object" && "message" in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(err);
+}
+
+/**
+ * Registra un intento de push fallido para `table`#`id`.
+ *
+ * - Si está offline (`!navigator.onLine`), NO consume un intento — el
+ *   fallo es de conectividad, no del registro, así que no debe gastar
+ *   el presupuesto de reintentos.
+ * - Si el código de error es permanente, marca "failed" directo en el
+ *   intento 1 sin agotar el ciclo completo.
+ * - Si se alcanza `MAX_ATTEMPTS`, marca "failed".
+ * - En cualquier otro caso, programa el próximo intento con backoff
+ *   exponencial + jitter y deja el status en "retrying".
+ *
+ * Devuelve el status final ("retrying" | "failed") para que el llamador
+ * decida si debe reflejar sync_status="failed" en la tabla Dexie local.
+ */
+export async function recordFailure(
+  table: string,
+  id: string,
+  error: unknown
+): Promise<SyncRetry["status"]> {
+  if (!navigator.onLine) {
+    logger.warn("sync:retry", `Fallo offline en ${table}#${id} — no se cuenta como intento`, error);
+    return "retrying";
+  }
+
+  const code = extractErrorCode(error);
+  const message = extractErrorMessage(error);
+  const now = new Date();
+
+  const existing = await db.sync_retry.get([table, id]);
+  const attempts = (existing?.attempts ?? 0) + 1;
+  const permanent = isPermanent(code);
+  const exhausted = attempts >= MAX_ATTEMPTS;
+  const status: SyncRetry["status"] = permanent || exhausted ? "failed" : "retrying";
+
+  const nextAttemptAt =
+    status === "failed"
+      ? now.toISOString()
+      : new Date(now.getTime() + computeBackoffDelayMs(attempts)).toISOString();
+
+  await db.sync_retry.put({
+    table_name: table,
+    record_id: id,
+    attempts,
+    next_attempt_at: nextAttemptAt,
+    status,
+    last_error: message,
+    last_error_code: code,
+    updated_at: now.toISOString(),
+  });
+
+  logger.warn(
+    "sync:retry",
+    `${table}#${id.slice(0, 8)} intento ${attempts}/${MAX_ATTEMPTS} — ${status}`,
+    { code, message }
+  );
+
+  return status;
+}
+
+/** Push exitoso — borra la fila de seguimiento de reintentos, si existe. */
+export async function recordSuccess(table: string, id: string): Promise<void> {
+  await db.sync_retry.delete([table, id]);
+}
+
+/** Verdadero si ya llegó la hora programada del próximo intento. */
+export function isDue(retry: Pick<SyncRetry, "next_attempt_at">): boolean {
+  return new Date(retry.next_attempt_at).getTime() <= Date.now();
+}


### PR DESCRIPTION
## Qué pasó

Los PRs #18-#22 de la cadena `sync-engine-entrega-garantizada` se crearon con base la rama del PR anterior en vez de `main` (error de configuración del stacking). Al mergearlos en orden, el código quedó encadenado en `feat/sync-engine-docs-sincronizacion`, pero nunca llegó a `main` — solo el PR #17 (paginación) sí entró.

`main` le falta: retry con backoff (#18), lock de concurrencia (#19), indicador global (#20), corrección de docs (#21), cierre de warnings de sdd-verify (#22).

## Este PR

Trae exactamente esos 6 commits ya revisados y mergeados a `main`, sin cambios nuevos — es un PR de "enderezar la cadena", no de código nuevo.

## Test plan
- [x] `npm run test:run` — 131/131 (ya verificado en cada PR individual)
- [x] Sin commits nuevos, solo el merge hacia `main`