### PR TITLE
fix(sync): franja de sync no debe cubrir el sidebar en desktop

### DIFF
--- a/src/components/sync-status-bar.tsx
+++ b/src/components/sync-status-bar.tsx
@@ -72,7 +72,7 @@ export function SyncStatusBar() {
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-0 inset-x-0 z-30 h-9 flex items-center justify-between px-3 sm:px-4 ${colorClasses}`}
+      className={`fixed top-0 inset-x-0 md:left-(--sidebar-width) z-30 h-9 flex items-center justify-between px-3 sm:px-4 ${colorClasses}`}
     >
       <Link
         href="/dashboard/sync"


### PR DESCRIPTION
## Summary
- La franja fija de estado de sync (`SyncStatusBar`) usaba `inset-x-0` (ancho completo de pantalla), tapando el sidebar en desktop.
- Ahora arranca después de `--sidebar-width` en `md+` (en mobile el sidebar es un Sheet flotante, ahí sí ocupa todo el ancho).

## Test plan
- [x] `npx vitest run src/components/sync-status-bar.test.tsx` — 7/7
- [x] `npx tsc --noEmit` — limpio
- [x] Verificación visual pendiente (desktop y mobile)