### PR TITLE
fix(sync): las actualizaciones en módulos de prueba no sincronizaban

### DIFF
--- a/src/components/visita-modulos/grupo-a-modulo.tsx
+++ b/src/components/visita-modulos/grupo-a-modulo.tsx
@@ -5,9 +5,10 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle } from "@/lib/supabase/sync-engine";
+import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
+  Check,
   Gauge,
   Plus,
   Trash2,
@@ -29,6 +30,8 @@ import { Button } from "@/components/ui/button";
 import { irAModulo } from "@/lib/modulo-nav";
 import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
+import { SetupField } from "@/components/visita-modulos/setup-field";
+import { useRowSavedFlash } from "@/hooks/use-row-saved";
 import type { ConvInspeccionItem } from "@/lib/equipos/convencional/db/types";
 
 // ─── Constants ───
@@ -321,6 +324,9 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
   const [manualOpen, setManualOpen] = useState(false);
   const [manualPrueba, setManualPrueba] = useState<string | undefined>();
   const pruebasGrupoA = getManualGrupo("A");
+  // Indicador liviano de "guardado" para filas de las tablas de mediciones,
+  // elementos de protección e inspección visual — ver useRowSavedFlash.
+  const { isSaved, flash } = useRowSavedFlash();
 
   // ─── Live data from dedicated conv_ tables ───
   const data = useLiveQuery(async () => {
@@ -404,7 +410,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
     setupTimer.current = setTimeout(() => {
       const payload = setupPending.current;
       setupPending.current = {};
-      db.conv_levantamiento_setup.update(data.setup!.id!, payload);
+      updateAndSync("conv_levantamiento_setup", data.setup!.id!, payload);
     }, 600);
   }
 
@@ -442,7 +448,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
     if (tipoArea === "controlada") concepto = dosis <= 5 ? "Conforme" : "No_conforme";
     else if (tipoArea === "supervisada") concepto = dosis <= 0.5 ? "Conforme" : "No_conforme";
 
-    await db.conv_mediciones.update(id, {
+    await updateAndSync("conv_mediciones", id, {
       ...fields,
       tasa_dosis_msv_h: msvH || undefined,
       factor_uso_u: u,
@@ -458,7 +464,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function updateInspeccionItem(id: string, fields: Record<string, unknown>) {
-    await db.conv_inspeccion_items.update(id, fields);
+    await updateAndSync("conv_inspeccion_items", id, fields);
   }
 
   async function addElemento() {
@@ -474,7 +480,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function updateElemento(id: string, fields: Record<string, unknown>) {
-    await db.conv_elementos_proteccion.update(id, fields);
+    await updateAndSync("conv_elementos_proteccion", id, fields);
   }
 
   async function removeElemento(id: string) {
@@ -669,42 +675,22 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
               tasa promedio.
             </Tip>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                  Fondo natural (μSv/h)
-                </label>
-                <Input
-                  type="number"
-                  step="0.001"
-                  className="rounded-xl h-9 text-sm font-medium"
-                  defaultValue={setup?.fondo_natural_usv_h ?? ""}
-                  onBlur={(e) =>
-                    updateSetup({
-                      fondo_natural_usv_h: e.target.value ? parseFloat(e.target.value) : undefined,
-                    })
-                  }
-                  placeholder="Ej: 0.08"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                  Distancia tubo — operario (m)
-                </label>
-                <Input
-                  type="number"
-                  step="0.1"
-                  className="rounded-xl h-9 text-sm font-medium"
-                  defaultValue={setup?.distancia_tubo_operario_m ?? ""}
-                  onBlur={(e) =>
-                    updateSetup({
-                      distancia_tubo_operario_m: e.target.value
-                        ? parseFloat(e.target.value)
-                        : undefined,
-                    })
-                  }
-                  placeholder="Ej: 2.5"
-                />
-              </div>
+              <SetupField
+                label="Fondo natural (μSv/h)"
+                step="0.001"
+                defaultValue={setup?.fondo_natural_usv_h ?? ""}
+                placeholder="Ej: 0.08"
+                onSave={(v) => updateSetup({ fondo_natural_usv_h: v ? parseFloat(v) : undefined })}
+              />
+              <SetupField
+                label="Distancia tubo — operario (m)"
+                step="0.1"
+                defaultValue={setup?.distancia_tubo_operario_m ?? ""}
+                placeholder="Ej: 2.5"
+                onSave={(v) =>
+                  updateSetup({ distancia_tubo_operario_m: v ? parseFloat(v) : undefined })
+                }
+              />
             </div>
           </CollapsibleSection>
 
@@ -722,23 +708,14 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                   ["tecnica_mas", "Exposición (mAs)", "20"],
                 ] as const
               ).map(([field, label, ph]) => (
-                <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                    {label}
-                  </label>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    className="rounded-xl h-9 text-sm font-medium"
-                    defaultValue={setup?.[field] ?? ""}
-                    onBlur={(e) =>
-                      updateSetup({
-                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                      })
-                    }
-                    placeholder={ph}
-                  />
-                </div>
+                <SetupField
+                  key={field}
+                  label={label}
+                  step="0.01"
+                  defaultValue={setup?.[field] ?? ""}
+                  placeholder={ph}
+                  onSave={(v) => updateSetup({ [field]: v ? parseFloat(v) : undefined })}
+                />
               ))}
             </div>
           </CollapsibleSection>
@@ -801,18 +778,10 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                 </div>
               </div>
               <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                  Semanas laborales
-                </label>
-                <Input
-                  type="number"
-                  className="rounded-xl h-9 text-sm font-medium"
+                <SetupField
+                  label="Semanas laborales"
                   defaultValue={setup?.semanas_laborales ?? 50}
-                  onBlur={(e) =>
-                    updateSetup({
-                      semanas_laborales: e.target.value ? parseFloat(e.target.value) : 50,
-                    })
-                  }
+                  onSave={(v) => updateSetup({ semanas_laborales: v ? parseFloat(v) : 50 })}
                 />
                 {semanasLaborales < 50 && (
                   <p className="text-[10px] font-bold text-amber-600">
@@ -872,15 +841,22 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
 
                   return (
                     <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                      <td className="py-1.5 px-1.5 font-black text-primary">{m.punto_numero}</td>
+                      <td className="py-1.5 px-1.5 font-black text-primary">
+                        <span className="inline-flex items-center gap-1">
+                          {m.punto_numero}
+                          {m.id && isSaved(m.id) && <Check className="w-3 h-3 text-emerald-500" />}
+                        </span>
+                      </td>
                       <td className="py-1.5 px-1.5">
                         <Input
                           className="rounded-lg h-7 text-xs font-medium border-slate-200"
                           defaultValue={m.ubicacion_descripcion}
                           placeholder="Ej: Puerta principal"
-                          onBlur={(e) =>
-                            m.id && updateMedicion(m.id, { ubicacion_descripcion: e.target.value })
-                          }
+                          onBlur={(e) => {
+                            if (!m.id) return;
+                            updateMedicion(m.id, { ubicacion_descripcion: e.target.value });
+                            flash(m.id);
+                          }}
                         />
                       </td>
                       <td className="py-1.5 px-1.5">
@@ -894,6 +870,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                             if (!m.id) return;
                             const usv = e.target.value ? parseFloat(e.target.value) : undefined;
                             updateMedicion(m.id, { tasa_dosis_usv_h: usv });
+                            flash(m.id);
                           }}
                         />
                       </td>
@@ -904,10 +881,13 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                         <select
                           className="rounded-lg border border-slate-200 h-7 text-xs font-medium px-1 bg-white w-full"
                           defaultValue={m.factor_ocupacion_t ?? 1}
-                          onChange={(e) =>
-                            m.id &&
-                            updateMedicion(m.id, { factor_ocupacion_t: parseFloat(e.target.value) })
-                          }
+                          onChange={(e) => {
+                            if (!m.id) return;
+                            updateMedicion(m.id, {
+                              factor_ocupacion_t: parseFloat(e.target.value),
+                            });
+                            flash(m.id);
+                          }}
                         >
                           <option value={1}>1</option>
                           <option value={0.5}>0.5</option>
@@ -920,10 +900,11 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                         <select
                           className="rounded-lg border border-slate-200 h-7 text-xs font-medium px-1 bg-white w-full"
                           defaultValue={m.factor_uso_u ?? 1}
-                          onChange={(e) =>
-                            m.id &&
-                            updateMedicion(m.id, { factor_uso_u: parseFloat(e.target.value) })
-                          }
+                          onChange={(e) => {
+                            if (!m.id) return;
+                            updateMedicion(m.id, { factor_uso_u: parseFloat(e.target.value) });
+                            flash(m.id);
+                          }}
                         >
                           <option value={0.3}>0.3</option>
                           <option value={0.7}>0.7</option>
@@ -934,9 +915,11 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                         <select
                           className="rounded-lg border border-slate-200 h-7 text-xs font-medium px-1 bg-white w-full"
                           defaultValue={m.tipo_area ?? ""}
-                          onChange={(e) =>
-                            m.id && updateMedicion(m.id, { tipo_area: e.target.value || undefined })
-                          }
+                          onChange={(e) => {
+                            if (!m.id) return;
+                            updateMedicion(m.id, { tipo_area: e.target.value || undefined });
+                            flash(m.id);
+                          }}
                         >
                           <option value="">—</option>
                           <option value="controlada">Controlada</option>
@@ -1141,14 +1124,23 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
               <tbody>
                 {(data.elementos ?? []).map((elem, idx) => (
                   <tr key={elem.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                    <td className="py-1.5 px-1.5 font-black text-primary">{idx + 1}</td>
+                    <td className="py-1.5 px-1.5 font-black text-primary">
+                      <span className="inline-flex items-center gap-1">
+                        {idx + 1}
+                        {elem.id && isSaved(elem.id) && (
+                          <Check className="w-3 h-3 text-emerald-500" />
+                        )}
+                      </span>
+                    </td>
                     <td className="py-1.5 px-1.5">
                       <select
                         className="w-full rounded-lg border border-slate-200 h-7 text-xs font-medium px-1 bg-white"
                         defaultValue={elem.descripcion}
-                        onChange={(e) =>
-                          elem.id && updateElemento(elem.id, { descripcion: e.target.value })
-                        }
+                        onChange={(e) => {
+                          if (!elem.id) return;
+                          updateElemento(elem.id, { descripcion: e.target.value });
+                          flash(elem.id);
+                        }}
                       >
                         <option value="">Seleccionar elemento</option>
                         {CATALOGO_ELEMENTOS_PROTECCION.map((nombre) => (
@@ -1163,22 +1155,24 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                         type="number"
                         className="rounded-lg h-7 text-xs font-medium border-slate-200 w-16"
                         defaultValue={elem.cantidad ?? ""}
-                        onBlur={(e) =>
-                          elem.id &&
+                        onBlur={(e) => {
+                          if (!elem.id) return;
                           updateElemento(elem.id, {
                             cantidad: e.target.value ? parseInt(e.target.value) : undefined,
-                          })
-                        }
+                          });
+                          flash(elem.id);
+                        }}
                       />
                     </td>
                     <td className="py-1.5 px-1.5">
                       <select
                         className="rounded-xl font-bold text-xs h-9 px-2 border border-slate-200 bg-white text-slate-600 min-w-[110px]"
                         defaultValue={elem.tipo_paciente ?? ""}
-                        onChange={(e) =>
-                          elem.id &&
-                          updateElemento(elem.id, { tipo_paciente: e.target.value || undefined })
-                        }
+                        onChange={(e) => {
+                          if (!elem.id) return;
+                          updateElemento(elem.id, { tipo_paciente: e.target.value || undefined });
+                          flash(elem.id);
+                        }}
                       >
                         <option value="">Seleccionar</option>
                         <option value="adulto">Adulto</option>
@@ -1188,7 +1182,11 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                     <td className="py-1.5 px-1.5">
                       <ConceptoSelect
                         value={elem.concepto}
-                        onChange={(v) => elem.id && updateElemento(elem.id, { concepto: v })}
+                        onChange={(v) => {
+                          if (!elem.id) return;
+                          updateElemento(elem.id, { concepto: v });
+                          flash(elem.id);
+                        }}
                       />
                     </td>
                     <td className="py-1.5 px-1.5">
@@ -1196,9 +1194,11 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                         className="rounded-lg h-7 text-xs font-medium border-slate-200"
                         placeholder="Estado, grosor, etc."
                         defaultValue={elem.observacion ?? ""}
-                        onBlur={(e) =>
-                          elem.id && updateElemento(elem.id, { observacion: e.target.value })
-                        }
+                        onBlur={(e) => {
+                          if (!elem.id) return;
+                          updateElemento(elem.id, { observacion: e.target.value });
+                          flash(elem.id);
+                        }}
                       />
                     </td>
                     <td className="py-1.5 px-1.5">

--- a/src/components/visita-modulos/grupo-b-modulo.tsx
+++ b/src/components/visita-modulos/grupo-b-modulo.tsx
@@ -5,9 +5,10 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle } from "@/lib/supabase/sync-engine";
+import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
+  Check,
   Zap,
   Trash2,
   Loader2,
@@ -31,6 +32,8 @@ import { Button } from "@/components/ui/button";
 import { irAModulo } from "@/lib/modulo-nav";
 import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
+import { SetupField } from "@/components/visita-modulos/setup-field";
+import { useRowSavedFlash } from "@/hooks/use-row-saved";
 
 // ─── Constants ───
 
@@ -321,6 +324,9 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
   const [manualPrueba, setManualPrueba] = useState<string | undefined>();
   const [importVersion, setImportVersion] = useState(0);
   const pruebasGrupoB = getManualGrupo("B");
+  // Indicador liviano de "guardado" para las filas de las 4 tablas de
+  // disparos RaySafe — ver useRowSavedFlash.
+  const { isSaved, flash } = useRowSavedFlash();
 
   const data = useLiveQuery(async () => {
     if (!isReady || !visitaId) return null;
@@ -449,7 +455,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
         if (m.kv_nominal == null && ref.kv_nominal != null) updates.kv_nominal = ref.kv_nominal;
         if (m.mas_nominal == null && ref.mas_nominal != null) updates.mas_nominal = ref.mas_nominal;
       }
-      if (Object.keys(updates).length > 0) db.conv_raysafe_mediciones.update(m.id, updates);
+      if (Object.keys(updates).length > 0) updateAndSync("conv_raysafe_mediciones", m.id, updates);
     }
   }, [data, visitaId]);
 
@@ -459,7 +465,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
       const m = medicionesFiltradas[i];
       const r = rows[i];
       if (!m.id) continue;
-      await db.conv_raysafe_mediciones.update(m.id, {
+      await updateAndSync("conv_raysafe_mediciones", m.id, {
         kv_medido: r.kv ?? undefined,
         dosis_medida_mgy: r.dosis_mgy ?? undefined,
         tiempo_medido_s: r.tiempo_s ?? undefined,
@@ -491,12 +497,12 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
     if (!data?.setup?.id) return;
     if (setupTimer.current) clearTimeout(setupTimer.current);
     setupTimer.current = setTimeout(() => {
-      db.conv_raysafe_setup.update(data.setup!.id!, fields);
+      updateAndSync("conv_raysafe_setup", data.setup!.id!, fields);
     }, 600);
   }
 
   async function updateMedicion(id: string, fields: Record<string, unknown>) {
-    await db.conv_raysafe_mediciones.update(id, fields);
+    await updateAndSync("conv_raysafe_mediciones", id, fields);
   }
 
   /** Propaga la técnica nominal a todas las tomas del mismo grupo (espejo). */
@@ -507,7 +513,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
     if (grupoNumero == null) return;
     const tomas = principales.filter((p) => p.grupo_numero === grupoNumero);
     await Promise.all(
-      tomas.map((t) => (t.id ? db.conv_raysafe_mediciones.update(t.id, fields) : undefined))
+      tomas.map((t) => (t.id ? updateAndSync("conv_raysafe_mediciones", t.id, fields) : undefined))
     );
   }
 
@@ -523,16 +529,16 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
     field: CampoNominal,
     value: number | undefined
   ) {
-    await db.conv_raysafe_mediciones.update(conRejillaId, { [field]: value });
+    await updateAndSync("conv_raysafe_mediciones", conRejillaId, { [field]: value });
     if (!programaClinico) return;
     const sinRejillaMatch = sinRejilla.find((m) => m.programa_clinico === programaClinico);
     if (sinRejillaMatch?.id) {
-      await db.conv_raysafe_mediciones.update(sinRejillaMatch.id, { [field]: value });
+      await updateAndSync("conv_raysafe_mediciones", sinRejillaMatch.id, { [field]: value });
     }
     if (field === "kv_nominal" || field === "mas_nominal") {
       const kermaMatch = kerma.find((m) => m.programa_clinico === programaClinico);
       if (kermaMatch?.id) {
-        await db.conv_raysafe_mediciones.update(kermaMatch.id, { [field]: value });
+        await updateAndSync("conv_raysafe_mediciones", kermaMatch.id, { [field]: value });
       }
     }
   }
@@ -662,21 +668,11 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
           </Alert>
 
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                Distancia foco-sensor (cm)
-              </label>
-              <Input
-                type="number"
-                className="rounded-xl h-9 text-sm font-medium"
-                defaultValue={setup?.distancia_foco_sensor_cm ?? 100}
-                onBlur={(e) =>
-                  updateSetup({
-                    distancia_foco_sensor_cm: e.target.value ? parseFloat(e.target.value) : 100,
-                  })
-                }
-              />
-            </div>
+            <SetupField
+              label="Distancia foco-sensor (cm)"
+              defaultValue={setup?.distancia_foco_sensor_cm ?? 100}
+              onSave={(v) => updateSetup({ distancia_foco_sensor_cm: v ? parseFloat(v) : 100 })}
+            />
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -774,6 +770,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                           if (esEspejo && isFirstInGroup)
                             updateNominalGrupo(m.grupo_numero, { [campo]: val });
                           else updateMedicion(m.id, { [campo]: val });
+                          flash(m.id);
                         }}
                       />
                     );
@@ -788,7 +785,12 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                       <td className="py-1.5 px-1 font-black text-primary">
                         {isFirstInGroup ? m.grupo_numero : ""}
                       </td>
-                      <td className="py-1.5 px-1 text-slate-500 font-mono">{m.toma_numero}</td>
+                      <td className="py-1.5 px-1 text-slate-500 font-mono">
+                        <span className="inline-flex items-center gap-1">
+                          {m.toma_numero}
+                          {m.id && isSaved(m.id) && <Check className="w-3 h-3 text-emerald-500" />}
+                        </span>
+                      </td>
                       <td className="py-1.5 px-1">{celdaNominal("kv_nominal", "w-16")}</td>
                       <td className="py-1.5 px-1">{celdaNominal("ma_nominal", "w-16")}</td>
                       <td className="py-1.5 px-1">
@@ -815,12 +817,13 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                           className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-16"
                           defaultValue={m.dap_medido ?? ""}
                           placeholder="—"
-                          onBlur={(e) =>
-                            m.id &&
+                          onBlur={(e) => {
+                            if (!m.id) return;
                             updateMedicion(m.id, {
                               dap_medido: e.target.value ? parseFloat(e.target.value) : undefined,
-                            })
-                          }
+                            });
+                            flash(m.id);
+                          }}
                         />
                       </td>
                       <td className="py-1.5 px-1 text-[10px] text-slate-400 font-medium">
@@ -881,7 +884,12 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
               <tbody>
                 {conRejilla.map((m) => (
                   <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                    <td className="py-1.5 px-1.5 font-black text-primary">{m.toma_numero}</td>
+                    <td className="py-1.5 px-1.5 font-black text-primary">
+                      <span className="inline-flex items-center gap-1">
+                        {m.toma_numero}
+                        {m.id && isSaved(m.id) && <Check className="w-3 h-3 text-emerald-500" />}
+                      </span>
+                    </td>
                     <td className="py-1.5 px-1.5 font-medium text-slate-700">
                       {m.programa_clinico}
                     </td>
@@ -893,15 +901,16 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                             step="0.01"
                             className="rounded-lg h-7 text-xs font-medium border-slate-200 w-16"
                             defaultValue={m[field] ?? ""}
-                            onBlur={(e) =>
-                              m.id &&
+                            onBlur={(e) => {
+                              if (!m.id) return;
                               updateNominalConRejilla(
                                 m.id,
                                 m.programa_clinico,
                                 field,
                                 e.target.value ? parseFloat(e.target.value) : undefined
-                              )
-                            }
+                              );
+                              flash(m.id);
+                            }}
                           />
                         </td>
                       )
@@ -915,12 +924,13 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                             className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
                             defaultValue={m[field] ?? ""}
                             placeholder="—"
-                            onBlur={(e) =>
-                              m.id &&
+                            onBlur={(e) => {
+                              if (!m.id) return;
                               updateMedicion(m.id, {
                                 [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                              })
-                            }
+                              });
+                              flash(m.id);
+                            }}
                           />
                         </td>
                       )
@@ -951,42 +961,22 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
           </Tip>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
-            <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                Distancia foco-sensor d1 (cm)
-              </label>
-              <Input
-                type="number"
-                className="rounded-xl h-9 text-sm font-medium"
-                defaultValue={setup?.distancia_foco_sensor_d1_cm ?? ""}
-                placeholder="100"
-                onBlur={(e) =>
-                  updateSetup({
-                    distancia_foco_sensor_d1_cm: e.target.value
-                      ? parseFloat(e.target.value)
-                      : undefined,
-                  })
-                }
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                Distancia foco-detector d2 (cm)
-              </label>
-              <Input
-                type="number"
-                className="rounded-xl h-9 text-sm font-medium"
-                defaultValue={setup?.distancia_foco_detector_d2_cm ?? ""}
-                placeholder="110"
-                onBlur={(e) =>
-                  updateSetup({
-                    distancia_foco_detector_d2_cm: e.target.value
-                      ? parseFloat(e.target.value)
-                      : undefined,
-                  })
-                }
-              />
-            </div>
+            <SetupField
+              label="Distancia foco-sensor d1 (cm)"
+              defaultValue={setup?.distancia_foco_sensor_d1_cm ?? ""}
+              placeholder="100"
+              onSave={(v) =>
+                updateSetup({ distancia_foco_sensor_d1_cm: v ? parseFloat(v) : undefined })
+              }
+            />
+            <SetupField
+              label="Distancia foco-detector d2 (cm)"
+              defaultValue={setup?.distancia_foco_detector_d2_cm ?? ""}
+              placeholder="110"
+              onSave={(v) =>
+                updateSetup({ distancia_foco_detector_d2_cm: v ? parseFloat(v) : undefined })
+              }
+            />
           </div>
 
           <div
@@ -1024,7 +1014,12 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                     : undefined;
                   return (
                     <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                      <td className="py-1.5 px-1.5 font-black text-primary">{m.toma_numero}</td>
+                      <td className="py-1.5 px-1.5 font-black text-primary">
+                        <span className="inline-flex items-center gap-1">
+                          {m.toma_numero}
+                          {m.id && isSaved(m.id) && <Check className="w-3 h-3 text-emerald-500" />}
+                        </span>
+                      </td>
                       <td className="py-1.5 px-1.5 font-medium text-slate-700">
                         {m.programa_clinico}
                       </td>
@@ -1048,12 +1043,13 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                               className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
                               defaultValue={m[field] ?? ""}
                               placeholder="—"
-                              onBlur={(e) =>
-                                m.id &&
+                              onBlur={(e) => {
+                                if (!m.id) return;
                                 updateMedicion(m.id, {
                                   [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                                })
-                              }
+                                });
+                                flash(m.id);
+                              }}
                             />
                           </td>
                         )
@@ -1065,14 +1061,15 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                           className="rounded-lg h-7 text-xs font-medium border-amber-200 bg-amber-50/50 w-20"
                           defaultValue={m.dosis_base_mgy ?? ""}
                           placeholder="—"
-                          onBlur={(e) =>
-                            m.id &&
+                          onBlur={(e) => {
+                            if (!m.id) return;
                             updateMedicion(m.id, {
                               dosis_base_mgy: e.target.value
                                 ? parseFloat(e.target.value)
                                 : undefined,
-                            })
-                          }
+                            });
+                            flash(m.id);
+                          }}
                         />
                       </td>
                     </tr>
@@ -1138,7 +1135,12 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                     : undefined;
                   return (
                     <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                      <td className="py-1.5 px-1 font-black text-primary">{m.toma_numero}</td>
+                      <td className="py-1.5 px-1 font-black text-primary">
+                        <span className="inline-flex items-center gap-1">
+                          {m.toma_numero}
+                          {m.id && isSaved(m.id) && <Check className="w-3 h-3 text-emerald-500" />}
+                        </span>
+                      </td>
                       <td className="py-1.5 px-1 font-medium text-slate-700">
                         {m.programa_clinico}
                       </td>
@@ -1175,12 +1177,13 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                               ((m as unknown as Record<string, unknown>)[field] as string) ?? ""
                             }
                             placeholder="—"
-                            onBlur={(e) =>
-                              m.id &&
+                            onBlur={(e) => {
+                              if (!m.id) return;
                               updateMedicion(m.id, {
                                 [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                              })
-                            }
+                              });
+                              flash(m.id);
+                            }}
                           />
                         </td>
                       ))}

--- a/src/components/visita-modulos/grupo-c-modulo.tsx
+++ b/src/components/visita-modulos/grupo-c-modulo.tsx
@@ -5,9 +5,10 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle } from "@/lib/supabase/sync-engine";
+import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
+  Check,
   SlidersHorizontal,
   Loader2,
   AlertCircle,
@@ -26,6 +27,8 @@ import { Button } from "@/components/ui/button";
 import { irAModulo } from "@/lib/modulo-nav";
 import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
+import { SetupField } from "@/components/visita-modulos/setup-field";
+import { useRowSavedFlash } from "@/hooks/use-row-saved";
 
 // ─── Constants ───
 
@@ -278,6 +281,9 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
   const [manualOpen, setManualOpen] = useState(false);
   const [manualPrueba, setManualPrueba] = useState<string | undefined>();
   const pruebasManual = getManualGrupo("C");
+  // Indicador liviano de "guardado" para la tabla de 15 disparos — ver
+  // useRowSavedFlash.
+  const { isSaved, flash } = useRowSavedFlash();
 
   // ─── Live data ───
   const data = useLiveQuery(async () => {
@@ -319,7 +325,7 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
 
   // ─── Save helpers ───
   async function updateMedicion(id: string, fields: Record<string, unknown>) {
-    await db.conv_cae_mediciones.update(id, fields);
+    await updateAndSync("conv_cae_mediciones", id, fields);
   }
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
@@ -368,7 +374,7 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
 
   async function saveSetup(fields: Record<string, number | undefined>) {
     if (setup?.id) {
-      await db.conv_cae_setup.update(setup.id, fields);
+      await updateAndSync("conv_cae_setup", setup.id, fields);
     } else {
       const newId = await db.conv_cae_setup.add({
         id: randomUUID(),
@@ -596,7 +602,12 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
                   const disp = DISPAROS_CAE.find((d) => d.toma === m.toma_numero);
                   return (
                     <tr key={m.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                      <td className="py-1.5 px-1.5 font-black text-primary">{m.toma_numero}</td>
+                      <td className="py-1.5 px-1.5 font-black text-primary">
+                        <span className="inline-flex items-center gap-1">
+                          {m.toma_numero}
+                          {m.id && isSaved(m.id) && <Check className="w-3 h-3 text-emerald-500" />}
+                        </span>
+                      </td>
                       <td className="py-1.5 px-1.5 text-slate-600 font-mono">{m.kv_nominal}</td>
                       <td className="py-1.5 px-1.5 text-slate-600 font-mono">{m.espesor_cu_mm}</td>
                       <td className="py-1.5 px-1.5 text-slate-600 font-medium text-[11px]">
@@ -611,12 +622,13 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
                             className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
                             defaultValue={m[field] ?? ""}
                             placeholder="—"
-                            onBlur={(e) =>
-                              m.id &&
+                            onBlur={(e) => {
+                              if (!m.id) return;
                               updateMedicion(m.id, {
                                 [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                              })
-                            }
+                              });
+                              flash(m.id);
+                            }}
                           />
                         </td>
                       ))}
@@ -656,19 +668,14 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
                   { label: "D.I. base", field: "di_base_217" },
                 ] as const
               ).map(({ label, field }) => (
-                <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                    {label}
-                  </label>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    className="rounded-xl h-9 text-sm font-medium"
-                    defaultValue={setup?.[field] ?? ""}
-                    placeholder="—"
-                    onBlur={(e) => saveSetup({ [field]: parseSetupField(e.target.value) })}
-                  />
-                </div>
+                <SetupField
+                  key={field}
+                  label={label}
+                  step="0.01"
+                  defaultValue={setup?.[field] ?? ""}
+                  placeholder="—"
+                  onSave={(v) => saveSetup({ [field]: parseSetupField(v) })}
+                />
               ))}
             </div>
           </CollapsibleSection>
@@ -696,19 +703,15 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
                 <div key={kv} className="grid grid-cols-4 gap-2 items-end">
                   <div className="text-xs font-black text-primary">{kv} kVp</div>
                   {(["mas", "ei", "di"] as const).map((f) => (
-                    <div key={f} className="space-y-1">
-                      <label className="text-[9px] font-black text-slate-400 uppercase">
-                        {f === "mas" ? "mAs" : f === "ei" ? "EI" : "D.I."}
-                      </label>
-                      <Input
-                        type="number"
-                        step="0.01"
-                        className="rounded-lg h-8 text-xs font-medium"
-                        defaultValue={setup?.[fields[f]] ?? ""}
-                        placeholder="—"
-                        onBlur={(e) => saveSetup({ [fields[f]]: parseSetupField(e.target.value) })}
-                      />
-                    </div>
+                    <SetupField
+                      key={f}
+                      label={f === "mas" ? "mAs" : f === "ei" ? "EI" : "D.I."}
+                      step="0.01"
+                      className="rounded-lg h-8 text-xs font-medium"
+                      defaultValue={setup?.[fields[f]] ?? ""}
+                      placeholder="—"
+                      onSave={(v) => saveSetup({ [fields[f]]: parseSetupField(v) })}
+                    />
                   ))}
                 </div>
               ))}
@@ -738,19 +741,15 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
                 <div key={cu} className="grid grid-cols-4 gap-2 items-end">
                   <div className="text-xs font-black text-primary">Cu {cu} mm</div>
                   {(["mas", "ei", "di"] as const).map((f) => (
-                    <div key={f} className="space-y-1">
-                      <label className="text-[9px] font-black text-slate-400 uppercase">
-                        {f === "mas" ? "mAs" : f === "ei" ? "EI" : "D.I."}
-                      </label>
-                      <Input
-                        type="number"
-                        step="0.01"
-                        className="rounded-lg h-8 text-xs font-medium"
-                        defaultValue={setup?.[fields[f]] ?? ""}
-                        placeholder="—"
-                        onBlur={(e) => saveSetup({ [fields[f]]: parseSetupField(e.target.value) })}
-                      />
-                    </div>
+                    <SetupField
+                      key={f}
+                      label={f === "mas" ? "mAs" : f === "ei" ? "EI" : "D.I."}
+                      step="0.01"
+                      className="rounded-lg h-8 text-xs font-medium"
+                      defaultValue={setup?.[fields[f]] ?? ""}
+                      placeholder="—"
+                      onSave={(v) => saveSetup({ [fields[f]]: parseSetupField(v) })}
+                    />
                   ))}
                 </div>
               ))}

--- a/src/components/visita-modulos/grupo-d-modulo.tsx
+++ b/src/components/visita-modulos/grupo-d-modulo.tsx
@@ -5,9 +5,10 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle } from "@/lib/supabase/sync-engine";
+import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
+  Check,
   MonitorCheck,
   Loader2,
   AlertCircle,
@@ -27,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { irAModulo } from "@/lib/modulo-nav";
 import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
+import { useRowSavedFlash } from "@/hooks/use-row-saved";
 
 // ─── Helpers ───
 
@@ -271,6 +273,9 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
   const [manualOpen, setManualOpen] = useState(false);
   const [manualPrueba, setManualPrueba] = useState<string | undefined>();
   const pruebasManual = getManualGrupo("D");
+  // Indicador liviano de "guardado" para las tablas de disparos DDI,
+  // cassettes y uniformidad — ver useRowSavedFlash.
+  const { isSaved, flash } = useRowSavedFlash();
 
   // ─── Live data ───
   const data = useLiveQuery(async () => {
@@ -320,6 +325,8 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
   // ─── Valores base (precarga) para 2.9 ───
   const [baseEi29, setBaseEi29] = useState("");
   const [baseDi29, setBaseDi29] = useState("");
+  const [savedEiBase, setSavedEiBase] = useState(false);
+  const [savedDiBase, setSavedDiBase] = useState(false);
 
   // Initialize base values from DB record once data loads
   useEffect(() => {
@@ -331,7 +338,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
 
   // ─── Save helpers ───
   async function updateDdi(id: string, fields: Record<string, unknown>) {
-    await db.conv_ddi_mediciones.update(id, fields);
+    await updateAndSync("conv_ddi_mediciones", id, fields);
   }
 
   async function addCassette() {
@@ -348,7 +355,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function updateCassette(id: string, fields: Record<string, unknown>) {
-    await db.conv_cassette_inspeccion.update(id, fields);
+    await updateAndSync("conv_cassette_inspeccion", id, fields);
   }
 
   async function removeCassette(id: string) {
@@ -369,7 +376,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function updateUniformidad(id: string, fields: Record<string, unknown>) {
-    await db.conv_uniformidad_cr.update(id, fields);
+    await updateAndSync("conv_uniformidad_cr", id, fields);
   }
 
   async function removeUniformidad(id: string) {
@@ -575,15 +582,22 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                       <td className="py-1.5 px-1.5 font-black text-primary">
                         {isFirstInGroup ? m.grupo : ""}
                       </td>
-                      <td className="py-1.5 px-1.5 text-slate-500 font-mono">{m.toma_numero}</td>
+                      <td className="py-1.5 px-1.5 text-slate-500 font-mono">
+                        <span className="inline-flex items-center gap-1">
+                          {m.toma_numero}
+                          {m.id && isSaved(m.id) && <Check className="w-3 h-3 text-emerald-500" />}
+                        </span>
+                      </td>
                       <td className="py-1.5 px-1.5">
                         <Input
                           className="rounded-lg h-7 text-xs font-medium border-slate-200 w-28"
                           defaultValue={m.serie_detector ?? ""}
                           placeholder="Serie"
-                          onBlur={(e) =>
-                            m.id && updateDdi(m.id, { serie_detector: e.target.value || undefined })
-                          }
+                          onBlur={(e) => {
+                            if (!m.id) return;
+                            updateDdi(m.id, { serie_detector: e.target.value || undefined });
+                            flash(m.id);
+                          }}
                         />
                       </td>
                       <td className="py-1.5 px-1.5 text-slate-600 font-mono">{m.kv_nominal}</td>
@@ -595,12 +609,13 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                             className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
                             defaultValue={m[field] ?? ""}
                             placeholder="—"
-                            onBlur={(e) =>
-                              m.id &&
+                            onBlur={(e) => {
+                              if (!m.id) return;
                               updateDdi(m.id, {
                                 [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                              })
-                            }
+                              });
+                              flash(m.id);
+                            }}
                           />
                         </td>
                       ))}
@@ -625,8 +640,9 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
           </StepHeader>
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
                 EI base
+                {savedEiBase && <Check className="w-3 h-3 text-emerald-500" />}
               </label>
               <Input
                 type="number"
@@ -636,14 +652,19 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                 onChange={(e) => setBaseEi29(e.target.value)}
                 onBlur={(e) => {
                   const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
-                  if (t1?.id) updateDdi(t1.id, { ei_base: parseFloat(e.target.value) || null });
+                  if (t1?.id) {
+                    updateDdi(t1.id, { ei_base: parseFloat(e.target.value) || null });
+                    setSavedEiBase(true);
+                    setTimeout(() => setSavedEiBase(false), 1500);
+                  }
                 }}
                 placeholder="—"
               />
             </div>
             <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
                 D.I. base
+                {savedDiBase && <Check className="w-3 h-3 text-emerald-500" />}
               </label>
               <Input
                 type="number"
@@ -653,7 +674,11 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                 onChange={(e) => setBaseDi29(e.target.value)}
                 onBlur={(e) => {
                   const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
-                  if (t1?.id) updateDdi(t1.id, { di_base: parseFloat(e.target.value) || null });
+                  if (t1?.id) {
+                    updateDdi(t1.id, { di_base: parseFloat(e.target.value) || null });
+                    setSavedDiBase(true);
+                    setTimeout(() => setSavedDiBase(false), 1500);
+                  }
                 }}
                 placeholder="—"
               />
@@ -751,16 +776,19 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
             >
               <div className="space-y-3">
                 <div className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
                     Serie del detector
+                    {c.id && isSaved(c.id) && <Check className="w-3 h-3 text-emerald-500" />}
                   </label>
                   <Input
                     className="rounded-xl h-8 text-xs font-medium"
                     defaultValue={c.serie_detector ?? ""}
                     placeholder="Ej: SN-12345"
-                    onBlur={(e) =>
-                      c.id && updateCassette(c.id, { serie_detector: e.target.value || undefined })
-                    }
+                    onBlur={(e) => {
+                      if (!c.id) return;
+                      updateCassette(c.id, { serie_detector: e.target.value || undefined });
+                      flash(c.id);
+                    }}
                   />
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
@@ -772,7 +800,11 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                       <span className="text-[11px] font-medium text-slate-600">{campo.label}</span>
                       <ConceptoSelect
                         value={c[campo.key]}
-                        onChange={(v) => c.id && updateCassette(c.id, { [campo.key]: v })}
+                        onChange={(v) => {
+                          if (!c.id) return;
+                          updateCassette(c.id, { [campo.key]: v });
+                          flash(c.id);
+                        }}
                       />
                     </div>
                   ))}
@@ -781,16 +813,22 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                   <span className="text-[11px] font-bold text-slate-700">Concepto global</span>
                   <ConceptoSelect
                     value={c.concepto}
-                    onChange={(v) => c.id && updateCassette(c.id, { concepto: v })}
+                    onChange={(v) => {
+                      if (!c.id) return;
+                      updateCassette(c.id, { concepto: v });
+                      flash(c.id);
+                    }}
                   />
                 </div>
                 <Input
                   className="rounded-xl h-8 text-xs font-medium"
                   placeholder="Observaciones"
                   defaultValue={c.observacion ?? ""}
-                  onBlur={(e) =>
-                    c.id && updateCassette(c.id, { observacion: e.target.value || undefined })
-                  }
+                  onBlur={(e) => {
+                    if (!c.id) return;
+                    updateCassette(c.id, { observacion: e.target.value || undefined });
+                    flash(c.id);
+                  }}
                 />
                 <button
                   type="button"
@@ -846,16 +884,22 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
               <tbody>
                 {(data.uniformidad ?? []).map((u) => (
                   <tr key={u.id} className="border-b border-slate-100 hover:bg-slate-50/50">
-                    <td className="py-1.5 px-1.5 font-black text-primary">{u.item_numero}</td>
+                    <td className="py-1.5 px-1.5 font-black text-primary">
+                      <span className="inline-flex items-center gap-1">
+                        {u.item_numero}
+                        {u.id && isSaved(u.id) && <Check className="w-3 h-3 text-emerald-500" />}
+                      </span>
+                    </td>
                     <td className="py-1.5 px-1.5">
                       <Input
                         className="rounded-lg h-7 text-xs font-medium border-slate-200 w-28"
                         defaultValue={u.serie_cassette ?? ""}
                         placeholder="Serie"
-                        onBlur={(e) =>
-                          u.id &&
-                          updateUniformidad(u.id, { serie_cassette: e.target.value || undefined })
-                        }
+                        onBlur={(e) => {
+                          if (!u.id) return;
+                          updateUniformidad(u.id, { serie_cassette: e.target.value || undefined });
+                          flash(u.id);
+                        }}
                       />
                     </td>
                     {(["carga_mas", "ei", "di", "tei"] as const).map((field) => (
@@ -866,12 +910,13 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                           className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50 w-20"
                           defaultValue={u[field] ?? ""}
                           placeholder="—"
-                          onBlur={(e) =>
-                            u.id &&
+                          onBlur={(e) => {
+                            if (!u.id) return;
                             updateUniformidad(u.id, {
                               [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                            })
-                          }
+                            });
+                            flash(u.id);
+                          }}
                         />
                       </td>
                     ))}

--- a/src/components/visita-modulos/grupo-e-modulo.tsx
+++ b/src/components/visita-modulos/grupo-e-modulo.tsx
@@ -5,9 +5,10 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle } from "@/lib/supabase/sync-engine";
+import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
+  Check,
   Target,
   Loader2,
   AlertCircle,
@@ -27,6 +28,8 @@ import { Button } from "@/components/ui/button";
 import { irAModulo } from "@/lib/modulo-nav";
 import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
+import { SetupField } from "@/components/visita-modulos/setup-field";
+import { useRowSavedFlash } from "@/hooks/use-row-saved";
 
 // ─── Helpers ───
 
@@ -232,6 +235,9 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
   const [manualOpen, setManualOpen] = useState(false);
   const [manualPrueba, setManualPrueba] = useState<string | undefined>();
   const pruebasManual = getManualGrupo("E");
+  // Indicador liviano de "guardado" para la tabla de uniformidad de
+  // detectores — ver useRowSavedFlash.
+  const { isSaved, flash } = useRowSavedFlash();
 
   // ─── Live data ───
   const data = useLiveQuery(async () => {
@@ -321,23 +327,23 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
     if (!data?.colimacion?.id) return;
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
-      db.conv_colimacion.update(data.colimacion!.id!, fields);
+      updateAndSync("conv_colimacion", data.colimacion!.id!, fields);
     }, 600);
   }
 
   function updateResolucion(fields: Record<string, unknown>) {
     if (!data?.resolucion?.id) return;
-    db.conv_resolucion.update(data.resolucion.id, fields);
+    updateAndSync("conv_resolucion", data.resolucion.id, fields);
   }
 
   function updateBajoContraste(fields: Record<string, unknown>) {
     if (!data?.bajoContraste?.id) return;
-    db.conv_bajo_contraste.update(data.bajoContraste.id, fields);
+    updateAndSync("conv_bajo_contraste", data.bajoContraste.id, fields);
   }
 
   function updateMtf(fields: Record<string, unknown>) {
     if (!data?.mtf?.id) return;
-    db.conv_mtf.update(data.mtf.id, fields);
+    updateAndSync("conv_mtf", data.mtf.id, fields);
   }
 
   async function addUniformidadDet() {
@@ -354,7 +360,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function updateUniformidadDet(id: string, fields: Record<string, unknown>) {
-    await db.conv_uniformidad_detector.update(id, fields);
+    await updateAndSync("conv_uniformidad_detector", id, fields);
   }
 
   async function removeUniformidadDet(id: string) {
@@ -542,43 +548,26 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
 
           <CollapsibleSection title="Tecnica y distancia">
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-              <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                  SID (cm)
-                </label>
-                <Input
-                  type="number"
-                  className="rounded-xl h-9 text-sm font-medium"
-                  defaultValue={colim?.sid_cm ?? 100}
-                  onBlur={(e) =>
-                    updateColimacion({ sid_cm: e.target.value ? parseFloat(e.target.value) : 100 })
-                  }
-                />
-              </div>
+              <SetupField
+                label="SID (cm)"
+                defaultValue={colim?.sid_cm ?? 100}
+                onSave={(v) => updateColimacion({ sid_cm: v ? parseFloat(v) : 100 })}
+              />
               {[
                 ["tecnica_kv", "kVp", "75"],
                 ["tecnica_ma", "mA", ""],
                 ["tecnica_mas", "mAs", ""],
               ].map(([field, label, ph]) => (
-                <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                    {label}
-                  </label>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    className="rounded-xl h-9 text-sm font-medium"
-                    defaultValue={
-                      ((colim as Record<string, unknown> | undefined)?.[field] as string) ?? ""
-                    }
-                    placeholder={ph}
-                    onBlur={(e) =>
-                      updateColimacion({
-                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                      })
-                    }
-                  />
-                </div>
+                <SetupField
+                  key={field}
+                  label={label}
+                  step="0.01"
+                  defaultValue={
+                    ((colim as Record<string, unknown> | undefined)?.[field] as string) ?? ""
+                  }
+                  placeholder={ph}
+                  onSave={(v) => updateColimacion({ [field]: v ? parseFloat(v) : undefined })}
+                />
               ))}
             </div>
           </CollapsibleSection>
@@ -589,52 +578,34 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
               {DIRECCIONES.map((d) => (
                 <div key={d.key} className="grid grid-cols-3 gap-2 items-end">
                   <div className="text-xs font-black text-primary">{d.label}</div>
-                  <div className="space-y-1">
-                    <label className="text-[9px] font-black text-slate-400 uppercase">
-                      Nominal (cm)
-                    </label>
-                    <Input
-                      type="number"
-                      step="0.1"
-                      className="rounded-lg h-8 text-xs font-medium"
-                      defaultValue={
-                        ((colim as Record<string, unknown> | undefined)?.[
-                          `${d.key}_nominal`
-                        ] as string) ?? ""
-                      }
-                      placeholder="—"
-                      onBlur={(e) =>
-                        updateColimacion({
-                          [`${d.key}_nominal`]: e.target.value
-                            ? parseFloat(e.target.value)
-                            : undefined,
-                        })
-                      }
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <label className="text-[9px] font-black text-slate-400 uppercase">
-                      Medido (cm)
-                    </label>
-                    <Input
-                      type="number"
-                      step="0.1"
-                      className="rounded-lg h-8 text-xs font-medium border-blue-200 bg-blue-50/50"
-                      defaultValue={
-                        ((colim as Record<string, unknown> | undefined)?.[
-                          `${d.key}_medido`
-                        ] as string) ?? ""
-                      }
-                      placeholder="—"
-                      onBlur={(e) =>
-                        updateColimacion({
-                          [`${d.key}_medido`]: e.target.value
-                            ? parseFloat(e.target.value)
-                            : undefined,
-                        })
-                      }
-                    />
-                  </div>
+                  <SetupField
+                    label="Nominal (cm)"
+                    step="0.1"
+                    className="rounded-lg h-8 text-xs font-medium"
+                    defaultValue={
+                      ((colim as Record<string, unknown> | undefined)?.[
+                        `${d.key}_nominal`
+                      ] as string) ?? ""
+                    }
+                    placeholder="—"
+                    onSave={(v) =>
+                      updateColimacion({ [`${d.key}_nominal`]: v ? parseFloat(v) : undefined })
+                    }
+                  />
+                  <SetupField
+                    label="Medido (cm)"
+                    step="0.1"
+                    className="rounded-lg h-8 text-xs font-medium border-blue-200 bg-blue-50/50"
+                    defaultValue={
+                      ((colim as Record<string, unknown> | undefined)?.[
+                        `${d.key}_medido`
+                      ] as string) ?? ""
+                    }
+                    placeholder="—"
+                    onSave={(v) =>
+                      updateColimacion({ [`${d.key}_medido`]: v ? parseFloat(v) : undefined })
+                    }
+                  />
                 </div>
               ))}
             </div>
@@ -758,15 +729,26 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
               title={`Detector ${idx + 1}${ur.det.serie_detector ? ` — ${ur.det.serie_detector}` : ""}`}
             >
               <div className="space-y-3">
-                <Input
-                  className="rounded-xl h-8 text-xs font-medium"
-                  placeholder="Serie del detector"
-                  defaultValue={ur.det.serie_detector ?? ""}
-                  onBlur={(e) =>
-                    ur.det.id &&
-                    updateUniformidadDet(ur.det.id, { serie_detector: e.target.value || undefined })
-                  }
-                />
+                <div className="space-y-1">
+                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
+                    Serie del detector
+                    {ur.det.id && isSaved(ur.det.id) && (
+                      <Check className="w-3 h-3 text-emerald-500" />
+                    )}
+                  </label>
+                  <Input
+                    className="rounded-xl h-8 text-xs font-medium"
+                    placeholder="Serie del detector"
+                    defaultValue={ur.det.serie_detector ?? ""}
+                    onBlur={(e) => {
+                      if (!ur.det.id) return;
+                      updateUniformidadDet(ur.det.id, {
+                        serie_detector: e.target.value || undefined,
+                      });
+                      flash(ur.det.id);
+                    }}
+                  />
+                </div>
 
                 {/* Tolerancia */}
                 <div className="flex items-center gap-2">
@@ -778,12 +760,13 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                     step="1"
                     className="rounded-lg h-7 text-xs font-medium w-20"
                     defaultValue={ur.det.tolerancia_pct ?? 15}
-                    onBlur={(e) =>
-                      ur.det.id &&
+                    onBlur={(e) => {
+                      if (!ur.det.id) return;
                       updateUniformidadDet(ur.det.id, {
                         tolerancia_pct: e.target.value ? parseFloat(e.target.value) : 15,
-                      })
-                    }
+                      });
+                      flash(ur.det.id);
+                    }}
                   />
                 </div>
 
@@ -807,14 +790,15 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                               className="rounded-lg h-7 text-xs font-medium border-blue-200 bg-blue-50/50"
                               defaultValue={(ur.det[vmpField] as number) ?? ""}
                               placeholder="VMP"
-                              onBlur={(e) =>
-                                ur.det.id &&
+                              onBlur={(e) => {
+                                if (!ur.det.id) return;
                                 updateUniformidadDet(ur.det.id, {
                                   [vmpField]: e.target.value
                                     ? parseFloat(e.target.value)
                                     : undefined,
-                                })
-                              }
+                                });
+                                flash(ur.det.id);
+                              }}
                             />
                             <Input
                               type="number"
@@ -822,14 +806,15 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                               className="rounded-lg h-7 text-xs font-medium border-slate-200"
                               defaultValue={(ur.det[desvField] as number) ?? ""}
                               placeholder="Desv."
-                              onBlur={(e) =>
-                                ur.det.id &&
+                              onBlur={(e) => {
+                                if (!ur.det.id) return;
                                 updateUniformidadDet(ur.det.id, {
                                   [desvField]: e.target.value
                                     ? parseFloat(e.target.value)
                                     : undefined,
-                                })
-                              }
+                                });
+                                flash(ur.det.id);
+                              }}
                             />
                           </div>
                         );
@@ -954,49 +939,21 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
           </div>
 
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                SID (cm)
-              </label>
-              <Input
-                type="number"
-                className="rounded-xl h-9 text-sm font-medium"
-                defaultValue={resol?.sid_cm ?? 100}
-                onBlur={(e) =>
-                  updateResolucion({ sid_cm: e.target.value ? parseFloat(e.target.value) : 100 })
-                }
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                kVp
-              </label>
-              <Input
-                type="number"
-                className="rounded-xl h-9 text-sm font-medium"
-                defaultValue={resol?.tecnica_kv ?? 75}
-                onBlur={(e) =>
-                  updateResolucion({
-                    tecnica_kv: e.target.value ? parseFloat(e.target.value) : undefined,
-                  })
-                }
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                mAs
-              </label>
-              <Input
-                type="number"
-                className="rounded-xl h-9 text-sm font-medium"
-                defaultValue={resol?.tecnica_mas ?? ""}
-                onBlur={(e) =>
-                  updateResolucion({
-                    tecnica_mas: e.target.value ? parseFloat(e.target.value) : undefined,
-                  })
-                }
-              />
-            </div>
+            <SetupField
+              label="SID (cm)"
+              defaultValue={resol?.sid_cm ?? 100}
+              onSave={(v) => updateResolucion({ sid_cm: v ? parseFloat(v) : 100 })}
+            />
+            <SetupField
+              label="kVp"
+              defaultValue={resol?.tecnica_kv ?? 75}
+              onSave={(v) => updateResolucion({ tecnica_kv: v ? parseFloat(v) : undefined })}
+            />
+            <SetupField
+              label="mAs"
+              defaultValue={resol?.tecnica_mas ?? ""}
+              onSave={(v) => updateResolucion({ tecnica_mas: v ? parseFloat(v) : undefined })}
+            />
           </div>
 
           <div className="space-y-1">
@@ -1153,25 +1110,16 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                 ["pixel_size_mm", "Pixel size (mm)", "0.15"],
                 ["nyquist_lpmm", "Nyquist (lp/mm)", "3.33"],
               ].map(([field, label, ph]) => (
-                <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                    {label}
-                  </label>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    className="rounded-xl h-9 text-sm font-medium"
-                    defaultValue={
-                      ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
-                    }
-                    placeholder={ph}
-                    onBlur={(e) =>
-                      updateMtf({
-                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                      })
-                    }
-                  />
-                </div>
+                <SetupField
+                  key={field}
+                  label={label}
+                  step="0.01"
+                  defaultValue={
+                    ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
+                  }
+                  placeholder={ph}
+                  onSave={(v) => updateMtf({ [field]: v ? parseFloat(v) : undefined })}
+                />
               ))}
             </div>
           </CollapsibleSection>
@@ -1184,25 +1132,17 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                 ["mtf50_vertical", "MTF50 Vertical (lp/mm)"],
                 ["mtf20_vertical", "MTF20 Vertical (lp/mm)"],
               ].map(([field, label]) => (
-                <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                    {label}
-                  </label>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    className="rounded-xl h-9 text-sm font-medium border-blue-200 bg-blue-50/50"
-                    defaultValue={
-                      ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
-                    }
-                    placeholder="—"
-                    onBlur={(e) =>
-                      updateMtf({
-                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                      })
-                    }
-                  />
-                </div>
+                <SetupField
+                  key={field}
+                  label={label}
+                  step="0.01"
+                  className="rounded-xl h-9 text-sm font-medium border-blue-200 bg-blue-50/50"
+                  defaultValue={
+                    ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
+                  }
+                  placeholder="—"
+                  onSave={(v) => updateMtf({ [field]: v ? parseFloat(v) : undefined })}
+                />
               ))}
             </div>
           </CollapsibleSection>
@@ -1216,25 +1156,16 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                 ["mtf50_base_vertical", "MTF50 Base Vert."],
                 ["mtf20_base_vertical", "MTF20 Base Vert."],
               ].map(([field, label]) => (
-                <div key={field} className="space-y-1">
-                  <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                    {label}
-                  </label>
-                  <Input
-                    type="number"
-                    step="0.01"
-                    className="rounded-xl h-9 text-sm font-medium"
-                    defaultValue={
-                      ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
-                    }
-                    placeholder="—"
-                    onBlur={(e) =>
-                      updateMtf({
-                        [field]: e.target.value ? parseFloat(e.target.value) : undefined,
-                      })
-                    }
-                  />
-                </div>
+                <SetupField
+                  key={field}
+                  label={label}
+                  step="0.01"
+                  defaultValue={
+                    ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
+                  }
+                  placeholder="—"
+                  onSave={(v) => updateMtf({ [field]: v ? parseFloat(v) : undefined })}
+                />
               ))}
             </div>
           </CollapsibleSection>

--- a/src/components/visita-modulos/pre-informe-modulo.tsx
+++ b/src/components/visita-modulos/pre-informe-modulo.tsx
@@ -5,10 +5,12 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { randomUUID } from "@/lib/uuid";
 import { useDb } from "@/components/db-provider";
+import { updateAndSync } from "@/lib/supabase/sync-engine";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
   ArrowLeft,
+  Check,
   FileText,
   Download,
   Eye,
@@ -74,6 +76,20 @@ function SeccionCard({
   const analisisRef = useRef<HTMLTextAreaElement>(null);
   const accionesRef = useRef<HTMLTextAreaElement>(null);
   const sinCriterio = !tieneCriterio(catalogo.codigo);
+  const [savedAcciones, setSavedAcciones] = useState(false);
+  const [savedObservaciones, setSavedObservaciones] = useState(false);
+
+  const handleUpdateAcciones = (v: string) => {
+    onUpdateAcciones(v);
+    setSavedAcciones(true);
+    setTimeout(() => setSavedAcciones(false), 1500);
+  };
+
+  const handleUpdateObservaciones = (v: string) => {
+    onUpdateObservaciones(v);
+    setSavedObservaciones(true);
+    setTimeout(() => setSavedObservaciones(false), 1500);
+  };
 
   // Acciones correctivas con predeterminado editable — solo 2.1, 2.2 y 2.13
   // (las demás pruebas usan el textarea libre, solo visible en No conforme).
@@ -169,14 +185,15 @@ function SeccionCard({
           {tieneAccionesPredeterminadas && accionDefault != null ? (
             <div className="space-y-1">
               <div className="flex items-center justify-between gap-2">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
                   Acciones correctivas
+                  {savedAcciones && <Check className="w-3 h-3 text-emerald-500" />}
                 </label>
                 <button
                   type="button"
                   onClick={() => {
                     if (accionesRef.current) accionesRef.current.value = accionDefault;
-                    onUpdateAcciones(accionDefault);
+                    handleUpdateAcciones(accionDefault);
                   }}
                   className="inline-flex items-center gap-1 text-[10px] font-bold text-slate-400 hover:text-primary transition-colors"
                 >
@@ -190,20 +207,21 @@ function SeccionCard({
                 className="w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
                 defaultValue={seccion.acciones_correctivas ?? accionDefault}
                 placeholder="Describa las acciones correctivas requeridas..."
-                onBlur={(e) => onUpdateAcciones(e.target.value)}
+                onBlur={(e) => handleUpdateAcciones(e.target.value)}
               />
             </div>
           ) : (
             conceptoEfectivo === "No_conforme" && (
               <div className="space-y-1">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
                   Acciones correctivas
+                  {savedAcciones && <Check className="w-3 h-3 text-emerald-500" />}
                 </label>
                 <textarea
                   className="w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
                   defaultValue={seccion.acciones_correctivas ?? ""}
                   placeholder="Describa las acciones correctivas requeridas..."
-                  onBlur={(e) => onUpdateAcciones(e.target.value)}
+                  onBlur={(e) => handleUpdateAcciones(e.target.value)}
                 />
               </div>
             )
@@ -214,15 +232,16 @@ function SeccionCard({
           {catalogo.analisis && (
             <div className="space-y-1">
               <div className="flex items-center justify-between gap-2">
-                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
                   Análisis
+                  {savedObservaciones && <Check className="w-3 h-3 text-emerald-500" />}
                 </label>
                 <button
                   type="button"
                   onClick={() => {
                     const def = catalogo.analisis ?? "";
                     if (analisisRef.current) analisisRef.current.value = def;
-                    onUpdateObservaciones(def);
+                    handleUpdateObservaciones(def);
                   }}
                   className="inline-flex items-center gap-1 text-[10px] font-bold text-slate-400 hover:text-primary transition-colors"
                 >
@@ -235,7 +254,7 @@ function SeccionCard({
                 className="w-full rounded-xl border border-slate-200 p-2.5 text-xs font-medium resize-none h-40 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
                 defaultValue={seccion.observaciones ?? catalogo.analisis ?? ""}
                 placeholder="Análisis de la inspección visual..."
-                onBlur={(e) => onUpdateObservaciones(e.target.value)}
+                onBlur={(e) => handleUpdateObservaciones(e.target.value)}
               />
             </div>
           )}
@@ -362,13 +381,15 @@ export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
 
   // ─── Update helpers ───
   async function updateSeccion(id: string, fields: Partial<ConvInformeSeccion>) {
-    await db.conv_informe_secciones.update(id, fields);
+    await updateAndSync("conv_informe_secciones", id, fields);
   }
 
   // ─── Toggle all ───
   async function toggleAll(incluida: boolean) {
     await Promise.all(
-      secciones.map((s) => s.id && db.conv_informe_secciones.update(s.id, { incluida }))
+      secciones.map((s) =>
+        s.id ? updateAndSync("conv_informe_secciones", s.id, { incluida }) : undefined
+      )
     );
   }
 

--- a/src/components/visita-modulos/setup-field.tsx
+++ b/src/components/visita-modulos/setup-field.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Check } from "lucide-react";
+import { Input } from "@/components/ui/input";
+
+interface SetupFieldProps {
+  label: string;
+  defaultValue: string | number;
+  type?: "text" | "number" | "date";
+  step?: string;
+  placeholder?: string;
+  className?: string;
+  onSave: (value: string) => void;
+}
+
+/**
+ * Campo "setup" (uno por visita — distancia, técnica, etc.) con guardado
+ * on-blur y check de confirmación (1500ms), replicando el patrón visual de
+ * `EditableField` en info-modulo.tsx para los módulos Grupo A-E. A
+ * diferencia de `EditableField` (controlado, debounce por tecla), este es
+ * no controlado (`defaultValue` + `onBlur`) para calzar con el patrón que
+ * ya usan estos módulos — el guardado real puede tener su propio debounce
+ * externo (ver `updateSetup` en cada módulo).
+ */
+export function SetupField({
+  label,
+  defaultValue,
+  type = "number",
+  step,
+  placeholder,
+  className = "rounded-xl h-9 text-sm font-medium",
+  onSave,
+}: SetupFieldProps) {
+  const [saved, setSaved] = useState(false);
+
+  const handleBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      onSave(e.target.value);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
+    },
+    [onSave]
+  );
+
+  return (
+    <div className="space-y-1">
+      <label className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
+        {label}
+        {saved && <Check className="w-3 h-3 text-emerald-500" />}
+      </label>
+      <Input
+        type={type}
+        step={step}
+        className={className}
+        defaultValue={defaultValue}
+        placeholder={placeholder}
+        onBlur={handleBlur}
+      />
+    </div>
+  );
+}

--- a/src/hooks/use-row-saved.ts
+++ b/src/hooks/use-row-saved.ts
@@ -1,0 +1,37 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Indicador liviano de "guardado" para filas de tablas densas (mediciones,
+ * disparos, cassettes, etc.) — evita repetir un `useState<boolean>` por
+ * celda cuando la UI no lo soporta bien. `flash(id)` marca una fila como
+ * recién guardada por 1500ms (mismo timing que el check de campo
+ * individual en info-modulo.tsx), luego se oculta sola.
+ */
+export function useRowSavedFlash() {
+  const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const flash = useCallback((id: string) => {
+    setSavedIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+    const existing = timers.current.get(id);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      setSavedIds((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      timers.current.delete(id);
+    }, 1500);
+    timers.current.set(id, timer);
+  }, []);
+
+  const isSaved = useCallback((id: string) => savedIds.has(id), [savedIds]);
+
+  return { isSaved, flash };
+}

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -25,6 +25,7 @@ import {
   pullSyncTable,
   pushAllPending,
   retryRecord,
+  updateAndSync,
 } from "./sync-engine";
 
 // ============================================================
@@ -355,5 +356,91 @@ describe("sync-engine — getPendingRecords", () => {
     const pending = await getPendingRecords();
 
     expect(pending).toEqual([]);
+  });
+});
+
+// ============================================================
+//  updateAndSync — helper compartido para updates de módulos de
+//  captura (Grupo A-E, Convencional)
+//
+//  Bug real: las funciones `update(...)` de los módulos de prueba NO
+//  marcaban `sync_status: "pending"` ni llamaban a `pushSingle` tras
+//  actualizar un registro ya sincronizado — el cambio quedaba huérfano
+//  en Dexie para siempre, sin ningún indicio visible en la UI. Este
+//  helper centraliza "actualizar + marcar pendiente + pushear ya" para
+//  que ningún módulo pueda repetir el bug.
+// ============================================================
+
+describe("sync-engine — updateAndSync", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("aplica el patch, marca sync_status pending y lo deja synced tras el push exitoso", async () => {
+    await db.clientes.put({
+      id: "id-existente",
+      nombre_cliente: "Cliente original",
+      nit: "NIT-1",
+      sync_status: "synced",
+      last_modified: "2020-01-01T00:00:00.000Z",
+    });
+
+    await updateAndSync("clientes", "id-existente", { nombre_cliente: "Cliente actualizado" });
+
+    const record = await db.clientes.get("id-existente");
+    expect(record?.nombre_cliente).toBe("Cliente actualizado");
+    expect(record?.sync_status).toBe("synced");
+    expect(record?.last_modified).not.toBe("2020-01-01T00:00:00.000Z");
+
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(1);
+  });
+
+  it("envía a Supabase los datos ya actualizados (no la versión vieja)", async () => {
+    await db.clientes.put({
+      id: "id-existente",
+      nombre_cliente: "Cliente original",
+      nit: "NIT-1",
+      sync_status: "synced",
+    });
+
+    await updateAndSync("clientes", "id-existente", { nombre_cliente: "Cliente actualizado" });
+
+    const remote = await fakeClient.from("clientes").select("*");
+    const remoteRecord = (remote.data as { id: string; nombre_cliente: string }[]).find(
+      (r) => r.id === "id-existente"
+    );
+    expect(remoteRecord?.nombre_cliente).toBe("Cliente actualizado");
+  });
+
+  it("ignora un sync_status/last_modified que venga en el patch — siempre gana pending + timestamp nuevo", async () => {
+    await db.clientes.put({
+      id: "id-existente",
+      nombre_cliente: "Cliente original",
+      nit: "NIT-1",
+      sync_status: "synced",
+    });
+
+    await updateAndSync("clientes", "id-existente", {
+      nombre_cliente: "Cliente actualizado",
+      // El caller no debería mandar esto, pero probamos robustez ante el caso.
+      sync_status: "conflict",
+      last_modified: "1999-01-01T00:00:00.000Z",
+    });
+
+    const record = await db.clientes.get("id-existente");
+    // Tras el push exitoso queda "synced" (no "conflict", que es lo que
+    // el patch intentaba forzar) y el timestamp es el del push, no 1999.
+    expect(record?.sync_status).toBe("synced");
+    expect(record?.last_modified).not.toBe("1999-01-01T00:00:00.000Z");
+  });
+
+  it("no rompe ni llama a pushSingle cuando el registro no existe", async () => {
+    await expect(
+      updateAndSync("clientes", "id-inexistente", { nombre_cliente: "Nadie" })
+    ).resolves.toBeUndefined();
+
+    expect(fakeClient.callCount("clientes", "upsert")).toBe(0);
+    await expect(db.clientes.get("id-inexistente")).resolves.toBeUndefined();
   });
 });

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -446,6 +446,31 @@ export async function pushSingle(localTable: string, localId: string): Promise<b
 }
 
 /**
+ * Actualiza un registro local Y lo marca para re-sincronizar en el mismo
+ * paso — evita el bug de "el update queda con sync_status viejo y nunca
+ * se vuelve a subir" (ver incidente de datos perdidos en Grupo A). Reusá
+ * esto en vez de llamar db.tabla.update(...) directo en cualquier módulo
+ * de captura.
+ */
+export async function updateAndSync(
+  localTable: string,
+  id: string,
+  patch: Record<string, unknown>
+): Promise<void> {
+  const dexieTable = getDexieTable(localTable);
+  if (!dexieTable) return;
+
+  const updated = await dexieTable.update(id, {
+    ...patch,
+    sync_status: "pending" as SyncStatus,
+    last_modified: new Date().toISOString(),
+  });
+  if (!updated) return;
+
+  await pushSingle(localTable, id);
+}
+
+/**
  * Reintento manual de un registro puntual — se salta el schedule de
  * backoff de `sync_retry` y fuerza el push inmediato. Pensado para que
  * el técnico de campo pueda reintentar un registro "failed" sin esperar


### PR DESCRIPTION
## Summary

Bug de pérdida de datos real: al crear un registro en cualquier módulo del paquete Convencional (Grupo A-E) el sync funcionaba bien, pero actualizar ese mismo registro después nunca llegaba a Supabase, **sin ningún error visible**. Causa: las funciones `update()` dejaban el `sync_status` viejo (`"synced"`) intacto, así que `pushTable`/`pushSingle` —que solo suben registros `"pending"`— nunca volvían a considerarlos.

- Agrega `updateAndSync()` en `sync-engine.ts`: un solo punto que aplica el patch, marca `sync_status="pending"` + `last_modified`, y dispara `pushSingle` en el mismo paso — para que esta clase de bug no se pueda repetir.
- Reemplaza los ~22 `update()` sueltos en `grupo-a..e-modulo.tsx` y `pre-informe-modulo.tsx` (incluye dos bugs adicionales del mismo tipo encontrados en el camino: backfill de RaySafe e "incluir/excluir todas" del pre-informe).
- `conv_evidencias.update(blob_local)` queda fuera a propósito (`LOCAL_ONLY_FIELDS`, sync de Storage aparte).
- Replica el check visual de confirmación de `info-modulo.tsx` en los módulos de prueba: `SetupField` para campos únicos por visita, `useRowSavedFlash` para filas de tablas de mediciones densas.

## Test plan
- [x] `npm run test:run` — 155/155
- [x] `npx tsc --noEmit` — limpio
- [x] `npm run lint` / `npm run format:check` — sin regresiones (verificado contra baseline)
- [x] Verificación manual pendiente: crear un registro, editarlo, confirmar en Supabase que el cambio llegó