### PR TITLE
fix(sync): franja solo visible cuando hay algo que atender

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -18,10 +18,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
             >
               Ir al contenido principal
             </a>
-            {/* Franja fija de estado de sincronización — persiste en toda la app */}
-            <SyncStatusBar />
             <AppSidebar />
-            <SidebarInset className="pt-9">
+            <SidebarInset>
+              {/* Estado de sincronización — solo visible si hay algo que atender
+                  (sin conexión, backlog, o error); no ocupa espacio si no. */}
+              <SyncStatusBar />
+
               {/* Header móvil con trigger del sidebar */}
               <header className="flex items-center gap-3 p-4 md:hidden border-b border-border bg-white/80 backdrop-blur-sm sticky top-9 z-10">
                 <SidebarTrigger className="text-slate-600" />

--- a/src/components/sync-status-bar.test.tsx
+++ b/src/components/sync-status-bar.test.tsx
@@ -89,13 +89,36 @@ describe("SyncStatusBar", () => {
     expect(screen.queryByText(/quedan 5/i)).toBeNull();
   });
 
-  it("estado sincronizado no muestra el chip de error si errorCount es 0", () => {
+  it("no muestra nada en el camino feliz (online, 0 pendientes, sin errores)", () => {
     mockState({ isOnline: true, pendingCount: 0, errorCount: 0 });
+
+    const { container } = render(<SyncStatusBar />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("no muestra nada con un solo pendiente online — evita el parpadeo por cada guardado", () => {
+    mockState({ isOnline: true, pendingCount: 1, errorCount: 0 });
+
+    const { container } = render(<SyncStatusBar />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("sí se muestra online con más de un pendiente", () => {
+    mockState({ isOnline: true, pendingCount: 2, errorCount: 0 });
 
     render(<SyncStatusBar />);
 
-    expect(screen.getByText(/sincronizado/i)).toBeTruthy();
-    expect(screen.queryByText(/con error/i)).toBeNull();
+    expect(screen.getByText(/quedan 2/i)).toBeTruthy();
+  });
+
+  it("se muestra igual si hay un solo pendiente pero también hay errores", () => {
+    mockState({ isOnline: true, pendingCount: 1, errorCount: 1 });
+
+    render(<SyncStatusBar />);
+
+    expect(screen.getByText(/1 con error/i)).toBeTruthy();
   });
 
   it("el chip de error aparece en paralelo en estado sincronizando cuando errorCount > 0", () => {

--- a/src/components/sync-status-bar.tsx
+++ b/src/components/sync-status-bar.tsx
@@ -11,13 +11,15 @@ import { formatRelativeTime } from "@/lib/format-relative-time";
 const LAST_SYNC_KEY = "ultima-sync-exitosa";
 
 /**
- * Franja fija de estado de sincronización — reemplaza a `ConnectionBadge`.
+ * Franja de estado de sincronización — reemplaza a `ConnectionBadge`.
  *
- * Chrome permanente (nunca se desmonta, sin auto-hide): el incidente que
- * motivó este componente fue justamente un fallo de sync que no dejó
- * ningún rastro visible. El estado "Sincronizado" queda pintado hasta el
- * próximo cambio, y el chip de error (si `errorCount > 0`) se muestra
- * SIEMPRE en paralelo a cualquier otro estado, nunca reemplazado por él.
+ * Solo se muestra sin conexión, con más de un cambio pendiente, o con
+ * algún error — no en el camino feliz online con 0-1 pendientes, para no
+ * parpadear ámbar→verde en cada guardado individual de un campo (mala
+ * experiencia). El chip de error, cuando aplica, se muestra SIEMPRE en
+ * paralelo a cualquier otro estado, nunca reemplazado por él — y el
+ * timestamp de última sync exitosa se sigue guardando aunque la franja
+ * esté oculta, para no perder ese rastro.
  */
 export function SyncStatusBar() {
   const isOnline = useOnlineStatus();
@@ -35,6 +37,9 @@ export function SyncStatusBar() {
     if (!isSynced) return;
     window.localStorage.setItem(LAST_SYNC_KEY, new Date().toISOString());
   }, [isSynced]);
+
+  const shouldShow = !!error || !isReady || !isOnline || pendingCount > 1 || errorCount > 0;
+  if (!shouldShow) return null;
 
   const lastSync =
     typeof window === "undefined" ? null : window.localStorage.getItem(LAST_SYNC_KEY);
@@ -72,7 +77,7 @@ export function SyncStatusBar() {
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-0 inset-x-0 md:left-(--sidebar-width) z-30 h-9 flex items-center justify-between px-3 sm:px-4 ${colorClasses}`}
+      className={`sticky top-0 z-30 h-9 flex items-center justify-between px-3 sm:px-4 ${colorClasses}`}
     >
       <Link
         href="/dashboard/sync"


### PR DESCRIPTION
## Summary
- Se mostraba en el camino feliz (online, sincronizado) y parpadeaba ámbar→verde en cada guardado individual de un campo — mala experiencia.
- Ahora solo aparece sin conexión, con más de un cambio pendiente, o con algún error; con 0-1 pendientes online no se renderiza nada.
- De paso, cambia de `position:fixed` (con el hack de `left` para no tapar el sidebar, PR #26) a `position:sticky` dentro de `SidebarInset`: se posiciona bien de forma natural y no deja un hueco vacío reservado cuando está oculta. Esto reemplaza por completo el enfoque de #26.

Rebaseada sobre `main` actual (ya incluye #26 y #27); conflicto en `sync-status-bar.tsx` resuelto a favor del nuevo enfoque `sticky`.

## Test plan
- [x] `npm run test:run` — 158/158
- [x] `npx tsc --noEmit` / `npm run lint` / `npm run format:check` — sin regresiones