### PR TITLE
feat(sync): propagar borrados a Supabase (soft-delete)

### DIFF
--- a/src/components/visita-modulos/grupo-a-modulo.tsx
+++ b/src/components/visita-modulos/grupo-a-modulo.tsx
@@ -5,7 +5,7 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
+import { deleteAndSync, pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
   Check,
@@ -336,10 +336,22 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
 
     const [setup, mediciones, inspeccion, elementos, evidencias] = await Promise.all([
       db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
-      db.conv_mediciones.where("visita_id").equals(visitaId).sortBy("punto_numero"),
+      db.conv_mediciones
+        .where("visita_id")
+        .equals(visitaId)
+        .filter((r) => !r.deleted_at)
+        .sortBy("punto_numero"),
       db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray(),
-      db.conv_elementos_proteccion.where("visita_id").equals(visitaId).toArray(),
-      db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+      db.conv_elementos_proteccion
+        .where("visita_id")
+        .equals(visitaId)
+        .filter((r) => !r.deleted_at)
+        .toArray(),
+      db.conv_evidencias
+        .where("visita_id")
+        .equals(visitaId)
+        .filter((r) => !r.deleted_at)
+        .toArray(),
     ]);
 
     return { visita, setup, mediciones, inspeccion, elementos, evidencias };
@@ -460,7 +472,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function removeMedicion(id: string) {
-    await db.conv_mediciones.delete(id);
+    await deleteAndSync("conv_mediciones", id);
   }
 
   async function updateInspeccionItem(id: string, fields: Record<string, unknown>) {
@@ -484,12 +496,12 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function removeElemento(id: string) {
-    await db.conv_elementos_proteccion.delete(id);
+    await deleteAndSync("conv_elementos_proteccion", id);
     // Limpiar la foto asociada al elemento para no dejar evidencias huérfanas
     const foto = data?.evidencias?.find(
       (e) => e.prueba_codigo === "2.2" && e.slot === `elemento_${id}`
     );
-    if (foto?.id) await db.conv_evidencias.delete(foto.id);
+    if (foto?.id) await deleteAndSync("conv_evidencias", foto.id);
   }
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
@@ -518,7 +530,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
-    if (existing?.id) await db.conv_evidencias.delete(existing.id);
+    if (existing?.id) await deleteAndSync("conv_evidencias", existing.id);
   }
 
   // ─── Derived values ───

--- a/src/components/visita-modulos/grupo-b-modulo.tsx
+++ b/src/components/visita-modulos/grupo-b-modulo.tsx
@@ -5,7 +5,7 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
+import { deleteAndSync, pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
   Check,
@@ -336,7 +336,11 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
     const [setup, mediciones, evidencias] = await Promise.all([
       db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
       db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
-      db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+      db.conv_evidencias
+        .where("visita_id")
+        .equals(visitaId)
+        .filter((r) => !r.deleted_at)
+        .toArray(),
     ]);
 
     return { visita, setup, mediciones, evidencias };
@@ -569,7 +573,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
-    if (existing?.id) await db.conv_evidencias.delete(existing.id);
+    if (existing?.id) await deleteAndSync("conv_evidencias", existing.id);
   }
 
   function getEvidencia(prueba: string, slot: string) {

--- a/src/components/visita-modulos/grupo-c-modulo.tsx
+++ b/src/components/visita-modulos/grupo-c-modulo.tsx
@@ -5,7 +5,7 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
+import { deleteAndSync, pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
   Check,
@@ -293,7 +293,11 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
 
     const [mediciones, evidencias, setup] = await Promise.all([
       db.conv_cae_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
-      db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+      db.conv_evidencias
+        .where("visita_id")
+        .equals(visitaId)
+        .filter((r) => !r.deleted_at)
+        .toArray(),
       db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
     ]);
 
@@ -354,7 +358,7 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
-    if (existing?.id) await db.conv_evidencias.delete(existing.id);
+    if (existing?.id) await deleteAndSync("conv_evidencias", existing.id);
   }
 
   function getEvidencia(prueba: string, slot: string) {

--- a/src/components/visita-modulos/grupo-d-modulo.tsx
+++ b/src/components/visita-modulos/grupo-d-modulo.tsx
@@ -5,7 +5,7 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
+import { deleteAndSync, pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
   Check,
@@ -285,9 +285,21 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
 
     const [ddiMediciones, cassettes, uniformidad, evidencias] = await Promise.all([
       db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
-      db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).sortBy("item_numero"),
-      db.conv_uniformidad_cr.where("visita_id").equals(visitaId).sortBy("item_numero"),
-      db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+      db.conv_cassette_inspeccion
+        .where("visita_id")
+        .equals(visitaId)
+        .filter((r) => !r.deleted_at)
+        .sortBy("item_numero"),
+      db.conv_uniformidad_cr
+        .where("visita_id")
+        .equals(visitaId)
+        .filter((r) => !r.deleted_at)
+        .sortBy("item_numero"),
+      db.conv_evidencias
+        .where("visita_id")
+        .equals(visitaId)
+        .filter((r) => !r.deleted_at)
+        .toArray(),
     ]);
 
     return { visita, ddiMediciones, cassettes, uniformidad, evidencias };
@@ -359,7 +371,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function removeCassette(id: string) {
-    await db.conv_cassette_inspeccion.delete(id);
+    await deleteAndSync("conv_cassette_inspeccion", id);
   }
 
   async function addUniformidad() {
@@ -380,7 +392,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function removeUniformidad(id: string) {
-    await db.conv_uniformidad_cr.delete(id);
+    await deleteAndSync("conv_uniformidad_cr", id);
   }
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
@@ -409,7 +421,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
-    if (existing?.id) await db.conv_evidencias.delete(existing.id);
+    if (existing?.id) await deleteAndSync("conv_evidencias", existing.id);
   }
 
   function getEvidencia(prueba: string, slot: string) {

--- a/src/components/visita-modulos/grupo-e-modulo.tsx
+++ b/src/components/visita-modulos/grupo-e-modulo.tsx
@@ -5,7 +5,7 @@ import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
-import { pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
+import { deleteAndSync, pushSingle, updateAndSync } from "@/lib/supabase/sync-engine";
 import {
   ArrowLeft,
   Check,
@@ -248,11 +248,19 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
     const [colimacion, uniformidadDet, resolucion, bajoContraste, mtf, evidencias] =
       await Promise.all([
         db.conv_colimacion.where("visita_id").equals(visitaId).first(),
-        db.conv_uniformidad_detector.where("visita_id").equals(visitaId).sortBy("item_numero"),
+        db.conv_uniformidad_detector
+          .where("visita_id")
+          .equals(visitaId)
+          .filter((r) => !r.deleted_at)
+          .sortBy("item_numero"),
         db.conv_resolucion.where("visita_id").equals(visitaId).first(),
         db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
         db.conv_mtf.where("visita_id").equals(visitaId).first(),
-        db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+        db.conv_evidencias
+          .where("visita_id")
+          .equals(visitaId)
+          .filter((r) => !r.deleted_at)
+          .toArray(),
       ]);
 
     return { visita, colimacion, uniformidadDet, resolucion, bajoContraste, mtf, evidencias };
@@ -364,7 +372,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   async function removeUniformidadDet(id: string) {
-    await db.conv_uniformidad_detector.delete(id);
+    await deleteAndSync("conv_uniformidad_detector", id);
   }
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
@@ -393,7 +401,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
-    if (existing?.id) await db.conv_evidencias.delete(existing.id);
+    if (existing?.id) await deleteAndSync("conv_evidencias", existing.id);
   }
 
   function getEvidencia(prueba: string, slot: string) {

--- a/src/lib/equipos/convencional/db/types.ts
+++ b/src/lib/equipos/convencional/db/types.ts
@@ -50,6 +50,8 @@ export interface ConvMedicionRadiometrica extends Partial<SyncFields> {
   concepto?: "Conforme" | "No_conforme";
   observacion?: string;
   creado_en?: string;
+  /** Soft-delete: borrado viaja como cambio (UPSERT) para que el pull lo propague */
+  deleted_at?: string;
 }
 
 // ─── Grupo A: Inspección Visual (prueba 2.2) ───
@@ -76,6 +78,8 @@ export interface ConvElementoProteccion extends Partial<SyncFields> {
   concepto?: "Conforme" | "No_conforme" | "No_aplica";
   observacion?: string;
   creado_en?: string;
+  /** Soft-delete: borrado viaja como cambio (UPSERT) para que el pull lo propague */
+  deleted_at?: string;
 }
 
 // ─── Grupo B: RaySafe ───
@@ -231,6 +235,8 @@ export interface ConvCassetteInspeccion extends Partial<SyncFields> {
   concepto?: "Conforme" | "No_conforme";
   observacion?: string;
   creado_en?: string;
+  /** Soft-delete: borrado viaja como cambio (UPSERT) para que el pull lo propague */
+  deleted_at?: string;
 }
 
 /** Medición de uniformidad CR (prueba 2.15) — 1 por cassette por visita */
@@ -244,6 +250,8 @@ export interface ConvUniformidadCr extends Partial<SyncFields> {
   di?: number;
   tei?: number;
   creado_en?: string;
+  /** Soft-delete: borrado viaja como cambio (UPSERT) para que el pull lo propague */
+  deleted_at?: string;
 }
 
 // ─── Grupo E: Colimación, Resolución, Contraste, MTF ───
@@ -306,6 +314,8 @@ export interface ConvUniformidadDetector extends Partial<SyncFields> {
   artefactos?: boolean;
   artefactos_descripcion?: string;
   creado_en?: string;
+  /** Soft-delete: borrado viaja como cambio (UPSERT) para que el pull lo propague */
+  deleted_at?: string;
 }
 
 /** Prueba 2.12 — Resolución espacial alto contraste */
@@ -438,4 +448,6 @@ export interface ConvEvidencia extends Partial<SyncFields> {
   url_storage?: string;
   fecha_captura?: string;
   creado_en?: string;
+  /** Soft-delete: borrado viaja como cambio (UPSERT) para que el pull lo propague */
+  deleted_at?: string;
 }

--- a/src/lib/equipos/convencional/evaluacion.ts
+++ b/src/lib/equipos/convencional/evaluacion.ts
@@ -510,18 +510,38 @@ export async function cargarTablasConv(visitaId: string): Promise<DatosEvalConv>
     caeSetup,
     caeMediciones,
   ] = await Promise.all([
-    db.conv_mediciones.where("visita_id").equals(visitaId).toArray(),
+    db.conv_mediciones
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .toArray(),
     db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray(),
-    db.conv_elementos_proteccion.where("visita_id").equals(visitaId).toArray(),
+    db.conv_elementos_proteccion
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .toArray(),
     db.conv_colimacion.where("visita_id").equals(visitaId).first(),
     db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
     db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).toArray(),
     db.conv_ddi_mediciones.where("visita_id").equals(visitaId).toArray(),
-    db.conv_uniformidad_detector.where("visita_id").equals(visitaId).toArray(),
+    db.conv_uniformidad_detector
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .toArray(),
     db.conv_resolucion.where("visita_id").equals(visitaId).first(),
     db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
-    db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).toArray(),
-    db.conv_uniformidad_cr.where("visita_id").equals(visitaId).toArray(),
+    db.conv_cassette_inspeccion
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .toArray(),
+    db.conv_uniformidad_cr
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .toArray(),
     db.conv_mtf.where("visita_id").equals(visitaId).first(),
     db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
     db.conv_cae_mediciones.where("visita_id").equals(visitaId).toArray(),

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -199,20 +199,44 @@ export async function recopilarDatosConv(visitaId: string): Promise<DatosConvenc
   ] = await Promise.all([
     db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
     db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
-    db.conv_mediciones.where("visita_id").equals(visitaId).sortBy("punto_numero"),
+    db.conv_mediciones
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .sortBy("punto_numero"),
     db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray(),
-    db.conv_elementos_proteccion.where("visita_id").equals(visitaId).toArray(),
+    db.conv_elementos_proteccion
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .toArray(),
     db.conv_resultados_prueba.where("visita_id").equals(visitaId).toArray(),
-    db.conv_evidencias.where("visita_id").equals(visitaId).toArray(),
+    db.conv_evidencias
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .toArray(),
     db.conv_colimacion.where("visita_id").equals(visitaId).first(),
     db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
     db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
     db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
-    db.conv_uniformidad_detector.where("visita_id").equals(visitaId).sortBy("item_numero"),
+    db.conv_uniformidad_detector
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .sortBy("item_numero"),
     db.conv_resolucion.where("visita_id").equals(visitaId).first(),
     db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
-    db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).sortBy("item_numero"),
-    db.conv_uniformidad_cr.where("visita_id").equals(visitaId).sortBy("item_numero"),
+    db.conv_cassette_inspeccion
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .sortBy("item_numero"),
+    db.conv_uniformidad_cr
+      .where("visita_id")
+      .equals(visitaId)
+      .filter((r) => !r.deleted_at)
+      .sortBy("item_numero"),
     db.conv_mtf.where("visita_id").equals(visitaId).first(),
     db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
     db.conv_cae_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -20,6 +20,7 @@ vi.mock("./client", () => ({
 // Import estático: `vi.mock` se hoistea sobre los imports, así que el mock
 // de "./client" ya está activo cuando `sync-engine.ts` se evalúa.
 import {
+  deleteAndSync,
   fullSync,
   getPendingRecords,
   pullSyncTable,
@@ -442,5 +443,106 @@ describe("sync-engine — updateAndSync", () => {
 
     expect(fakeClient.callCount("clientes", "upsert")).toBe(0);
     await expect(db.clientes.get("id-inexistente")).resolves.toBeUndefined();
+  });
+});
+
+// ============================================================
+//  Propagación de borrados — soft-delete (feat/sync-borrados-soft-delete)
+//
+//  Un `dexieTable.delete(id)` puro nunca avisa al motor de sync: la
+//  fila queda huérfana en Supabase. `deleteAndSync` marca el registro
+//  con `deleted_at` (viaja como cualquier otro cambio, mismo UPSERT
+//  local-first) en vez de borrarlo de entrada. El pull, del otro lado,
+//  debe reconocer `deleted_at` en un registro remoto y SÍ borrar la
+//  copia local — así un segundo dispositivo se entera de la baja.
+// ============================================================
+
+describe("sync-engine — deleteAndSync (soft-delete local + push)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("no borra la fila de Dexie: la marca con deleted_at y sync_status pending, luego la sincroniza", async () => {
+    await db.conv_mediciones.put({
+      id: "id-to-delete",
+      visita_id: "visita-1",
+      punto_numero: 1,
+      ubicacion_descripcion: "Consola",
+      sync_status: "synced",
+    });
+
+    await deleteAndSync("conv_mediciones", "id-to-delete");
+
+    // (a) el registro AÚN EXISTE en Dexie, con deleted_at seteado —
+    // no se hizo dexieTable.delete() de entrada.
+    const local = await db.conv_mediciones.get("id-to-delete");
+    expect(local).toBeDefined();
+    expect(local?.deleted_at).toBeTruthy();
+
+    // (b) terminó sync_status "synced" tras el push inmediato.
+    expect(local?.sync_status).toBe("synced");
+
+    // (c) Supabase (fake) recibió el deleted_at en el upsert — el
+    // borrado viajó como cualquier otro cambio de campo.
+    expect(fakeClient.callCount("conv_mediciones", "upsert")).toBe(1);
+    const { data } = await fakeClient.from("conv_mediciones").select("*");
+    const remoteRow = data?.find((r: FakeRow) => r.id === "id-to-delete");
+    expect(remoteRow?.deleted_at).toBeTruthy();
+  });
+});
+
+describe("sync-engine — pullSyncTable borra localmente cuando el remoto trae deleted_at", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("una fila remota con deleted_at seteado se borra de verdad en Dexie (no queda como fantasma)", async () => {
+    await db.conv_mediciones.put({
+      id: "id-remote-deleted",
+      visita_id: "visita-1",
+      punto_numero: 1,
+      ubicacion_descripcion: "Consola",
+      sync_status: "synced",
+      last_modified: "2026-01-01T00:00:00.000Z",
+    });
+
+    fakeClient.seedTable("conv_mediciones", [
+      {
+        id: "id-remote-deleted",
+        visita_id: "visita-1",
+        punto_numero: 1,
+        ubicacion_descripcion: "Consola",
+        last_modified: "2026-02-01T00:00:00.000Z",
+        deleted_at: "2026-02-01T00:00:00.000Z",
+        sync_status: "synced",
+      },
+    ]);
+
+    const pulled = await pullSyncTable(fakeClient, "conv_mediciones", "conv_mediciones");
+
+    expect(pulled).toBe(1);
+    await expect(db.conv_mediciones.get("id-remote-deleted")).resolves.toBeUndefined();
+  });
+
+  it("una fila remota SIN deleted_at se sigue aplicando con put normal (no rompe el flujo existente)", async () => {
+    fakeClient.seedTable("conv_mediciones", [
+      {
+        id: "id-remote-normal",
+        visita_id: "visita-1",
+        punto_numero: 1,
+        ubicacion_descripcion: "Consola",
+        last_modified: "2026-02-01T00:00:00.000Z",
+        sync_status: "synced",
+      },
+    ]);
+
+    const pulled = await pullSyncTable(fakeClient, "conv_mediciones", "conv_mediciones");
+
+    expect(pulled).toBe(1);
+    const local = await db.conv_mediciones.get("id-remote-normal");
+    expect(local).toBeDefined();
+    expect(local?.sync_status).toBe("synced");
   });
 });

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -471,6 +471,25 @@ export async function updateAndSync(
 }
 
 /**
+ * Borrado con propagación — soft-delete.
+ *
+ * Un `dexieTable.delete(id)` puro es solo local: nunca avisa al motor
+ * de sync, así que la fila queda huérfana en Supabase para siempre.
+ * En vez de eso, marcamos el registro con `deleted_at` (vía
+ * `updateAndSync`, mismo mecanismo que un edit cualquiera) — mismo
+ * UPSERT local-first que ya usa todo el motor. El registro sigue
+ * existiendo en Dexie; la UI debe filtrar `deleted_at` en sus queries
+ * para dejar de mostrarlo.
+ *
+ * Del otro lado, `applyRemoteSyncRecord` reconoce `deleted_at` en un
+ * registro remoto y hace `dexieTable.delete()` local de verdad — así
+ * un segundo dispositivo se entera de la baja.
+ */
+export async function deleteAndSync(localTable: string, id: string): Promise<void> {
+  await updateAndSync(localTable, id, { deleted_at: new Date().toISOString() });
+}
+
+/**
  * Reintento manual de un registro puntual — se salta el schedule de
  * backoff de `sync_retry` y fuerza el push inmediato. Pensado para que
  * el técnico de campo pueda reintentar un registro "failed" sin esperar
@@ -628,6 +647,13 @@ async function applyRemoteSyncRecord(
   const localRecord = await dexieTable.get(remoteRecord.id as string);
 
   if (!localRecord || localRecord.sync_status === "synced") {
+    // Soft-delete: el remoto trae `deleted_at` seteado — se borra la
+    // copia local de verdad (no se deja como fantasma con put), para
+    // que este dispositivo se entere de la baja hecha en otro lado.
+    if (remoteRecord.deleted_at) {
+      await dexieTable.delete(remoteRecord.id as string);
+      return 1;
+    }
     await dexieTable.put({ ...remoteRecord, sync_status: "synced" as SyncStatus });
     return 1;
   }

--- a/supabase/migrations/015_soft_delete_conv_tablas.sql
+++ b/supabase/migrations/015_soft_delete_conv_tablas.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- Migración 015: soft-delete en tablas conv_* con filas hijas
+--
+-- Los borrados de mediciones/elementos/evidencias desde los módulos
+-- de prueba Convencional eran puramente locales (dexieTable.delete)
+-- — nunca se avisaba al motor de sync, así que la fila quedaba
+-- huérfana en Supabase para siempre.
+--
+-- `pullSyncTable` es incremental (solo trae `last_modified >
+-- watermark`), así que un DELETE real en Supabase no deja rastro:
+-- un segundo dispositivo que ya tenía la fila local nunca se
+-- enteraría de la baja. Con `deleted_at`, el borrado viaja como
+-- cualquier otro cambio (mismo UPSERT local-first que ya usa el
+-- motor) y el pull puede reconocerlo y borrar la copia local.
+-- ============================================================
+
+ALTER TABLE conv_mediciones ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE conv_elementos_proteccion ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE conv_evidencias ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE conv_cassette_inspeccion ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE conv_uniformidad_cr ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE conv_uniformidad_detector ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary

Los borrados en los módulos de prueba (mediciones, elementos de protección, evidencias, cassettes, uniformidad CR/detector) eran puramente locales — nunca se avisaba al motor de sync, así que la fila quedaba huérfana en Supabase para siempre.

- **Soft-delete, no DELETE real**: `pullSyncTable` es incremental (`last_modified > watermark`), así que un DELETE real no deja rastro para que otro dispositivo se entere de la baja. Con `deleted_at`, el borrado viaja como cualquier otro cambio, mismo patrón local-first-upsert del motor.
- `deleteAndSync()` reusa `updateAndSync()` (de #27) para marcar `deleted_at` + `pending` + push — sin duplicar lógica.
- `applyRemoteSyncRecord()` borra local de verdad cuando el pull trae `deleted_at` seteado, para que un segundo dispositivo limpie su copia.
- Reemplaza los 11 `db.tabla.delete()` sueltos en los 5 módulos, y filtra `deleted_at` en cada lectura de esas 6 tablas (listados en UI, generación de PDF, cálculo de completitud/conceptos).

Rebaseada sobre `main` actual (ya incluye #26 y #27); conflictos resueltos combinando ambos cambios (no eran contradictorios) en `sync-engine.ts`, `sync-engine.test.ts` y los 5 módulos.

## ⚠️ Acción manual requerida
La migración `supabase/migrations/015_soft_delete_conv_tablas.sql` **no se ejecutó** — hay que aplicarla manualmente en Supabase (Dashboard → SQL Editor, o `supabase db push`). Sin la columna `deleted_at` en remoto, este fix no tiene efecto real.

## Test plan
- [x] `npm run test:run` — 158/158
- [x] `npx tsc --noEmit` / `npm run lint` / `npm run format:check` — sin regresiones
- [x] Verificación manual pendiente (borrar un registro, confirmar en Supabase que `deleted_at` se seteó, y que otro dispositivo/DB local resetea sin volver a traerlo)