### PR TITLE
fix(sync): carrera en el login + pull incremental periódico

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { fullSync } from "@/lib/supabase/sync-engine";
+import { logger } from "@/lib/logger";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -69,8 +70,17 @@ function LoginForm() {
       router.push(redirect);
       router.refresh();
 
-      // Sincronizar en background — no bloquea la navegación
-      fullSync().catch(() => console.warn("[Login] Sync inicial falló, se reintentará después"));
+      // Sincronizar en background — no bloquea la navegación. fullSync()
+      // no lanza en fallos esperados (ej. sin sesión, sin conexión), así
+      // que el resultado hay que inspeccionarlo para no perder el rastro
+      // de un pull inicial fallido — antes quedaba 100% en silencio.
+      fullSync()
+        .then((result) => {
+          if (result.errors.length > 0) {
+            logger.warn("login:sync-inicial", "Sync inicial con errores", result.errors);
+          }
+        })
+        .catch((err) => logger.error("login:sync-inicial", "Sync inicial falló", err));
     } catch {
       setError("Error de conexión. Verifica tu internet.");
     } finally {

--- a/src/hooks/use-auto-sync.ts
+++ b/src/hooks/use-auto-sync.ts
@@ -1,14 +1,32 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { pushAllPending } from "@/lib/supabase/sync-engine";
+import { pullAllPending, pushAllPending } from "@/lib/supabase/sync-engine";
 import { useOnlineStatus } from "./use-online-status";
 
 const SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutos
 
 /**
- * Hook que ejecuta push automático de registros pendientes cada 5 min.
- * Solo corre cuando hay conexión. Se pausa al perder red y retoma al reconectarse.
+ * Push de lo propio, después pull incremental de lo ajeno — en ese orden
+ * y esperado (no en paralelo): ambos usan el mismo lock global
+ * (`withSyncLock`), así que si se disparan sin esperar uno al otro, el
+ * segundo se saltaría por lock ya tomado y este ciclo nunca haría pull.
+ */
+async function syncCycle() {
+  await pushAllPending();
+  await pullAllPending();
+}
+
+/**
+ * Hook que ejecuta push + pull incremental automático cada 5 min. Solo
+ * corre cuando hay conexión. Se pausa al perder red y retoma al
+ * reconectarse.
+ *
+ * El pull es necesario acá, no solo el push: sin él, un dispositivo sin
+ * cambios propios pendientes de subir nunca se entera de cambios que
+ * hizo otro usuario (ej. una visita recién asignada) hasta que cierre y
+ * reabra sesión, o dependa del Background Sync del navegador — no
+ * soportado en Safari/iOS/Firefox y con timing no garantizado en Chrome.
  */
 export function useAutoSync() {
   const isOnline = useOnlineStatus();
@@ -23,11 +41,11 @@ export function useAutoSync() {
       return;
     }
 
-    // Push inmediato al recuperar conexión
-    pushAllPending();
+    // Ciclo inmediato al recuperar conexión
+    syncCycle();
 
     timerRef.current = setInterval(() => {
-      pushAllPending();
+      syncCycle();
     }, SYNC_INTERVAL_MS);
 
     return () => {

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "@/lib/db";
 import { resetTestDb } from "@/test/db-reset";
 import {
@@ -22,7 +22,9 @@ vi.mock("./client", () => ({
 import {
   deleteAndSync,
   fullSync,
+  getAuthenticatedUser,
   getPendingRecords,
+  pullAllPending,
   pullSyncTable,
   pushAllPending,
   retryRecord,
@@ -544,5 +546,119 @@ describe("sync-engine — pullSyncTable borra localmente cuando el remoto trae d
     const local = await db.conv_mediciones.get("id-remote-normal");
     expect(local).toBeDefined();
     expect(local?.sync_status).toBe("synced");
+  });
+});
+
+// ============================================================
+//  getAuthenticatedUser — reintento de sesión (bug del primer login)
+//
+//  `fullSync()` se dispara en el login como fire-and-forget, justo
+//  después de `signInWithPassword`. La sesión de la nueva instancia
+//  de Supabase puede tardar en asentarse (lectura async de storage),
+//  así que un primer `getUser()` sin usuario no debe rendirse de
+//  entrada — reintenta una vez tras un breve delay.
+// ============================================================
+
+describe("sync-engine — getAuthenticatedUser", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reintenta una vez y devuelve el usuario si la sesión aparece en el segundo intento", async () => {
+    vi.useFakeTimers();
+    const getUser = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { user: null } })
+      .mockResolvedValueOnce({ data: { user: { id: "user-1" } } });
+
+    const promise = getAuthenticatedUser({ auth: { getUser } });
+    await vi.advanceTimersByTimeAsync(1000);
+    const user = await promise;
+
+    expect(user).toEqual({ id: "user-1" });
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+
+  it("devuelve el usuario de una sin esperar si el primer intento ya tiene sesión", async () => {
+    const getUser = vi.fn().mockResolvedValueOnce({ data: { user: { id: "user-1" } } });
+
+    const user = await getAuthenticatedUser({ auth: { getUser } });
+
+    expect(user).toEqual({ id: "user-1" });
+    expect(getUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("devuelve null si sigue sin sesión después del reintento (no reintenta indefinidamente)", async () => {
+    vi.useFakeTimers();
+    const getUser = vi.fn().mockResolvedValue({ data: { user: null } });
+
+    const promise = getAuthenticatedUser({ auth: { getUser } });
+    await vi.advanceTimersByTimeAsync(1000);
+    const user = await promise;
+
+    expect(user).toBeNull();
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ============================================================
+//  pullAllPending — pull incremental periódico (auto-sync)
+//
+//  El auto-sync de 5 min solo empujaba cambios propios (pushAllPending)
+//  — un dispositivo sin nada propio pendiente nunca se enteraba de
+//  cambios de otro usuario (ej. una visita recién asignada) salvo que
+//  hiciera login de nuevo o el Background Sync del navegador disparara
+//  (no soportado en Safari/iOS/Firefox, timing no garantizado en Chrome).
+//  pullAllPending trae SYNC_TABLES de forma incremental (mismo watermark
+//  que ya usa pullSyncTable) SIN tocar MASTER_TABLES — más liviano que
+//  un fullSync() completo para correr cada 5 min.
+// ============================================================
+
+describe("sync-engine — pullAllPending", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("trae cambios de una tabla de sync (visitas) sin necesitar cambios locales propios", async () => {
+    fakeClient.seedTable("visitas", [
+      {
+        id: "visita-asignada",
+        solicitud_id: "sol-1",
+        tecnico_id: "tecnico-1",
+        estado_visita: "asignada",
+        last_modified: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const result = await pullAllPending();
+
+    expect(result.pulled).toBeGreaterThan(0);
+    const local = await db.visitas.get("visita-asignada");
+    expect(local).toBeDefined();
+    expect(local?.sync_status).toBe("synced");
+  });
+
+  it("no toca las tablas maestras — solo pull incremental de SYNC_TABLES", async () => {
+    fakeClient.seedTable("departamentos", [{ id: 1, nombre: "Bogotá D.C." }]);
+
+    await pullAllPending();
+
+    expect(fakeClient.callCount("departamentos", "select")).toBe(0);
+  });
+
+  it("devuelve 0 sin llamar a Supabase si no hay sesión activa", async () => {
+    fakeClient.setUser(null);
+    fakeClient.seedTable("visitas", [
+      {
+        id: "visita-sin-sesion",
+        last_modified: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const result = await pullAllPending();
+
+    expect(result.pulled).toBe(0);
+    await expect(db.visitas.get("visita-sin-sesion")).resolves.toBeUndefined();
   });
 });

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -242,6 +242,29 @@ export async function fullSync(): Promise<SyncResult> {
   return lockResult.value;
 }
 
+/**
+ * `getUser()` con un reintento tras un breve delay si la primera lectura
+ * no encuentra sesión. Existe por el bug del primer login: `fullSync()`
+ * se dispara fire-and-forget justo después de `signInWithPassword` sobre
+ * una instancia de Supabase recién creada, cuya sesión puede tardar en
+ * asentarse (lectura async de storage) — sin este reintento, ese primer
+ * pull fallaba en silencio y la app quedaba vacía hasta el próximo login.
+ */
+export async function getAuthenticatedUser(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  retries = 1,
+  delayMs = 500
+): Promise<{ id: string } | null> {
+  for (let attempt = 0; ; attempt++) {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user || attempt >= retries) return user;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
+
 async function runFullSync(): Promise<SyncResult> {
   const result: SyncResult = {
     pushed: 0,
@@ -252,9 +275,7 @@ async function runFullSync(): Promise<SyncResult> {
 
   const supabase = createClient();
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getAuthenticatedUser(supabase);
   if (!user) {
     result.errors.push({
       table: "_auth",
@@ -571,9 +592,7 @@ async function runPushAllPending(): Promise<{ pushed: number; errors: number }> 
   if (!navigator.onLine) return { pushed: 0, errors: 0 };
 
   const supabase = createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getAuthenticatedUser(supabase);
   if (!user) return { pushed: 0, errors: 0 };
 
   let totalPushed = 0;
@@ -590,6 +609,59 @@ async function runPushAllPending(): Promise<{ pushed: number; errors: number }> 
   }
 
   return { pushed: totalPushed, errors: totalErrors };
+}
+
+/**
+ * Pull incremental de las tablas de campo (`SYNC_TABLES`), sin tocar las
+ * tablas maestras — pensado para correr periódicamente junto al
+ * auto-sync (cada 5 min), no solo al loguear o tocar el botón manual.
+ *
+ * Antes de esto, un dispositivo sin cambios propios pendientes de subir
+ * nunca se enteraba de cambios que hizo otro usuario (ej. una visita
+ * recién asignada por un coordinador) salvo que cerrara/reabriera
+ * sesión o el Background Sync del navegador disparara — mecanismo no
+ * soportado en Safari/iOS/Firefox y con timing no garantizado en Chrome.
+ *
+ * Deliberadamente NO recorre `MASTER_TABLES`: son datos de referencia
+ * que cambian poco y ya se refrescan por completo al loguear/sincronizar
+ * manualmente — correr ese reemplazo completo cada 5 min sería más
+ * costoso de lo que vale para este caso de uso.
+ *
+ * Protegido por `withSyncLock`, igual que `pushAllPending`/`fullSync`.
+ */
+export async function pullAllPending(): Promise<{ pulled: number; errors: number }> {
+  const lockResult = await withSyncLock(runPullAllPending);
+  if (!lockResult.ran) {
+    logger.info("sync:lock", "pullAllPending omitido: ya hay una sincronización en curso");
+    return { pulled: 0, errors: 0 };
+  }
+  return lockResult.value;
+}
+
+async function runPullAllPending(): Promise<{ pulled: number; errors: number }> {
+  if (!navigator.onLine) return { pulled: 0, errors: 0 };
+
+  const supabase = createClient();
+  const user = await getAuthenticatedUser(supabase);
+  if (!user) return { pulled: 0, errors: 0 };
+
+  let totalPulled = 0;
+  let totalErrors = 0;
+
+  for (const table of SYNC_TABLES) {
+    try {
+      totalPulled += await pullSyncTable(supabase, table.local, table.remote);
+    } catch (err) {
+      totalErrors++;
+      logger.error("sync:pull-incremental", `Error descargando ${tableLabel(table.local)}`, err);
+    }
+  }
+
+  if (totalPulled > 0) {
+    logger.info("sync:auto", `Auto-pull: ${totalPulled} registros actualizados`);
+  }
+
+  return { pulled: totalPulled, errors: totalErrors };
 }
 
 /**


### PR DESCRIPTION
## Summary

Dos problemas relacionados, ambos por el mismo punto ciego: `fullSync()` es el único que hace pull, y solo se dispara al loguear, al tocar el botón manual, o vía Background Sync del navegador (no soportado en Safari/iOS/Firefox, timing no garantizado en Chrome).

1. **Bug del primer login**: `fullSync()` se disparaba fire-and-forget justo después de `signInWithPassword`, sin esperar a que la sesión de la nueva instancia de Supabase terminara de asentarse. Si el primer `getUser()` no encontraba sesión, el pull abortaba en silencio — la app quedaba vacía hasta el próximo login. `getAuthenticatedUser()` reintenta una vez tras un breve delay antes de rendirse; el login ahora también loguea el resultado en vez de ignorarlo.
2. **Latencia de propagación entre dispositivos**: el auto-sync de 5 min solo empujaba cambios propios (`pushAllPending`), nunca bajaba cambios ajenos — un técnico sin nada propio pendiente no se enteraba de una visita recién asignada hasta cerrar/reabrir sesión. `pullAllPending()` agrega un pull incremental de `SYNC_TABLES` (mismo watermark que `pullSyncTable`, sin tocar `MASTER_TABLES`) al ciclo de auto-sync — ahora corre cada 5 min junto al push.

## Test plan
- [x] `npm run test:run` — 167/167
- [x] `npx tsc --noEmit` / `npm run lint` / `npm run format:check` — sin regresiones
- [x] Verificación manual pendiente: borrar DB local, loguear una vez, confirmar que los datos cargan sin necesitar un segundo login; asignar una visita desde otra sesión y confirmar que aparece en ≤5 min sin recargar