### PR TITLE
chore(test): Tier 0 — infra de test y CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,16 @@ jobs:
       - run: npm ci
 
       - name: Type check
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
-      - name: Test
-        run: npx vitest run
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Test + coverage
+        run: npm run test:coverage
 
       - name: Build
         run: npx next build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,12 +7,36 @@ const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
   prettier,
-  globalIgnores([
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-  ]),
+  globalIgnores([".next/**", "out/**", "build/**", "coverage/**", "next-env.d.ts"]),
+  {
+    // Deuda técnica conocida y rastreada — NO es una exención permanente.
+    //
+    // `react-hooks/set-state-in-effect` marca 14 llamadas a setState dentro
+    // de useEffect (hooks base + src/components/visita-modulos/*). Varias son
+    // reales (doble render) y otras son "sincronizar estado derivado al
+    // montar", que la regla no distingue. Arreglarlas ahora, sin tests que
+    // cubran esos componentes de 1000+ líneas, es riesgoso.
+    //
+    // Baja a "warn" para que el CI pueda exigir 0 errores desde ya. Cada
+    // módulo afectado re-escala la regla a "error" en su ruta (o corrige la
+    // violación con test) como criterio de salida de su tier:
+    //   - src/hooks/**            -> Tier 1
+    //   - src/components/visita-modulos/**, manual-drawer -> Tier 6
+    //   - src/app/dashboard/**    -> Tier 7
+    rules: {
+      "react-hooks/set-state-in-effect": "warn",
+    },
+  },
+  {
+    // Un argumento/variable con prefijo `_` es "sin usar a propósito"
+    // (firmas de callback, destructuring parcial). Convención estándar.
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.6",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2876,6 +2877,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,json,css}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,json,css}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,json,css}\"",
+    "verify": "npm run typecheck && npm run lint && npm run format:check && npm run test:run"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -40,6 +42,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,14 +72,14 @@
 
   /* Secundario — purpura suave */
   --secondary: oklch(0.95 0.03 285);
-  --secondary-foreground: oklch(0.40 0.15 285);
+  --secondary-foreground: oklch(0.4 0.15 285);
 
   --muted: oklch(0.96 0.005 250);
   --muted-foreground: oklch(0.55 0.01 250);
 
   /* Acento — purpura claro */
   --accent: oklch(0.93 0.04 285);
-  --accent-foreground: oklch(0.40 0.15 285);
+  --accent-foreground: oklch(0.4 0.15 285);
 
   --destructive: oklch(0.577 0.245 27.325);
 
@@ -102,7 +102,7 @@
   --sidebar-primary: oklch(0.553 0.215 285);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent: oklch(0.95 0.03 285);
-  --sidebar-accent-foreground: oklch(0.40 0.15 285);
+  --sidebar-accent-foreground: oklch(0.4 0.15 285);
   --sidebar-border: oklch(0.94 0.005 250);
   --sidebar-ring: oklch(0.553 0.215 285);
 }

--- a/src/components/db-provider.tsx
+++ b/src/components/db-provider.tsx
@@ -47,9 +47,7 @@ export function DbProvider({ children }: { children: React.ReactNode }) {
           const tx = idb.transaction("clientes", "readonly");
           const store = tx.objectStore("clientes");
           if (!store.indexNames.contains("sync_status")) {
-            console.warn(
-              "[DbProvider] DB desactualizada — cierra todas las pestañas y recarga"
-            );
+            console.warn("[DbProvider] DB desactualizada — cierra todas las pestañas y recarga");
             setNeedsReload(true);
           }
         }
@@ -69,8 +67,18 @@ export function DbProvider({ children }: { children: React.ReactNode }) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 p-8 text-center">
         <div className="bg-amber-100 p-4 rounded-2xl">
-          <svg className="w-10 h-10 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          <svg
+            className="w-10 h-10 text-amber-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
           </svg>
         </div>
         <h2 className="text-xl font-black text-slate-900">Base de datos desactualizada</h2>
@@ -88,5 +96,7 @@ export function DbProvider({ children }: { children: React.ReactNode }) {
     );
   }
 
-  return <DbContext.Provider value={{ isReady, error, needsReload }}>{children}</DbContext.Provider>;
+  return (
+    <DbContext.Provider value={{ isReady, error, needsReload }}>{children}</DbContext.Provider>
+  );
 }

--- a/src/components/manual-drawer.tsx
+++ b/src/components/manual-drawer.tsx
@@ -55,7 +55,7 @@ export function ManualDrawer({ open, onClose, pruebas, pruebaCodigo }: ManualDra
     (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     },
-    [onClose],
+    [onClose]
   );
   useEffect(() => {
     if (!open) return;

--- a/src/lib/equipos/convencional/grupos.ts
+++ b/src/lib/equipos/convencional/grupos.ts
@@ -93,8 +93,7 @@ const GRUPO_B: GrupoPruebaDefinition = {
       codigo: "2.7",
       numero_tecdoc: "2.7",
       nombre: "Valor del rendimiento del tubo de rayos X, repetibilidad y linealidad",
-      descripcion:
-        "Cuánta radiación produce el tubo por cada mAs — debe ser consistente y lineal",
+      descripcion: "Cuánta radiación produce el tubo por cada mAs — debe ser consistente y lineal",
       orden_en_grupo: 4,
       orden_global: 6,
       formulas: [],
@@ -168,7 +167,8 @@ const GRUPO_C: GrupoPruebaDefinition = {
       codigo: "2.19",
       numero_tecdoc: "2.19",
       nombre: "Repetibilidad del CAE",
-      descripcion: "Verifica que disparando varias veces con la misma configuración, el CAE da resultados consistentes",
+      descripcion:
+        "Verifica que disparando varias veces con la misma configuración, el CAE da resultados consistentes",
       orden_en_grupo: 3,
       orden_global: 11,
       formulas: [],

--- a/src/lib/equipos/convencional/informe.ts
+++ b/src/lib/equipos/convencional/informe.ts
@@ -1,6 +1,4 @@
-export async function generarInformeConvencional(
-  _visitaId: string,
-): Promise<Blob | null> {
+export async function generarInformeConvencional(_visitaId: string): Promise<Blob | null> {
   // TODO: implementar generación de PDF desde especificación
   return null;
 }

--- a/src/lib/equipos/convencional/manual.ts
+++ b/src/lib/equipos/convencional/manual.ts
@@ -200,11 +200,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
     grupo: "B",
     objetivo:
       "Medir cuánta radiación llega al detector de imagen usando los programas clínicos reales del equipo. Se compara con los valores de referencia (base) de la visita anterior.",
-    instrumentacion: [
-      "Sensor RaySafe X2 RF",
-      "Rejilla del equipo",
-      "Cinta métrica",
-    ],
+    instrumentacion: ["Sensor RaySafe X2 RF", "Rejilla del equipo", "Cinta métrica"],
     pasos: [
       "Haz 3 disparos CON rejilla usando programas clínicos reales (Extremidad, Tórax AP, Columna AP).",
       "Haz 3 disparos SIN rejilla con los mismos programas.",
@@ -267,10 +263,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
     grupo: "C",
     objetivo:
       "Verificar que el CAE da valores similares a los de la visita anterior (valores base). Si cambió mucho, el CAE puede estar descalibrado.",
-    instrumentacion: [
-      "Placas de cobre (1 mm) como atenuador",
-      "Equipo con CAE activado",
-    ],
+    instrumentacion: ["Placas de cobre (1 mm) como atenuador", "Equipo con CAE activado"],
     pasos: [
       "Activa el CAE del equipo en modo automático.",
       "Coloca el colimador en modo manual.",
@@ -310,9 +303,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
       { descripcion: "Variación entre sensores (EI)", limite: "≤ 30%" },
       { descripcion: "Variación entre sensores (D.I.)", limite: "≤ 30%" },
     ],
-    tips: [
-      "Si un sensor da resultados muy diferentes, puede estar dañado o desalineado.",
-    ],
+    tips: ["Si un sensor da resultados muy diferentes, puede estar dañado o desalineado."],
     alertas: [],
   },
   {
@@ -333,9 +324,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
       { descripcion: "CV del EI", limite: "≤ 10%" },
       { descripcion: "CV del D.I.", limite: "≤ 10%" },
     ],
-    tips: [
-      "Si el CV es alto, el CAE no está regulando consistentemente la exposición.",
-    ],
+    tips: ["Si el CV es alto, el CAE no está regulando consistentemente la exposición."],
     alertas: [],
   },
   {
@@ -344,10 +333,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
     grupo: "C",
     objetivo:
       "Verificar que el CAE ajusta correctamente la exposición cuando cambia el voltaje (kVp) o el espesor del paciente (simulado con placas de cobre de diferente grosor).",
-    instrumentacion: [
-      "Placas de cobre: 1 mm, 2 mm, 3 mm",
-      "Equipo con CAE activado",
-    ],
+    instrumentacion: ["Placas de cobre: 1 mm, 2 mm, 3 mm", "Equipo con CAE activado"],
     pasos: [
       "Compensación por kVp: dispara a 60, 70 y 81 kVp con Cu 1mm y sensor Centro. Compara con valores base.",
       "Compensación por espesores: dispara a 81 kVp con Cu 1mm, 2mm y 3mm. Compara con valores base.",
@@ -404,9 +390,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
       "Registra el DDI/EI de cada exposición.",
       "Calcula el CV (coeficiente de variación).",
     ],
-    criterios: [
-      { descripcion: "CV del DDI/EI", limite: "≤ 10%" },
-    ],
+    criterios: [{ descripcion: "CV del DDI/EI", limite: "≤ 10%" }],
     tips: [],
     alertas: [],
   },
@@ -443,9 +427,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
       "Analiza la imagen resultante buscando variaciones de densidad.",
       "Mide la uniformidad en diferentes regiones de la imagen.",
     ],
-    criterios: [
-      { descripcion: "Uniformidad de la sensibilidad", limite: "Según fabricante" },
-    ],
+    criterios: [{ descripcion: "Uniformidad de la sensibilidad", limite: "Según fabricante" }],
     tips: ["Solo aplica a sistemas CR."],
     alertas: [],
   },
@@ -475,9 +457,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
       },
       { descripcion: "Perpendicularidad del rayo central", limite: "≤ 1.5°" },
     ],
-    tips: [
-      "Toma fotografía del montaje experimental para documentar.",
-    ],
+    tips: ["Toma fotografía del montaje experimental para documentar."],
     alertas: [],
   },
   {
@@ -486,10 +466,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
     grupo: "E",
     objetivo:
       "Verificar que el detector de imagen produce una respuesta uniforme y no tiene artefactos que afecten la calidad diagnóstica.",
-    instrumentacion: [
-      "Detector de imagen (DR o CR)",
-      "Placa de cobre como filtro",
-    ],
+    instrumentacion: ["Detector de imagen (DR o CR)", "Placa de cobre como filtro"],
     pasos: [
       "Coloca el lado más largo del detector alineado con el tubo.",
       "Coloca un filtro de cobre a la salida del tubo.",
@@ -503,9 +480,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
     tips: [
       "Haz esta prueba ANTES que las demás o deja reposar el detector después para evitar imagen residual.",
     ],
-    alertas: [
-      "Coloca el filtro de cobre a la salida del tubo para obtener un haz uniforme.",
-    ],
+    alertas: ["Coloca el filtro de cobre a la salida del tubo para obtener un haz uniforme."],
   },
   {
     codigo: "2.12",
@@ -513,10 +488,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
     grupo: "E",
     objetivo:
       "Determinar la capacidad del sistema para distinguir objetos pequeños y cercanos entre sí. Se mide en pares de líneas por milímetro (pl/mm).",
-    instrumentacion: [
-      "Patrón de resolución (tipo barra de plomo)",
-      "Detector de imagen",
-    ],
+    instrumentacion: ["Patrón de resolución (tipo barra de plomo)", "Detector de imagen"],
     pasos: [
       "Coloca el patrón de resolución sobre el detector.",
       "Realiza una exposición con técnica estándar.",
@@ -529,9 +501,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
         limite: "≥ valor de referencia del sistema (según fabricante)",
       },
     ],
-    tips: [
-      "Usa zoom en la imagen para evaluar los patrones más finos.",
-    ],
+    tips: ["Usa zoom en la imagen para evaluar los patrones más finos."],
     alertas: [],
   },
   {
@@ -567,10 +537,7 @@ export const MANUAL_CONVENCIONAL: ManualPrueba[] = [
     grupo: "E",
     objetivo:
       "Evaluar la capacidad del sistema para reproducir fielmente el contraste de objetos de diferente tamaño. Es una medida más precisa que la resolución visual.",
-    instrumentacion: [
-      "Patrón MTF o borde recto (edge phantom)",
-      "Software de análisis DICOM",
-    ],
+    instrumentacion: ["Patrón MTF o borde recto (edge phantom)", "Software de análisis DICOM"],
     pasos: [
       "Coloca el patrón MTF o borde recto sobre el detector con una ligera inclinación (2–5°).",
       "Realiza una exposición.",

--- a/src/lib/equipos/convencional/raysafe-parser.ts
+++ b/src/lib/equipos/convencional/raysafe-parser.ts
@@ -37,8 +37,12 @@ function wsToRows(ws: import("xlsx").WorkSheet): RaysafeRow[] {
   // col G = No. RaySafe. En ese caso los datos empiezan en offset 6.
   const hasNominals =
     raw.length > 1 &&
-    (String(raw[0]?.[0] ?? "").toLowerCase().includes("grupo") ||
-      String(raw[1]?.[0] ?? "").toLowerCase().includes("grupo"));
+    (String(raw[0]?.[0] ?? "")
+      .toLowerCase()
+      .includes("grupo") ||
+      String(raw[1]?.[0] ?? "")
+        .toLowerCase()
+        .includes("grupo"));
   const off = hasNominals ? 6 : 0; // offset hacia col G en plantilla Sievert
 
   const rows: RaysafeRow[] = [];
@@ -47,10 +51,10 @@ function wsToRows(ws: import("xlsx").WorkSheet): RaysafeRow[] {
     if (isNaN(no) || no <= 0) continue;
     rows.push({
       numero: no,
-      kv: toNum(row[off + 4]),           // col K (kVp)
-      dosis_mgy: toNum(row[off + 6]),     // col M (mGy)
-      tiempo_s: toNum(row[off + 8]),      // col O (s)
-      chr_mmal: toNum(row[off + 10]),     // col Q (mm Al HVL)
+      kv: toNum(row[off + 4]), // col K (kVp)
+      dosis_mgy: toNum(row[off + 6]), // col M (mGy)
+      tiempo_s: toNum(row[off + 8]), // col O (s)
+      chr_mmal: toNum(row[off + 10]), // col Q (mm Al HVL)
       rendimiento_mgy_min: toNum(row[off + 12]), // col S (mGy/min)
     });
   }
@@ -81,7 +85,7 @@ export function parseRaysafeTsv(text: string): RaysafeRow[] {
 // Si sí, lee las 4 hojas y retorna RaysafePlantilla.
 // Si no (archivo RaySafe nativo exportado como xlsx), lee solo hoja 0.
 export async function parseRaysafeXlsx(
-  file: File,
+  file: File
 ): Promise<{ tipo: "plantilla"; data: RaysafePlantilla } | { tipo: "simple"; data: RaysafeRow[] }> {
   const XLSX = await import("xlsx");
   const buf = await file.arrayBuffer();

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -40,7 +40,7 @@ function evictStale() {
 export function rateLimit(
   key: string,
   limit: number,
-  windowMs: number,
+  windowMs: number
 ): { allowed: boolean; remaining: number } {
   const now = Date.now();
   const entry = hits.get(key);

--- a/src/lib/supabase/sync-classification.test.ts
+++ b/src/lib/supabase/sync-classification.test.ts
@@ -1,0 +1,68 @@
+// Guarda de clasificación de tablas.
+//
+// Toda tabla de Dexie tiene que estar clasificada como:
+//   - SYNC_TABLES     → sube y baja de Supabase (bidireccional)
+//   - MASTER_TABLES   → solo baja (catálogo de referencia)
+//   - LOCAL_ONLY      → nunca toca Supabase (bookkeeping de sync)
+//
+// Si alguien agrega una tabla nueva al esquema y no la clasifica, este test
+// falla. Es la red que evita que vuelvan los hallazgos #14 (una tabla queda
+// fuera del sync sin que nadie lo note) y #20 (columnas/tablas locales que
+// llegan a PostgREST y mandan la fila a `failed`).
+
+import { describe, it, expect, vi } from "vitest";
+import { db } from "@/lib/db";
+
+// sync-engine importa @/lib/supabase/client, que valida env vars y lanza
+// sin .env.local. Mismo mock que usa sync-engine.test.ts.
+vi.mock("./client", () => ({ createClient: () => ({}) }));
+
+import { SYNC_TABLES, MASTER_TABLES } from "./sync-engine";
+
+// Tablas que viven SOLO en el dispositivo — no tienen contraparte en
+// Supabase por diseño. Si agregás una acá, dejá el motivo.
+const LOCAL_ONLY = new Set<string>([
+  "sync_meta", // watermark de pull por tabla
+  "sync_retry", // backoff de reintentos de push
+  "change_logs", // auditoría local (change-tracker) — revisar en Tier 4 si debe sincronizar
+  // ── Deuda detectada por este guard (no es local-only "por diseño") ──
+  // `elementos_proteccion`: tabla legacy. Tiene contraparte en Supabase
+  // (types.ts) pero NO está en SYNC_TABLES, así que nunca sincroniza. Ya
+  // nada le escribe (el camino de escritura pasó a `conv_elementos_proteccion`),
+  // pero generar-pre-informe.ts:140 TODAVÍA la lee. Resolver en Tier 5 (PDF):
+  // o el PDF lee `conv_elementos_proteccion`, o se cablea al sync, o se borra
+  // la tabla. Hasta entonces se marca local-only para no romper el guard.
+  "elementos_proteccion",
+]);
+
+describe("clasificación de tablas de sync", () => {
+  const classified = new Set<string>([
+    ...SYNC_TABLES.map((t) => t.local),
+    ...MASTER_TABLES,
+    ...LOCAL_ONLY,
+  ]);
+
+  it("toda tabla de Dexie está clasificada (SYNC / MASTER / LOCAL_ONLY)", () => {
+    const dexieTables = db.tables.map((t) => t.name).sort();
+    const sinClasificar = dexieTables.filter((name) => !classified.has(name));
+
+    expect(
+      sinClasificar,
+      `Tablas de Dexie sin clasificar: ${sinClasificar.join(", ")}. ` +
+        `Agregala a SYNC_TABLES, MASTER_TABLES (sync-engine.ts) o a LOCAL_ONLY (este archivo).`
+    ).toEqual([]);
+  });
+
+  it("no hay tablas clasificadas que ya no existan en el esquema", () => {
+    const dexieTables = new Set(db.tables.map((t) => t.name));
+    const fantasma = [...classified].filter((name) => !dexieTables.has(name));
+
+    expect(fantasma, `Clasificadas pero inexistentes en Dexie: ${fantasma.join(", ")}`).toEqual([]);
+  });
+
+  it("ninguna tabla está en SYNC y MASTER a la vez", () => {
+    const master = new Set(MASTER_TABLES as readonly string[]);
+    const solapadas = SYNC_TABLES.map((t) => t.local).filter((l) => master.has(l));
+    expect(solapadas).toEqual([]);
+  });
+});

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -154,7 +154,7 @@ function prepareForRemote(
 }
 
 // Tablas de campo sincronizadas bidireccionalmente (tienen sync_status)
-const SYNC_TABLES = [
+export const SYNC_TABLES = [
   // ─── Maestras editables ───
   { local: "clientes", remote: "clientes" },
   { local: "contactos", remote: "contactos" },
@@ -195,7 +195,7 @@ const SYNC_TABLES = [
 ] as const;
 
 // Tablas maestras que se descargan del servidor (read-only para sync)
-const MASTER_TABLES = [
+export const MASTER_TABLES = [
   "departamentos",
   "municipios",
   "sala_dimensiones",

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,2779 +1,2771 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.5"
-  }
+    PostgrestVersion: "14.5";
+  };
   graphql_public: {
     Tables: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       change_logs: {
         Row: {
-          campo: string
-          fecha: string
-          id: string
-          modificado_por_id: string
-          registro_id: string
-          tabla: string
-          valor_anterior: string | null
-          valor_nuevo: string | null
-        }
+          campo: string;
+          fecha: string;
+          id: string;
+          modificado_por_id: string;
+          registro_id: string;
+          tabla: string;
+          valor_anterior: string | null;
+          valor_nuevo: string | null;
+        };
         Insert: {
-          campo: string
-          fecha?: string
-          id?: string
-          modificado_por_id: string
-          registro_id: string
-          tabla: string
-          valor_anterior?: string | null
-          valor_nuevo?: string | null
-        }
+          campo: string;
+          fecha?: string;
+          id?: string;
+          modificado_por_id: string;
+          registro_id: string;
+          tabla: string;
+          valor_anterior?: string | null;
+          valor_nuevo?: string | null;
+        };
         Update: {
-          campo?: string
-          fecha?: string
-          id?: string
-          modificado_por_id?: string
-          registro_id?: string
-          tabla?: string
-          valor_anterior?: string | null
-          valor_nuevo?: string | null
-        }
+          campo?: string;
+          fecha?: string;
+          id?: string;
+          modificado_por_id?: string;
+          registro_id?: string;
+          tabla?: string;
+          valor_anterior?: string | null;
+          valor_nuevo?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "change_logs_modificado_por_id_fkey"
-            columns: ["modificado_por_id"]
-            isOneToOne: false
-            referencedRelation: "usuarios"
-            referencedColumns: ["id"]
+            foreignKeyName: "change_logs_modificado_por_id_fkey";
+            columns: ["modificado_por_id"];
+            isOneToOne: false;
+            referencedRelation: "usuarios";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       clientes: {
         Row: {
-          creado_en: string
-          digito_verificacion: string | null
-          direccion: string | null
-          email: string | null
-          id: string
-          last_modified: string
-          naturaleza: string | null
-          nit: string
-          nombre_cliente: string
-          nombre_prestador: string | null
-          nombre_representante_legal: string | null
-          sync_status: string
-          telefono: string | null
-        }
+          creado_en: string;
+          digito_verificacion: string | null;
+          direccion: string | null;
+          email: string | null;
+          id: string;
+          last_modified: string;
+          naturaleza: string | null;
+          nit: string;
+          nombre_cliente: string;
+          nombre_prestador: string | null;
+          nombre_representante_legal: string | null;
+          sync_status: string;
+          telefono: string | null;
+        };
         Insert: {
-          creado_en?: string
-          digito_verificacion?: string | null
-          direccion?: string | null
-          email?: string | null
-          id?: string
-          last_modified?: string
-          naturaleza?: string | null
-          nit: string
-          nombre_cliente: string
-          nombre_prestador?: string | null
-          nombre_representante_legal?: string | null
-          sync_status?: string
-          telefono?: string | null
-        }
+          creado_en?: string;
+          digito_verificacion?: string | null;
+          direccion?: string | null;
+          email?: string | null;
+          id?: string;
+          last_modified?: string;
+          naturaleza?: string | null;
+          nit: string;
+          nombre_cliente: string;
+          nombre_prestador?: string | null;
+          nombre_representante_legal?: string | null;
+          sync_status?: string;
+          telefono?: string | null;
+        };
         Update: {
-          creado_en?: string
-          digito_verificacion?: string | null
-          direccion?: string | null
-          email?: string | null
-          id?: string
-          last_modified?: string
-          naturaleza?: string | null
-          nit?: string
-          nombre_cliente?: string
-          nombre_prestador?: string | null
-          nombre_representante_legal?: string | null
-          sync_status?: string
-          telefono?: string | null
-        }
-        Relationships: []
-      }
+          creado_en?: string;
+          digito_verificacion?: string | null;
+          direccion?: string | null;
+          email?: string | null;
+          id?: string;
+          last_modified?: string;
+          naturaleza?: string | null;
+          nit?: string;
+          nombre_cliente?: string;
+          nombre_prestador?: string | null;
+          nombre_representante_legal?: string | null;
+          sync_status?: string;
+          telefono?: string | null;
+        };
+        Relationships: [];
+      };
       colimadores: {
         Row: {
-          creado_en: string
-          equipo_id: string
-          id: string
-          last_modified: string
-          marca: string | null
-          modelo: string | null
-          numero_serie: string | null
-          sync_status: string
-        }
+          creado_en: string;
+          equipo_id: string;
+          id: string;
+          last_modified: string;
+          marca: string | null;
+          modelo: string | null;
+          numero_serie: string | null;
+          sync_status: string;
+        };
         Insert: {
-          creado_en?: string
-          equipo_id: string
-          id?: string
-          last_modified?: string
-          marca?: string | null
-          modelo?: string | null
-          numero_serie?: string | null
-          sync_status?: string
-        }
+          creado_en?: string;
+          equipo_id: string;
+          id?: string;
+          last_modified?: string;
+          marca?: string | null;
+          modelo?: string | null;
+          numero_serie?: string | null;
+          sync_status?: string;
+        };
         Update: {
-          creado_en?: string
-          equipo_id?: string
-          id?: string
-          last_modified?: string
-          marca?: string | null
-          modelo?: string | null
-          numero_serie?: string | null
-          sync_status?: string
-        }
+          creado_en?: string;
+          equipo_id?: string;
+          id?: string;
+          last_modified?: string;
+          marca?: string | null;
+          modelo?: string | null;
+          numero_serie?: string | null;
+          sync_status?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "colimadores_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "colimadores_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       contactos: {
         Row: {
-          cargo: string | null
-          cedula: string | null
-          cliente_id: string
-          creado_en: string
-          email: string | null
-          id: string
-          last_modified: string
-          nombre: string
-          para_programar: boolean
-          sync_status: string
-          telefono: string | null
-        }
+          cargo: string | null;
+          cedula: string | null;
+          cliente_id: string;
+          creado_en: string;
+          email: string | null;
+          id: string;
+          last_modified: string;
+          nombre: string;
+          para_programar: boolean;
+          sync_status: string;
+          telefono: string | null;
+        };
         Insert: {
-          cargo?: string | null
-          cedula?: string | null
-          cliente_id: string
-          creado_en?: string
-          email?: string | null
-          id?: string
-          last_modified?: string
-          nombre: string
-          para_programar?: boolean
-          sync_status?: string
-          telefono?: string | null
-        }
+          cargo?: string | null;
+          cedula?: string | null;
+          cliente_id: string;
+          creado_en?: string;
+          email?: string | null;
+          id?: string;
+          last_modified?: string;
+          nombre: string;
+          para_programar?: boolean;
+          sync_status?: string;
+          telefono?: string | null;
+        };
         Update: {
-          cargo?: string | null
-          cedula?: string | null
-          cliente_id?: string
-          creado_en?: string
-          email?: string | null
-          id?: string
-          last_modified?: string
-          nombre?: string
-          para_programar?: boolean
-          sync_status?: string
-          telefono?: string | null
-        }
+          cargo?: string | null;
+          cedula?: string | null;
+          cliente_id?: string;
+          creado_en?: string;
+          email?: string | null;
+          id?: string;
+          last_modified?: string;
+          nombre?: string;
+          para_programar?: boolean;
+          sync_status?: string;
+          telefono?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "contactos_cliente_id_fkey"
-            columns: ["cliente_id"]
-            isOneToOne: false
-            referencedRelation: "clientes"
-            referencedColumns: ["id"]
+            foreignKeyName: "contactos_cliente_id_fkey";
+            columns: ["cliente_id"];
+            isOneToOne: false;
+            referencedRelation: "clientes";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_bajo_contraste: {
         Row: {
-          creado_en: string
-          id: string
-          last_modified: string
-          notas: string | null
-          sync_status: string
-          umbral_detectado: number | null
-          visita_id: string
-        }
+          creado_en: string;
+          id: string;
+          last_modified: string;
+          notas: string | null;
+          sync_status: string;
+          umbral_detectado: number | null;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          sync_status?: string
-          umbral_detectado?: number | null
-          visita_id: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          sync_status?: string;
+          umbral_detectado?: number | null;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          sync_status?: string
-          umbral_detectado?: number | null
-          visita_id?: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          sync_status?: string;
+          umbral_detectado?: number | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_bajo_contraste_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_bajo_contraste_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_cae_mediciones: {
         Row: {
-          creado_en: string
-          filtro: string | null
-          id: string
-          kerma_mgy: number | null
-          kvp: number | null
-          last_modified: string
-          mas_resultado: number | null
-          notas: string | null
-          prueba_codigo: string
-          sync_status: string
-          valor_base: number | null
-          visita_id: string
-        }
+          creado_en: string;
+          filtro: string | null;
+          id: string;
+          kerma_mgy: number | null;
+          kvp: number | null;
+          last_modified: string;
+          mas_resultado: number | null;
+          notas: string | null;
+          prueba_codigo: string;
+          sync_status: string;
+          valor_base: number | null;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          filtro?: string | null
-          id?: string
-          kerma_mgy?: number | null
-          kvp?: number | null
-          last_modified?: string
-          mas_resultado?: number | null
-          notas?: string | null
-          prueba_codigo: string
-          sync_status?: string
-          valor_base?: number | null
-          visita_id: string
-        }
+          creado_en?: string;
+          filtro?: string | null;
+          id?: string;
+          kerma_mgy?: number | null;
+          kvp?: number | null;
+          last_modified?: string;
+          mas_resultado?: number | null;
+          notas?: string | null;
+          prueba_codigo: string;
+          sync_status?: string;
+          valor_base?: number | null;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          filtro?: string | null
-          id?: string
-          kerma_mgy?: number | null
-          kvp?: number | null
-          last_modified?: string
-          mas_resultado?: number | null
-          notas?: string | null
-          prueba_codigo?: string
-          sync_status?: string
-          valor_base?: number | null
-          visita_id?: string
-        }
+          creado_en?: string;
+          filtro?: string | null;
+          id?: string;
+          kerma_mgy?: number | null;
+          kvp?: number | null;
+          last_modified?: string;
+          mas_resultado?: number | null;
+          notas?: string | null;
+          prueba_codigo?: string;
+          sync_status?: string;
+          valor_base?: number | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_cae_mediciones_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_cae_mediciones_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_cae_setup: {
         Row: {
-          creado_en: string
-          id: string
-          last_modified: string
-          notas: string | null
-          phantom: string | null
-          posicion: string | null
-          sync_status: string
-          visita_id: string
-        }
+          creado_en: string;
+          id: string;
+          last_modified: string;
+          notas: string | null;
+          phantom: string | null;
+          posicion: string | null;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          phantom?: string | null
-          posicion?: string | null
-          sync_status?: string
-          visita_id: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          phantom?: string | null;
+          posicion?: string | null;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          phantom?: string | null
-          posicion?: string | null
-          sync_status?: string
-          visita_id?: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          phantom?: string | null;
+          posicion?: string | null;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_cae_setup_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_cae_setup_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_cassette_inspeccion: {
         Row: {
-          conformes: number | null
-          creado_en: string
-          id: string
-          last_modified: string
-          no_conformes: number | null
-          observaciones: string | null
-          sync_status: string
-          total: number | null
-          visita_id: string
-        }
+          conformes: number | null;
+          creado_en: string;
+          id: string;
+          last_modified: string;
+          no_conformes: number | null;
+          observaciones: string | null;
+          sync_status: string;
+          total: number | null;
+          visita_id: string;
+        };
         Insert: {
-          conformes?: number | null
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          no_conformes?: number | null
-          observaciones?: string | null
-          sync_status?: string
-          total?: number | null
-          visita_id: string
-        }
+          conformes?: number | null;
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          no_conformes?: number | null;
+          observaciones?: string | null;
+          sync_status?: string;
+          total?: number | null;
+          visita_id: string;
+        };
         Update: {
-          conformes?: number | null
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          no_conformes?: number | null
-          observaciones?: string | null
-          sync_status?: string
-          total?: number | null
-          visita_id?: string
-        }
+          conformes?: number | null;
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          no_conformes?: number | null;
+          observaciones?: string | null;
+          sync_status?: string;
+          total?: number | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_cassette_inspeccion_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_cassette_inspeccion_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_colimacion: {
         Row: {
-          campo_luz_cm: number | null
-          campo_rx_cm: number | null
-          creado_en: string
-          diferencia_cm: number | null
-          id: string
-          last_modified: string
-          notas: string | null
-          perpendiculares: Json | null
-          sync_status: string
-          visita_id: string
-        }
+          campo_luz_cm: number | null;
+          campo_rx_cm: number | null;
+          creado_en: string;
+          diferencia_cm: number | null;
+          id: string;
+          last_modified: string;
+          notas: string | null;
+          perpendiculares: Json | null;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          campo_luz_cm?: number | null
-          campo_rx_cm?: number | null
-          creado_en?: string
-          diferencia_cm?: number | null
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          perpendiculares?: Json | null
-          sync_status?: string
-          visita_id: string
-        }
+          campo_luz_cm?: number | null;
+          campo_rx_cm?: number | null;
+          creado_en?: string;
+          diferencia_cm?: number | null;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          perpendiculares?: Json | null;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          campo_luz_cm?: number | null
-          campo_rx_cm?: number | null
-          creado_en?: string
-          diferencia_cm?: number | null
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          perpendiculares?: Json | null
-          sync_status?: string
-          visita_id?: string
-        }
+          campo_luz_cm?: number | null;
+          campo_rx_cm?: number | null;
+          creado_en?: string;
+          diferencia_cm?: number | null;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          perpendiculares?: Json | null;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_colimacion_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_colimacion_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_ddi_mediciones: {
         Row: {
-          creado_en: string
-          ddi: number | null
-          ei: number | null
-          id: string
-          kv: number | null
-          last_modified: string
-          mas: number | null
-          notas: string | null
-          numero: number
-          prueba_codigo: string
-          sync_status: string
-          visita_id: string
-        }
+          creado_en: string;
+          ddi: number | null;
+          ei: number | null;
+          id: string;
+          kv: number | null;
+          last_modified: string;
+          mas: number | null;
+          notas: string | null;
+          numero: number;
+          prueba_codigo: string;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          ddi?: number | null
-          ei?: number | null
-          id?: string
-          kv?: number | null
-          last_modified?: string
-          mas?: number | null
-          notas?: string | null
-          numero: number
-          prueba_codigo: string
-          sync_status?: string
-          visita_id: string
-        }
+          creado_en?: string;
+          ddi?: number | null;
+          ei?: number | null;
+          id?: string;
+          kv?: number | null;
+          last_modified?: string;
+          mas?: number | null;
+          notas?: string | null;
+          numero: number;
+          prueba_codigo: string;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          ddi?: number | null
-          ei?: number | null
-          id?: string
-          kv?: number | null
-          last_modified?: string
-          mas?: number | null
-          notas?: string | null
-          numero?: number
-          prueba_codigo?: string
-          sync_status?: string
-          visita_id?: string
-        }
+          creado_en?: string;
+          ddi?: number | null;
+          ei?: number | null;
+          id?: string;
+          kv?: number | null;
+          last_modified?: string;
+          mas?: number | null;
+          notas?: string | null;
+          numero?: number;
+          prueba_codigo?: string;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_ddi_mediciones_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_ddi_mediciones_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_elementos_proteccion: {
         Row: {
-          cantidad: number | null
-          creado_en: string
-          descripcion: string
-          estado: string | null
-          id: string
-          last_modified: string
-          observacion: string | null
-          sync_status: string
-          visita_id: string
-        }
+          cantidad: number | null;
+          creado_en: string;
+          descripcion: string;
+          estado: string | null;
+          id: string;
+          last_modified: string;
+          observacion: string | null;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          cantidad?: number | null
-          creado_en?: string
-          descripcion: string
-          estado?: string | null
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          sync_status?: string
-          visita_id: string
-        }
+          cantidad?: number | null;
+          creado_en?: string;
+          descripcion: string;
+          estado?: string | null;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          cantidad?: number | null
-          creado_en?: string
-          descripcion?: string
-          estado?: string | null
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          sync_status?: string
-          visita_id?: string
-        }
+          cantidad?: number | null;
+          creado_en?: string;
+          descripcion?: string;
+          estado?: string | null;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_elementos_proteccion_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_elementos_proteccion_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_evidencias: {
         Row: {
-          creado_en: string
-          descripcion: string | null
-          id: string
-          last_modified: string
-          orden: number
-          prueba_codigo: string
-          storage_path: string | null
-          sync_status: string
-          url_storage: string | null
-          visita_id: string
-        }
+          creado_en: string;
+          descripcion: string | null;
+          id: string;
+          last_modified: string;
+          orden: number;
+          prueba_codigo: string;
+          storage_path: string | null;
+          sync_status: string;
+          url_storage: string | null;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          descripcion?: string | null
-          id?: string
-          last_modified?: string
-          orden?: number
-          prueba_codigo: string
-          storage_path?: string | null
-          sync_status?: string
-          url_storage?: string | null
-          visita_id: string
-        }
+          creado_en?: string;
+          descripcion?: string | null;
+          id?: string;
+          last_modified?: string;
+          orden?: number;
+          prueba_codigo: string;
+          storage_path?: string | null;
+          sync_status?: string;
+          url_storage?: string | null;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          descripcion?: string | null
-          id?: string
-          last_modified?: string
-          orden?: number
-          prueba_codigo?: string
-          storage_path?: string | null
-          sync_status?: string
-          url_storage?: string | null
-          visita_id?: string
-        }
+          creado_en?: string;
+          descripcion?: string | null;
+          id?: string;
+          last_modified?: string;
+          orden?: number;
+          prueba_codigo?: string;
+          storage_path?: string | null;
+          sync_status?: string;
+          url_storage?: string | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_evidencias_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_evidencias_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_informe_secciones: {
         Row: {
-          creado_en: string
-          id: string
-          last_modified: string
-          secciones: Json
-          sync_status: string
-          visita_id: string
-        }
+          creado_en: string;
+          id: string;
+          last_modified: string;
+          secciones: Json;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          secciones?: Json
-          sync_status?: string
-          visita_id: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          secciones?: Json;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          secciones?: Json
-          sync_status?: string
-          visita_id?: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          secciones?: Json;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_informe_secciones_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_informe_secciones_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_inspeccion_items: {
         Row: {
-          categoria: string | null
-          creado_en: string
-          estado: string | null
-          id: string
-          item: string
-          last_modified: string
-          observacion: string | null
-          sync_status: string
-          visita_id: string
-        }
+          categoria: string | null;
+          creado_en: string;
+          estado: string | null;
+          id: string;
+          item: string;
+          last_modified: string;
+          observacion: string | null;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          categoria?: string | null
-          creado_en?: string
-          estado?: string | null
-          id?: string
-          item: string
-          last_modified?: string
-          observacion?: string | null
-          sync_status?: string
-          visita_id: string
-        }
+          categoria?: string | null;
+          creado_en?: string;
+          estado?: string | null;
+          id?: string;
+          item: string;
+          last_modified?: string;
+          observacion?: string | null;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          categoria?: string | null
-          creado_en?: string
-          estado?: string | null
-          id?: string
-          item?: string
-          last_modified?: string
-          observacion?: string | null
-          sync_status?: string
-          visita_id?: string
-        }
+          categoria?: string | null;
+          creado_en?: string;
+          estado?: string | null;
+          id?: string;
+          item?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_inspeccion_items_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_inspeccion_items_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_levantamiento_setup: {
         Row: {
-          calibrado_en: string | null
-          creado_en: string
-          humedad_pct: number | null
-          id: string
-          instrumento: string | null
-          last_modified: string
-          notas: string | null
-          numero_serie: string | null
-          presion_hpa: number | null
-          sync_status: string
-          temperatura_c: number | null
-          visita_id: string
-        }
+          calibrado_en: string | null;
+          creado_en: string;
+          humedad_pct: number | null;
+          id: string;
+          instrumento: string | null;
+          last_modified: string;
+          notas: string | null;
+          numero_serie: string | null;
+          presion_hpa: number | null;
+          sync_status: string;
+          temperatura_c: number | null;
+          visita_id: string;
+        };
         Insert: {
-          calibrado_en?: string | null
-          creado_en?: string
-          humedad_pct?: number | null
-          id?: string
-          instrumento?: string | null
-          last_modified?: string
-          notas?: string | null
-          numero_serie?: string | null
-          presion_hpa?: number | null
-          sync_status?: string
-          temperatura_c?: number | null
-          visita_id: string
-        }
+          calibrado_en?: string | null;
+          creado_en?: string;
+          humedad_pct?: number | null;
+          id?: string;
+          instrumento?: string | null;
+          last_modified?: string;
+          notas?: string | null;
+          numero_serie?: string | null;
+          presion_hpa?: number | null;
+          sync_status?: string;
+          temperatura_c?: number | null;
+          visita_id: string;
+        };
         Update: {
-          calibrado_en?: string | null
-          creado_en?: string
-          humedad_pct?: number | null
-          id?: string
-          instrumento?: string | null
-          last_modified?: string
-          notas?: string | null
-          numero_serie?: string | null
-          presion_hpa?: number | null
-          sync_status?: string
-          temperatura_c?: number | null
-          visita_id?: string
-        }
+          calibrado_en?: string | null;
+          creado_en?: string;
+          humedad_pct?: number | null;
+          id?: string;
+          instrumento?: string | null;
+          last_modified?: string;
+          notas?: string | null;
+          numero_serie?: string | null;
+          presion_hpa?: number | null;
+          sync_status?: string;
+          temperatura_c?: number | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_levantamiento_setup_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_levantamiento_setup_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_mediciones: {
         Row: {
-          concepto: string | null
-          creado_en: string
-          dosis_anual_msv: number | null
-          factor_ocupacion: string | null
-          id: string
-          last_modified: string
-          observacion: string | null
-          punto_numero: number
-          sync_status: string
-          tasa_dosis_msv_h: number | null
-          tipo_area: string | null
-          ubicacion_descripcion: string
-          visita_id: string
-        }
+          concepto: string | null;
+          creado_en: string;
+          dosis_anual_msv: number | null;
+          factor_ocupacion: string | null;
+          id: string;
+          last_modified: string;
+          observacion: string | null;
+          punto_numero: number;
+          sync_status: string;
+          tasa_dosis_msv_h: number | null;
+          tipo_area: string | null;
+          ubicacion_descripcion: string;
+          visita_id: string;
+        };
         Insert: {
-          concepto?: string | null
-          creado_en?: string
-          dosis_anual_msv?: number | null
-          factor_ocupacion?: string | null
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          punto_numero: number
-          sync_status?: string
-          tasa_dosis_msv_h?: number | null
-          tipo_area?: string | null
-          ubicacion_descripcion: string
-          visita_id: string
-        }
+          concepto?: string | null;
+          creado_en?: string;
+          dosis_anual_msv?: number | null;
+          factor_ocupacion?: string | null;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          punto_numero: number;
+          sync_status?: string;
+          tasa_dosis_msv_h?: number | null;
+          tipo_area?: string | null;
+          ubicacion_descripcion: string;
+          visita_id: string;
+        };
         Update: {
-          concepto?: string | null
-          creado_en?: string
-          dosis_anual_msv?: number | null
-          factor_ocupacion?: string | null
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          punto_numero?: number
-          sync_status?: string
-          tasa_dosis_msv_h?: number | null
-          tipo_area?: string | null
-          ubicacion_descripcion?: string
-          visita_id?: string
-        }
+          concepto?: string | null;
+          creado_en?: string;
+          dosis_anual_msv?: number | null;
+          factor_ocupacion?: string | null;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          punto_numero?: number;
+          sync_status?: string;
+          tasa_dosis_msv_h?: number | null;
+          tipo_area?: string | null;
+          ubicacion_descripcion?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_mediciones_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_mediciones_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_mtf: {
         Row: {
-          creado_en: string
-          id: string
-          last_modified: string
-          notas: string | null
-          sync_status: string
-          valores_json: Json | null
-          visita_id: string
-        }
+          creado_en: string;
+          id: string;
+          last_modified: string;
+          notas: string | null;
+          sync_status: string;
+          valores_json: Json | null;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          sync_status?: string
-          valores_json?: Json | null
-          visita_id: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          sync_status?: string;
+          valores_json?: Json | null;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          sync_status?: string
-          valores_json?: Json | null
-          visita_id?: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          sync_status?: string;
+          valores_json?: Json | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_mtf_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_mtf_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_raysafe_mediciones: {
         Row: {
-          creado_en: string
-          ddi: number | null
-          dosis_base_mgy: number | null
-          ei: number | null
-          id: string
-          kerma_mgy: number | null
-          kv: number | null
-          last_modified: string
-          mas: number | null
-          notas: string | null
-          numero: number
-          sync_status: string
-          tipo_medicion: string
-          visita_id: string
-        }
+          creado_en: string;
+          ddi: number | null;
+          dosis_base_mgy: number | null;
+          ei: number | null;
+          id: string;
+          kerma_mgy: number | null;
+          kv: number | null;
+          last_modified: string;
+          mas: number | null;
+          notas: string | null;
+          numero: number;
+          sync_status: string;
+          tipo_medicion: string;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          ddi?: number | null
-          dosis_base_mgy?: number | null
-          ei?: number | null
-          id?: string
-          kerma_mgy?: number | null
-          kv?: number | null
-          last_modified?: string
-          mas?: number | null
-          notas?: string | null
-          numero: number
-          sync_status?: string
-          tipo_medicion: string
-          visita_id: string
-        }
+          creado_en?: string;
+          ddi?: number | null;
+          dosis_base_mgy?: number | null;
+          ei?: number | null;
+          id?: string;
+          kerma_mgy?: number | null;
+          kv?: number | null;
+          last_modified?: string;
+          mas?: number | null;
+          notas?: string | null;
+          numero: number;
+          sync_status?: string;
+          tipo_medicion: string;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          ddi?: number | null
-          dosis_base_mgy?: number | null
-          ei?: number | null
-          id?: string
-          kerma_mgy?: number | null
-          kv?: number | null
-          last_modified?: string
-          mas?: number | null
-          notas?: string | null
-          numero?: number
-          sync_status?: string
-          tipo_medicion?: string
-          visita_id?: string
-        }
+          creado_en?: string;
+          ddi?: number | null;
+          dosis_base_mgy?: number | null;
+          ei?: number | null;
+          id?: string;
+          kerma_mgy?: number | null;
+          kv?: number | null;
+          last_modified?: string;
+          mas?: number | null;
+          notas?: string | null;
+          numero?: number;
+          sync_status?: string;
+          tipo_medicion?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_raysafe_mediciones_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_raysafe_mediciones_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_raysafe_setup: {
         Row: {
-          creado_en: string
-          distancia_foco_detector_d1_cm: number | null
-          distancia_foco_detector_d2_cm: number | null
-          id: string
-          kv: number | null
-          last_modified: string
-          mas: number | null
-          modo_medicion: string | null
-          notas: string | null
-          sync_status: string
-          url_storage: string | null
-          visita_id: string
-        }
+          creado_en: string;
+          distancia_foco_detector_d1_cm: number | null;
+          distancia_foco_detector_d2_cm: number | null;
+          id: string;
+          kv: number | null;
+          last_modified: string;
+          mas: number | null;
+          modo_medicion: string | null;
+          notas: string | null;
+          sync_status: string;
+          url_storage: string | null;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          distancia_foco_detector_d1_cm?: number | null
-          distancia_foco_detector_d2_cm?: number | null
-          id?: string
-          kv?: number | null
-          last_modified?: string
-          mas?: number | null
-          modo_medicion?: string | null
-          notas?: string | null
-          sync_status?: string
-          url_storage?: string | null
-          visita_id: string
-        }
+          creado_en?: string;
+          distancia_foco_detector_d1_cm?: number | null;
+          distancia_foco_detector_d2_cm?: number | null;
+          id?: string;
+          kv?: number | null;
+          last_modified?: string;
+          mas?: number | null;
+          modo_medicion?: string | null;
+          notas?: string | null;
+          sync_status?: string;
+          url_storage?: string | null;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          distancia_foco_detector_d1_cm?: number | null
-          distancia_foco_detector_d2_cm?: number | null
-          id?: string
-          kv?: number | null
-          last_modified?: string
-          mas?: number | null
-          modo_medicion?: string | null
-          notas?: string | null
-          sync_status?: string
-          url_storage?: string | null
-          visita_id?: string
-        }
+          creado_en?: string;
+          distancia_foco_detector_d1_cm?: number | null;
+          distancia_foco_detector_d2_cm?: number | null;
+          id?: string;
+          kv?: number | null;
+          last_modified?: string;
+          mas?: number | null;
+          modo_medicion?: string | null;
+          notas?: string | null;
+          sync_status?: string;
+          url_storage?: string | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_raysafe_setup_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_raysafe_setup_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_resolucion: {
         Row: {
-          creado_en: string
-          id: string
-          last_modified: string
-          mtf20_h: number | null
-          mtf20_v: number | null
-          mtf50_h: number | null
-          mtf50_v: number | null
-          notas: string | null
-          sync_status: string
-          visita_id: string
-        }
+          creado_en: string;
+          id: string;
+          last_modified: string;
+          mtf20_h: number | null;
+          mtf20_v: number | null;
+          mtf50_h: number | null;
+          mtf50_v: number | null;
+          notas: string | null;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          mtf20_h?: number | null
-          mtf20_v?: number | null
-          mtf50_h?: number | null
-          mtf50_v?: number | null
-          notas?: string | null
-          sync_status?: string
-          visita_id: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          mtf20_h?: number | null;
+          mtf20_v?: number | null;
+          mtf50_h?: number | null;
+          mtf50_v?: number | null;
+          notas?: string | null;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          mtf20_h?: number | null
-          mtf20_v?: number | null
-          mtf50_h?: number | null
-          mtf50_v?: number | null
-          notas?: string | null
-          sync_status?: string
-          visita_id?: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          mtf20_h?: number | null;
+          mtf20_v?: number | null;
+          mtf50_h?: number | null;
+          mtf50_v?: number | null;
+          notas?: string | null;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_resolucion_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_resolucion_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_resultados_prueba: {
         Row: {
-          concepto: string | null
-          creado_en: string
-          datos_json: Json | null
-          id: string
-          last_modified: string
-          observaciones: string | null
-          prueba_codigo: string
-          sync_status: string
-          visita_id: string
-        }
+          concepto: string | null;
+          creado_en: string;
+          datos_json: Json | null;
+          id: string;
+          last_modified: string;
+          observaciones: string | null;
+          prueba_codigo: string;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          concepto?: string | null
-          creado_en?: string
-          datos_json?: Json | null
-          id?: string
-          last_modified?: string
-          observaciones?: string | null
-          prueba_codigo: string
-          sync_status?: string
-          visita_id: string
-        }
+          concepto?: string | null;
+          creado_en?: string;
+          datos_json?: Json | null;
+          id?: string;
+          last_modified?: string;
+          observaciones?: string | null;
+          prueba_codigo: string;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          concepto?: string | null
-          creado_en?: string
-          datos_json?: Json | null
-          id?: string
-          last_modified?: string
-          observaciones?: string | null
-          prueba_codigo?: string
-          sync_status?: string
-          visita_id?: string
-        }
+          concepto?: string | null;
+          creado_en?: string;
+          datos_json?: Json | null;
+          id?: string;
+          last_modified?: string;
+          observaciones?: string | null;
+          prueba_codigo?: string;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_resultados_prueba_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_resultados_prueba_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_uniformidad_cr: {
         Row: {
-          creado_en: string
-          desviacion: number | null
-          id: string
-          last_modified: string
-          notas: string | null
-          resultado: string | null
-          sync_status: string
-          valor_medio: number | null
-          visita_id: string
-        }
+          creado_en: string;
+          desviacion: number | null;
+          id: string;
+          last_modified: string;
+          notas: string | null;
+          resultado: string | null;
+          sync_status: string;
+          valor_medio: number | null;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          desviacion?: number | null
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          resultado?: string | null
-          sync_status?: string
-          valor_medio?: number | null
-          visita_id: string
-        }
+          creado_en?: string;
+          desviacion?: number | null;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          resultado?: string | null;
+          sync_status?: string;
+          valor_medio?: number | null;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          desviacion?: number | null
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          resultado?: string | null
-          sync_status?: string
-          valor_medio?: number | null
-          visita_id?: string
-        }
+          creado_en?: string;
+          desviacion?: number | null;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          resultado?: string | null;
+          sync_status?: string;
+          valor_medio?: number | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_uniformidad_cr_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_uniformidad_cr_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conv_uniformidad_detector: {
         Row: {
-          creado_en: string
-          id: string
-          last_modified: string
-          notas: string | null
-          sync_status: string
-          valores_json: Json | null
-          visita_id: string
-        }
+          creado_en: string;
+          id: string;
+          last_modified: string;
+          notas: string | null;
+          sync_status: string;
+          valores_json: Json | null;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          sync_status?: string
-          valores_json?: Json | null
-          visita_id: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          sync_status?: string;
+          valores_json?: Json | null;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          id?: string
-          last_modified?: string
-          notas?: string | null
-          sync_status?: string
-          valores_json?: Json | null
-          visita_id?: string
-        }
+          creado_en?: string;
+          id?: string;
+          last_modified?: string;
+          notas?: string | null;
+          sync_status?: string;
+          valores_json?: Json | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "conv_uniformidad_detector_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: true
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "conv_uniformidad_detector_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: true;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       cotizaciones: {
         Row: {
-          cliente_id: string
-          creado_en: string
-          estado: string | null
-          fecha_aceptacion: string | null
-          fecha_cotizacion: string | null
-          forma_pago: string | null
-          id: string
-          last_modified: string
-          sync_status: string
-          valor_total: number | null
-        }
+          cliente_id: string;
+          creado_en: string;
+          estado: string | null;
+          fecha_aceptacion: string | null;
+          fecha_cotizacion: string | null;
+          forma_pago: string | null;
+          id: string;
+          last_modified: string;
+          sync_status: string;
+          valor_total: number | null;
+        };
         Insert: {
-          cliente_id: string
-          creado_en?: string
-          estado?: string | null
-          fecha_aceptacion?: string | null
-          fecha_cotizacion?: string | null
-          forma_pago?: string | null
-          id?: string
-          last_modified?: string
-          sync_status?: string
-          valor_total?: number | null
-        }
+          cliente_id: string;
+          creado_en?: string;
+          estado?: string | null;
+          fecha_aceptacion?: string | null;
+          fecha_cotizacion?: string | null;
+          forma_pago?: string | null;
+          id?: string;
+          last_modified?: string;
+          sync_status?: string;
+          valor_total?: number | null;
+        };
         Update: {
-          cliente_id?: string
-          creado_en?: string
-          estado?: string | null
-          fecha_aceptacion?: string | null
-          fecha_cotizacion?: string | null
-          forma_pago?: string | null
-          id?: string
-          last_modified?: string
-          sync_status?: string
-          valor_total?: number | null
-        }
+          cliente_id?: string;
+          creado_en?: string;
+          estado?: string | null;
+          fecha_aceptacion?: string | null;
+          fecha_cotizacion?: string | null;
+          forma_pago?: string | null;
+          id?: string;
+          last_modified?: string;
+          sync_status?: string;
+          valor_total?: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "cotizaciones_cliente_id_fkey"
-            columns: ["cliente_id"]
-            isOneToOne: false
-            referencedRelation: "clientes"
-            referencedColumns: ["id"]
+            foreignKeyName: "cotizaciones_cliente_id_fkey";
+            columns: ["cliente_id"];
+            isOneToOne: false;
+            referencedRelation: "clientes";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       departamentos: {
         Row: {
-          codigo_dane: string
-          id: number
-          nombre: string
-        }
+          codigo_dane: string;
+          id: number;
+          nombre: string;
+        };
         Insert: {
-          codigo_dane: string
-          id: number
-          nombre: string
-        }
+          codigo_dane: string;
+          id: number;
+          nombre: string;
+        };
         Update: {
-          codigo_dane?: string
-          id?: number
-          nombre?: string
-        }
-        Relationships: []
-      }
+          codigo_dane?: string;
+          id?: number;
+          nombre?: string;
+        };
+        Relationships: [];
+      };
       elementos_proteccion: {
         Row: {
-          cantidad: number | null
-          concepto: string | null
-          creado_en: string
-          descripcion: string
-          id: string
-          last_modified: string
-          observacion: string | null
-          sync_status: string
-          visita_id: string
-        }
+          cantidad: number | null;
+          concepto: string | null;
+          creado_en: string;
+          descripcion: string;
+          id: string;
+          last_modified: string;
+          observacion: string | null;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          cantidad?: number | null
-          concepto?: string | null
-          creado_en?: string
-          descripcion: string
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          sync_status?: string
-          visita_id: string
-        }
+          cantidad?: number | null;
+          concepto?: string | null;
+          creado_en?: string;
+          descripcion: string;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          cantidad?: number | null
-          concepto?: string | null
-          creado_en?: string
-          descripcion?: string
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          sync_status?: string
-          visita_id?: string
-        }
+          cantidad?: number | null;
+          concepto?: string | null;
+          creado_en?: string;
+          descripcion?: string;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "elementos_proteccion_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "elementos_proteccion_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       equipo_movimientos: {
         Row: {
-          creado_en: string
-          equipo_id: string
-          fecha_movimiento: string
-          id: string
-          last_modified: string
-          motivo: string | null
-          registrado_por_id: string | null
-          sync_status: string
-          ubicacion_anterior_id: string | null
-          ubicacion_nueva_id: string
-        }
+          creado_en: string;
+          equipo_id: string;
+          fecha_movimiento: string;
+          id: string;
+          last_modified: string;
+          motivo: string | null;
+          registrado_por_id: string | null;
+          sync_status: string;
+          ubicacion_anterior_id: string | null;
+          ubicacion_nueva_id: string;
+        };
         Insert: {
-          creado_en?: string
-          equipo_id: string
-          fecha_movimiento: string
-          id?: string
-          last_modified?: string
-          motivo?: string | null
-          registrado_por_id?: string | null
-          sync_status?: string
-          ubicacion_anterior_id?: string | null
-          ubicacion_nueva_id: string
-        }
+          creado_en?: string;
+          equipo_id: string;
+          fecha_movimiento: string;
+          id?: string;
+          last_modified?: string;
+          motivo?: string | null;
+          registrado_por_id?: string | null;
+          sync_status?: string;
+          ubicacion_anterior_id?: string | null;
+          ubicacion_nueva_id: string;
+        };
         Update: {
-          creado_en?: string
-          equipo_id?: string
-          fecha_movimiento?: string
-          id?: string
-          last_modified?: string
-          motivo?: string | null
-          registrado_por_id?: string | null
-          sync_status?: string
-          ubicacion_anterior_id?: string | null
-          ubicacion_nueva_id?: string
-        }
+          creado_en?: string;
+          equipo_id?: string;
+          fecha_movimiento?: string;
+          id?: string;
+          last_modified?: string;
+          motivo?: string | null;
+          registrado_por_id?: string | null;
+          sync_status?: string;
+          ubicacion_anterior_id?: string | null;
+          ubicacion_nueva_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "equipo_movimientos_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "equipo_movimientos_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "equipo_movimientos_registrado_por_id_fkey"
-            columns: ["registrado_por_id"]
-            isOneToOne: false
-            referencedRelation: "usuarios"
-            referencedColumns: ["id"]
+            foreignKeyName: "equipo_movimientos_registrado_por_id_fkey";
+            columns: ["registrado_por_id"];
+            isOneToOne: false;
+            referencedRelation: "usuarios";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "equipo_movimientos_ubicacion_anterior_id_fkey"
-            columns: ["ubicacion_anterior_id"]
-            isOneToOne: false
-            referencedRelation: "ubicaciones_rx"
-            referencedColumns: ["id"]
+            foreignKeyName: "equipo_movimientos_ubicacion_anterior_id_fkey";
+            columns: ["ubicacion_anterior_id"];
+            isOneToOne: false;
+            referencedRelation: "ubicaciones_rx";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "equipo_movimientos_ubicacion_nueva_id_fkey"
-            columns: ["ubicacion_nueva_id"]
-            isOneToOne: false
-            referencedRelation: "ubicaciones_rx"
-            referencedColumns: ["id"]
+            foreignKeyName: "equipo_movimientos_ubicacion_nueva_id_fkey";
+            columns: ["ubicacion_nueva_id"];
+            isOneToOne: false;
+            referencedRelation: "ubicaciones_rx";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       equipos: {
         Row: {
-          bucky: string | null
-          creado_en: string
-          distancia_foco_paciente: number | null
-          filtracion_anadida_mmal: number | null
-          filtracion_inherente_mmal: number | null
-          gen_energia_fotones_mev: string | null
-          gen_fase: string | null
-          gen_fecha_fabricacion: string | null
-          gen_marca: string | null
-          gen_modelo: string | null
-          gen_numero_serie: string | null
-          id: string
-          last_modified: string
-          planilla_espacial: boolean
-          sistema_adquisicion: string | null
-          sync_status: string
-          tipo_equipo: string | null
-          ubicacion_id: string
-        }
+          bucky: string | null;
+          creado_en: string;
+          distancia_foco_paciente: number | null;
+          filtracion_anadida_mmal: number | null;
+          filtracion_inherente_mmal: number | null;
+          gen_energia_fotones_mev: string | null;
+          gen_fase: string | null;
+          gen_fecha_fabricacion: string | null;
+          gen_marca: string | null;
+          gen_modelo: string | null;
+          gen_numero_serie: string | null;
+          id: string;
+          last_modified: string;
+          planilla_espacial: boolean;
+          sistema_adquisicion: string | null;
+          sync_status: string;
+          tipo_equipo: string | null;
+          ubicacion_id: string;
+        };
         Insert: {
-          bucky?: string | null
-          creado_en?: string
-          distancia_foco_paciente?: number | null
-          filtracion_anadida_mmal?: number | null
-          filtracion_inherente_mmal?: number | null
-          gen_energia_fotones_mev?: string | null
-          gen_fase?: string | null
-          gen_fecha_fabricacion?: string | null
-          gen_marca?: string | null
-          gen_modelo?: string | null
-          gen_numero_serie?: string | null
-          id?: string
-          last_modified?: string
-          planilla_espacial?: boolean
-          sistema_adquisicion?: string | null
-          sync_status?: string
-          tipo_equipo?: string | null
-          ubicacion_id: string
-        }
+          bucky?: string | null;
+          creado_en?: string;
+          distancia_foco_paciente?: number | null;
+          filtracion_anadida_mmal?: number | null;
+          filtracion_inherente_mmal?: number | null;
+          gen_energia_fotones_mev?: string | null;
+          gen_fase?: string | null;
+          gen_fecha_fabricacion?: string | null;
+          gen_marca?: string | null;
+          gen_modelo?: string | null;
+          gen_numero_serie?: string | null;
+          id?: string;
+          last_modified?: string;
+          planilla_espacial?: boolean;
+          sistema_adquisicion?: string | null;
+          sync_status?: string;
+          tipo_equipo?: string | null;
+          ubicacion_id: string;
+        };
         Update: {
-          bucky?: string | null
-          creado_en?: string
-          distancia_foco_paciente?: number | null
-          filtracion_anadida_mmal?: number | null
-          filtracion_inherente_mmal?: number | null
-          gen_energia_fotones_mev?: string | null
-          gen_fase?: string | null
-          gen_fecha_fabricacion?: string | null
-          gen_marca?: string | null
-          gen_modelo?: string | null
-          gen_numero_serie?: string | null
-          id?: string
-          last_modified?: string
-          planilla_espacial?: boolean
-          sistema_adquisicion?: string | null
-          sync_status?: string
-          tipo_equipo?: string | null
-          ubicacion_id?: string
-        }
+          bucky?: string | null;
+          creado_en?: string;
+          distancia_foco_paciente?: number | null;
+          filtracion_anadida_mmal?: number | null;
+          filtracion_inherente_mmal?: number | null;
+          gen_energia_fotones_mev?: string | null;
+          gen_fase?: string | null;
+          gen_fecha_fabricacion?: string | null;
+          gen_marca?: string | null;
+          gen_modelo?: string | null;
+          gen_numero_serie?: string | null;
+          id?: string;
+          last_modified?: string;
+          planilla_espacial?: boolean;
+          sistema_adquisicion?: string | null;
+          sync_status?: string;
+          tipo_equipo?: string | null;
+          ubicacion_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "equipos_ubicacion_id_fkey"
-            columns: ["ubicacion_id"]
-            isOneToOne: false
-            referencedRelation: "ubicaciones_rx"
-            referencedColumns: ["id"]
+            foreignKeyName: "equipos_ubicacion_id_fkey";
+            columns: ["ubicacion_id"];
+            isOneToOne: false;
+            referencedRelation: "ubicaciones_rx";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       evidencias: {
         Row: {
-          creado_en: string
-          descripcion: string | null
-          fecha_captura: string | null
-          id: string
-          last_modified: string
-          prueba_resultado_id: string | null
-          storage_path: string | null
-          sync_status: string
-          tipo: string | null
-          url_storage: string | null
-          visita_id: string
-        }
+          creado_en: string;
+          descripcion: string | null;
+          fecha_captura: string | null;
+          id: string;
+          last_modified: string;
+          prueba_resultado_id: string | null;
+          storage_path: string | null;
+          sync_status: string;
+          tipo: string | null;
+          url_storage: string | null;
+          visita_id: string;
+        };
         Insert: {
-          creado_en?: string
-          descripcion?: string | null
-          fecha_captura?: string | null
-          id?: string
-          last_modified?: string
-          prueba_resultado_id?: string | null
-          storage_path?: string | null
-          sync_status?: string
-          tipo?: string | null
-          url_storage?: string | null
-          visita_id: string
-        }
+          creado_en?: string;
+          descripcion?: string | null;
+          fecha_captura?: string | null;
+          id?: string;
+          last_modified?: string;
+          prueba_resultado_id?: string | null;
+          storage_path?: string | null;
+          sync_status?: string;
+          tipo?: string | null;
+          url_storage?: string | null;
+          visita_id: string;
+        };
         Update: {
-          creado_en?: string
-          descripcion?: string | null
-          fecha_captura?: string | null
-          id?: string
-          last_modified?: string
-          prueba_resultado_id?: string | null
-          storage_path?: string | null
-          sync_status?: string
-          tipo?: string | null
-          url_storage?: string | null
-          visita_id?: string
-        }
+          creado_en?: string;
+          descripcion?: string | null;
+          fecha_captura?: string | null;
+          id?: string;
+          last_modified?: string;
+          prueba_resultado_id?: string | null;
+          storage_path?: string | null;
+          sync_status?: string;
+          tipo?: string | null;
+          url_storage?: string | null;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "evidencias_prueba_resultado_id_fkey"
-            columns: ["prueba_resultado_id"]
-            isOneToOne: false
-            referencedRelation: "prueba_resultados"
-            referencedColumns: ["id"]
+            foreignKeyName: "evidencias_prueba_resultado_id_fkey";
+            columns: ["prueba_resultado_id"];
+            isOneToOne: false;
+            referencedRelation: "prueba_resultados";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "evidencias_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "evidencias_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       gantry: {
         Row: {
-          creado_en: string
-          equipo_id: string
-          id: string
-          last_modified: string
-          marca: string | null
-          modelo: string | null
-          numero_serie: string | null
-          sync_status: string
-          tipo_detector: string | null
-        }
+          creado_en: string;
+          equipo_id: string;
+          id: string;
+          last_modified: string;
+          marca: string | null;
+          modelo: string | null;
+          numero_serie: string | null;
+          sync_status: string;
+          tipo_detector: string | null;
+        };
         Insert: {
-          creado_en?: string
-          equipo_id: string
-          id?: string
-          last_modified?: string
-          marca?: string | null
-          modelo?: string | null
-          numero_serie?: string | null
-          sync_status?: string
-          tipo_detector?: string | null
-        }
+          creado_en?: string;
+          equipo_id: string;
+          id?: string;
+          last_modified?: string;
+          marca?: string | null;
+          modelo?: string | null;
+          numero_serie?: string | null;
+          sync_status?: string;
+          tipo_detector?: string | null;
+        };
         Update: {
-          creado_en?: string
-          equipo_id?: string
-          id?: string
-          last_modified?: string
-          marca?: string | null
-          modelo?: string | null
-          numero_serie?: string | null
-          sync_status?: string
-          tipo_detector?: string | null
-        }
+          creado_en?: string;
+          equipo_id?: string;
+          id?: string;
+          last_modified?: string;
+          marca?: string | null;
+          modelo?: string | null;
+          numero_serie?: string | null;
+          sync_status?: string;
+          tipo_detector?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "gantry_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "gantry_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       grupo_pruebas: {
         Row: {
-          activo: boolean
-          codigo: string
-          creado_en: string
-          id: string
-          nombre: string
-          orden: number
-          schema_mediciones: Json
-          slots_imagen: Json
-          tipo_equipo: string
-        }
+          activo: boolean;
+          codigo: string;
+          creado_en: string;
+          id: string;
+          nombre: string;
+          orden: number;
+          schema_mediciones: Json;
+          slots_imagen: Json;
+          tipo_equipo: string;
+        };
         Insert: {
-          activo?: boolean
-          codigo: string
-          creado_en?: string
-          id?: string
-          nombre: string
-          orden?: number
-          schema_mediciones?: Json
-          slots_imagen?: Json
-          tipo_equipo: string
-        }
+          activo?: boolean;
+          codigo: string;
+          creado_en?: string;
+          id?: string;
+          nombre: string;
+          orden?: number;
+          schema_mediciones?: Json;
+          slots_imagen?: Json;
+          tipo_equipo: string;
+        };
         Update: {
-          activo?: boolean
-          codigo?: string
-          creado_en?: string
-          id?: string
-          nombre?: string
-          orden?: number
-          schema_mediciones?: Json
-          slots_imagen?: Json
-          tipo_equipo?: string
-        }
-        Relationships: []
-      }
+          activo?: boolean;
+          codigo?: string;
+          creado_en?: string;
+          id?: string;
+          nombre?: string;
+          orden?: number;
+          schema_mediciones?: Json;
+          slots_imagen?: Json;
+          tipo_equipo?: string;
+        };
+        Relationships: [];
+      };
       grupo_resultados: {
         Row: {
-          completado: boolean
-          creado_en: string
-          equipo_id: string
-          fecha_ejecucion: string | null
-          grupo_id: string
-          id: string
-          imagenes: Json
-          last_modified: string
-          mediciones_json: Json
-          sync_status: string
-          visita_id: string
-        }
+          completado: boolean;
+          creado_en: string;
+          equipo_id: string;
+          fecha_ejecucion: string | null;
+          grupo_id: string;
+          id: string;
+          imagenes: Json;
+          last_modified: string;
+          mediciones_json: Json;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          completado?: boolean
-          creado_en?: string
-          equipo_id: string
-          fecha_ejecucion?: string | null
-          grupo_id: string
-          id?: string
-          imagenes?: Json
-          last_modified?: string
-          mediciones_json?: Json
-          sync_status?: string
-          visita_id: string
-        }
+          completado?: boolean;
+          creado_en?: string;
+          equipo_id: string;
+          fecha_ejecucion?: string | null;
+          grupo_id: string;
+          id?: string;
+          imagenes?: Json;
+          last_modified?: string;
+          mediciones_json?: Json;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          completado?: boolean
-          creado_en?: string
-          equipo_id?: string
-          fecha_ejecucion?: string | null
-          grupo_id?: string
-          id?: string
-          imagenes?: Json
-          last_modified?: string
-          mediciones_json?: Json
-          sync_status?: string
-          visita_id?: string
-        }
+          completado?: boolean;
+          creado_en?: string;
+          equipo_id?: string;
+          fecha_ejecucion?: string | null;
+          grupo_id?: string;
+          id?: string;
+          imagenes?: Json;
+          last_modified?: string;
+          mediciones_json?: Json;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "grupo_resultados_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "grupo_resultados_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "grupo_resultados_grupo_id_fkey"
-            columns: ["grupo_id"]
-            isOneToOne: false
-            referencedRelation: "grupo_pruebas"
-            referencedColumns: ["id"]
+            foreignKeyName: "grupo_resultados_grupo_id_fkey";
+            columns: ["grupo_id"];
+            isOneToOne: false;
+            referencedRelation: "grupo_pruebas";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "grupo_resultados_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "grupo_resultados_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       informe_versiones: {
         Row: {
-          creado_en: string
-          descripcion_cambio: string | null
-          estado: string | null
-          fecha_aprobacion: string | null
-          fecha_generacion: string
-          fecha_revision: string | null
-          generado_por_id: string | null
-          id: string
-          informe_id: string
-          last_modified: string
-          motivo_cambio: string | null
-          numero_version: number
-          pdf_url: string | null
-          revisado_por_id: string | null
-          sync_status: string
-        }
+          creado_en: string;
+          descripcion_cambio: string | null;
+          estado: string | null;
+          fecha_aprobacion: string | null;
+          fecha_generacion: string;
+          fecha_revision: string | null;
+          generado_por_id: string | null;
+          id: string;
+          informe_id: string;
+          last_modified: string;
+          motivo_cambio: string | null;
+          numero_version: number;
+          pdf_url: string | null;
+          revisado_por_id: string | null;
+          sync_status: string;
+        };
         Insert: {
-          creado_en?: string
-          descripcion_cambio?: string | null
-          estado?: string | null
-          fecha_aprobacion?: string | null
-          fecha_generacion: string
-          fecha_revision?: string | null
-          generado_por_id?: string | null
-          id?: string
-          informe_id: string
-          last_modified?: string
-          motivo_cambio?: string | null
-          numero_version: number
-          pdf_url?: string | null
-          revisado_por_id?: string | null
-          sync_status?: string
-        }
+          creado_en?: string;
+          descripcion_cambio?: string | null;
+          estado?: string | null;
+          fecha_aprobacion?: string | null;
+          fecha_generacion: string;
+          fecha_revision?: string | null;
+          generado_por_id?: string | null;
+          id?: string;
+          informe_id: string;
+          last_modified?: string;
+          motivo_cambio?: string | null;
+          numero_version: number;
+          pdf_url?: string | null;
+          revisado_por_id?: string | null;
+          sync_status?: string;
+        };
         Update: {
-          creado_en?: string
-          descripcion_cambio?: string | null
-          estado?: string | null
-          fecha_aprobacion?: string | null
-          fecha_generacion?: string
-          fecha_revision?: string | null
-          generado_por_id?: string | null
-          id?: string
-          informe_id?: string
-          last_modified?: string
-          motivo_cambio?: string | null
-          numero_version?: number
-          pdf_url?: string | null
-          revisado_por_id?: string | null
-          sync_status?: string
-        }
+          creado_en?: string;
+          descripcion_cambio?: string | null;
+          estado?: string | null;
+          fecha_aprobacion?: string | null;
+          fecha_generacion?: string;
+          fecha_revision?: string | null;
+          generado_por_id?: string | null;
+          id?: string;
+          informe_id?: string;
+          last_modified?: string;
+          motivo_cambio?: string | null;
+          numero_version?: number;
+          pdf_url?: string | null;
+          revisado_por_id?: string | null;
+          sync_status?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "informe_versiones_generado_por_id_fkey"
-            columns: ["generado_por_id"]
-            isOneToOne: false
-            referencedRelation: "usuarios"
-            referencedColumns: ["id"]
+            foreignKeyName: "informe_versiones_generado_por_id_fkey";
+            columns: ["generado_por_id"];
+            isOneToOne: false;
+            referencedRelation: "usuarios";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "informe_versiones_informe_id_fkey"
-            columns: ["informe_id"]
-            isOneToOne: false
-            referencedRelation: "informes"
-            referencedColumns: ["id"]
+            foreignKeyName: "informe_versiones_informe_id_fkey";
+            columns: ["informe_id"];
+            isOneToOne: false;
+            referencedRelation: "informes";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "informe_versiones_revisado_por_id_fkey"
-            columns: ["revisado_por_id"]
-            isOneToOne: false
-            referencedRelation: "usuarios"
-            referencedColumns: ["id"]
+            foreignKeyName: "informe_versiones_revisado_por_id_fkey";
+            columns: ["revisado_por_id"];
+            isOneToOne: false;
+            referencedRelation: "usuarios";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       informes: {
         Row: {
-          concepto_general: string | null
-          creado_en: string
-          equipo_id: string
-          estado: string
-          fecha_emision: string
-          fecha_vencimiento: string
-          id: string
-          last_modified: string
-          numero_informe: string
-          plantilla: string | null
-          qr_token: string
-          qr_url: string | null
-          sync_status: string
-          titulo: string | null
-          ubicacion_id: string
-          version_actual: number
-          visita_id: string
-        }
+          concepto_general: string | null;
+          creado_en: string;
+          equipo_id: string;
+          estado: string;
+          fecha_emision: string;
+          fecha_vencimiento: string;
+          id: string;
+          last_modified: string;
+          numero_informe: string;
+          plantilla: string | null;
+          qr_token: string;
+          qr_url: string | null;
+          sync_status: string;
+          titulo: string | null;
+          ubicacion_id: string;
+          version_actual: number;
+          visita_id: string;
+        };
         Insert: {
-          concepto_general?: string | null
-          creado_en?: string
-          equipo_id: string
-          estado?: string
-          fecha_emision: string
-          fecha_vencimiento: string
-          id?: string
-          last_modified?: string
-          numero_informe: string
-          plantilla?: string | null
-          qr_token?: string
-          qr_url?: string | null
-          sync_status?: string
-          titulo?: string | null
-          ubicacion_id: string
-          version_actual?: number
-          visita_id: string
-        }
+          concepto_general?: string | null;
+          creado_en?: string;
+          equipo_id: string;
+          estado?: string;
+          fecha_emision: string;
+          fecha_vencimiento: string;
+          id?: string;
+          last_modified?: string;
+          numero_informe: string;
+          plantilla?: string | null;
+          qr_token?: string;
+          qr_url?: string | null;
+          sync_status?: string;
+          titulo?: string | null;
+          ubicacion_id: string;
+          version_actual?: number;
+          visita_id: string;
+        };
         Update: {
-          concepto_general?: string | null
-          creado_en?: string
-          equipo_id?: string
-          estado?: string
-          fecha_emision?: string
-          fecha_vencimiento?: string
-          id?: string
-          last_modified?: string
-          numero_informe?: string
-          plantilla?: string | null
-          qr_token?: string
-          qr_url?: string | null
-          sync_status?: string
-          titulo?: string | null
-          ubicacion_id?: string
-          version_actual?: number
-          visita_id?: string
-        }
+          concepto_general?: string | null;
+          creado_en?: string;
+          equipo_id?: string;
+          estado?: string;
+          fecha_emision?: string;
+          fecha_vencimiento?: string;
+          id?: string;
+          last_modified?: string;
+          numero_informe?: string;
+          plantilla?: string | null;
+          qr_token?: string;
+          qr_url?: string | null;
+          sync_status?: string;
+          titulo?: string | null;
+          ubicacion_id?: string;
+          version_actual?: number;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "informes_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "informes_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "informes_ubicacion_id_fkey"
-            columns: ["ubicacion_id"]
-            isOneToOne: false
-            referencedRelation: "ubicaciones_rx"
-            referencedColumns: ["id"]
+            foreignKeyName: "informes_ubicacion_id_fkey";
+            columns: ["ubicacion_id"];
+            isOneToOne: false;
+            referencedRelation: "ubicaciones_rx";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "informes_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "informes_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       mediciones_radiometricas: {
         Row: {
-          concepto: string | null
-          creado_en: string
-          dosis_anual_msv: number | null
-          factor_ocupacion: string | null
-          id: string
-          last_modified: string
-          observacion: string | null
-          punto_numero: number
-          sync_status: string
-          tasa_dosis_msv_h: number | null
-          tipo_area: string | null
-          ubicacion_descripcion: string
-          visita_id: string
-        }
+          concepto: string | null;
+          creado_en: string;
+          dosis_anual_msv: number | null;
+          factor_ocupacion: string | null;
+          id: string;
+          last_modified: string;
+          observacion: string | null;
+          punto_numero: number;
+          sync_status: string;
+          tasa_dosis_msv_h: number | null;
+          tipo_area: string | null;
+          ubicacion_descripcion: string;
+          visita_id: string;
+        };
         Insert: {
-          concepto?: string | null
-          creado_en?: string
-          dosis_anual_msv?: number | null
-          factor_ocupacion?: string | null
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          punto_numero: number
-          sync_status?: string
-          tasa_dosis_msv_h?: number | null
-          tipo_area?: string | null
-          ubicacion_descripcion: string
-          visita_id: string
-        }
+          concepto?: string | null;
+          creado_en?: string;
+          dosis_anual_msv?: number | null;
+          factor_ocupacion?: string | null;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          punto_numero: number;
+          sync_status?: string;
+          tasa_dosis_msv_h?: number | null;
+          tipo_area?: string | null;
+          ubicacion_descripcion: string;
+          visita_id: string;
+        };
         Update: {
-          concepto?: string | null
-          creado_en?: string
-          dosis_anual_msv?: number | null
-          factor_ocupacion?: string | null
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          punto_numero?: number
-          sync_status?: string
-          tasa_dosis_msv_h?: number | null
-          tipo_area?: string | null
-          ubicacion_descripcion?: string
-          visita_id?: string
-        }
+          concepto?: string | null;
+          creado_en?: string;
+          dosis_anual_msv?: number | null;
+          factor_ocupacion?: string | null;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          punto_numero?: number;
+          sync_status?: string;
+          tasa_dosis_msv_h?: number | null;
+          tipo_area?: string | null;
+          ubicacion_descripcion?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "mediciones_radiometricas_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "mediciones_radiometricas_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       municipios: {
         Row: {
-          codigo_dane: string
-          departamento_id: number
-          id: number
-          nombre: string
-        }
+          codigo_dane: string;
+          departamento_id: number;
+          id: number;
+          nombre: string;
+        };
         Insert: {
-          codigo_dane: string
-          departamento_id: number
-          id: number
-          nombre: string
-        }
+          codigo_dane: string;
+          departamento_id: number;
+          id: number;
+          nombre: string;
+        };
         Update: {
-          codigo_dane?: string
-          departamento_id?: number
-          id?: number
-          nombre?: string
-        }
+          codigo_dane?: string;
+          departamento_id?: number;
+          id?: number;
+          nombre?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "municipios_departamento_id_fkey"
-            columns: ["departamento_id"]
-            isOneToOne: false
-            referencedRelation: "departamentos"
-            referencedColumns: ["id"]
+            foreignKeyName: "municipios_departamento_id_fkey";
+            columns: ["departamento_id"];
+            isOneToOne: false;
+            referencedRelation: "departamentos";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       partes_equipo: {
         Row: {
-          creado_en: string
-          equipo_id: string
-          estado: string | null
-          id: string
-          last_modified: string
-          observacion: string | null
-          parte_nombre: string
-          sync_status: string
-        }
+          creado_en: string;
+          equipo_id: string;
+          estado: string | null;
+          id: string;
+          last_modified: string;
+          observacion: string | null;
+          parte_nombre: string;
+          sync_status: string;
+        };
         Insert: {
-          creado_en?: string
-          equipo_id: string
-          estado?: string | null
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          parte_nombre: string
-          sync_status?: string
-        }
+          creado_en?: string;
+          equipo_id: string;
+          estado?: string | null;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          parte_nombre: string;
+          sync_status?: string;
+        };
         Update: {
-          creado_en?: string
-          equipo_id?: string
-          estado?: string | null
-          id?: string
-          last_modified?: string
-          observacion?: string | null
-          parte_nombre?: string
-          sync_status?: string
-        }
+          creado_en?: string;
+          equipo_id?: string;
+          estado?: string | null;
+          id?: string;
+          last_modified?: string;
+          observacion?: string | null;
+          parte_nombre?: string;
+          sync_status?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "partes_equipo_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "partes_equipo_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       prueba_definiciones: {
         Row: {
-          activa: boolean
-          codigo: string
-          creado_en: string
-          criterios_aceptacion: Json | null
-          descripcion: string | null
-          formulas: Json | null
-          grupo_id: string | null
-          id: string
-          nombre: string
-          numero_tecdoc: string | null
-          orden_en_grupo: number | null
-          orden_sugerido: number | null
-          plantilla_informe: string | null
-          slots_imagen: Json | null
-          textos_informe: Json | null
-          tipos_equipo_aplicables: string[]
-        }
+          activa: boolean;
+          codigo: string;
+          creado_en: string;
+          criterios_aceptacion: Json | null;
+          descripcion: string | null;
+          formulas: Json | null;
+          grupo_id: string | null;
+          id: string;
+          nombre: string;
+          numero_tecdoc: string | null;
+          orden_en_grupo: number | null;
+          orden_sugerido: number | null;
+          plantilla_informe: string | null;
+          slots_imagen: Json | null;
+          textos_informe: Json | null;
+          tipos_equipo_aplicables: string[];
+        };
         Insert: {
-          activa?: boolean
-          codigo: string
-          creado_en?: string
-          criterios_aceptacion?: Json | null
-          descripcion?: string | null
-          formulas?: Json | null
-          grupo_id?: string | null
-          id?: string
-          nombre: string
-          numero_tecdoc?: string | null
-          orden_en_grupo?: number | null
-          orden_sugerido?: number | null
-          plantilla_informe?: string | null
-          slots_imagen?: Json | null
-          textos_informe?: Json | null
-          tipos_equipo_aplicables?: string[]
-        }
+          activa?: boolean;
+          codigo: string;
+          creado_en?: string;
+          criterios_aceptacion?: Json | null;
+          descripcion?: string | null;
+          formulas?: Json | null;
+          grupo_id?: string | null;
+          id?: string;
+          nombre: string;
+          numero_tecdoc?: string | null;
+          orden_en_grupo?: number | null;
+          orden_sugerido?: number | null;
+          plantilla_informe?: string | null;
+          slots_imagen?: Json | null;
+          textos_informe?: Json | null;
+          tipos_equipo_aplicables?: string[];
+        };
         Update: {
-          activa?: boolean
-          codigo?: string
-          creado_en?: string
-          criterios_aceptacion?: Json | null
-          descripcion?: string | null
-          formulas?: Json | null
-          grupo_id?: string | null
-          id?: string
-          nombre?: string
-          numero_tecdoc?: string | null
-          orden_en_grupo?: number | null
-          orden_sugerido?: number | null
-          plantilla_informe?: string | null
-          slots_imagen?: Json | null
-          textos_informe?: Json | null
-          tipos_equipo_aplicables?: string[]
-        }
+          activa?: boolean;
+          codigo?: string;
+          creado_en?: string;
+          criterios_aceptacion?: Json | null;
+          descripcion?: string | null;
+          formulas?: Json | null;
+          grupo_id?: string | null;
+          id?: string;
+          nombre?: string;
+          numero_tecdoc?: string | null;
+          orden_en_grupo?: number | null;
+          orden_sugerido?: number | null;
+          plantilla_informe?: string | null;
+          slots_imagen?: Json | null;
+          textos_informe?: Json | null;
+          tipos_equipo_aplicables?: string[];
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_prueba_def_grupo"
-            columns: ["grupo_id"]
-            isOneToOne: false
-            referencedRelation: "grupo_pruebas"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_prueba_def_grupo";
+            columns: ["grupo_id"];
+            isOneToOne: false;
+            referencedRelation: "grupo_pruebas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       prueba_resultados: {
         Row: {
-          acciones_correctivas: string | null
-          completado: boolean
-          concepto: string | null
-          creado_en: string
-          datos_json: Json | null
-          equipo_id: string
-          evaluacion_criterios: Json | null
-          fecha_ejecucion: string | null
-          grupo_resultado_id: string | null
-          id: string
-          imagenes: Json | null
-          last_modified: string
-          prueba_definicion_id: string
-          resultados_calculados: Json | null
-          sync_status: string
-          visita_id: string
-        }
+          acciones_correctivas: string | null;
+          completado: boolean;
+          concepto: string | null;
+          creado_en: string;
+          datos_json: Json | null;
+          equipo_id: string;
+          evaluacion_criterios: Json | null;
+          fecha_ejecucion: string | null;
+          grupo_resultado_id: string | null;
+          id: string;
+          imagenes: Json | null;
+          last_modified: string;
+          prueba_definicion_id: string;
+          resultados_calculados: Json | null;
+          sync_status: string;
+          visita_id: string;
+        };
         Insert: {
-          acciones_correctivas?: string | null
-          completado?: boolean
-          concepto?: string | null
-          creado_en?: string
-          datos_json?: Json | null
-          equipo_id: string
-          evaluacion_criterios?: Json | null
-          fecha_ejecucion?: string | null
-          grupo_resultado_id?: string | null
-          id?: string
-          imagenes?: Json | null
-          last_modified?: string
-          prueba_definicion_id: string
-          resultados_calculados?: Json | null
-          sync_status?: string
-          visita_id: string
-        }
+          acciones_correctivas?: string | null;
+          completado?: boolean;
+          concepto?: string | null;
+          creado_en?: string;
+          datos_json?: Json | null;
+          equipo_id: string;
+          evaluacion_criterios?: Json | null;
+          fecha_ejecucion?: string | null;
+          grupo_resultado_id?: string | null;
+          id?: string;
+          imagenes?: Json | null;
+          last_modified?: string;
+          prueba_definicion_id: string;
+          resultados_calculados?: Json | null;
+          sync_status?: string;
+          visita_id: string;
+        };
         Update: {
-          acciones_correctivas?: string | null
-          completado?: boolean
-          concepto?: string | null
-          creado_en?: string
-          datos_json?: Json | null
-          equipo_id?: string
-          evaluacion_criterios?: Json | null
-          fecha_ejecucion?: string | null
-          grupo_resultado_id?: string | null
-          id?: string
-          imagenes?: Json | null
-          last_modified?: string
-          prueba_definicion_id?: string
-          resultados_calculados?: Json | null
-          sync_status?: string
-          visita_id?: string
-        }
+          acciones_correctivas?: string | null;
+          completado?: boolean;
+          concepto?: string | null;
+          creado_en?: string;
+          datos_json?: Json | null;
+          equipo_id?: string;
+          evaluacion_criterios?: Json | null;
+          fecha_ejecucion?: string | null;
+          grupo_resultado_id?: string | null;
+          id?: string;
+          imagenes?: Json | null;
+          last_modified?: string;
+          prueba_definicion_id?: string;
+          resultados_calculados?: Json | null;
+          sync_status?: string;
+          visita_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "prueba_resultados_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "prueba_resultados_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "prueba_resultados_grupo_resultado_id_fkey"
-            columns: ["grupo_resultado_id"]
-            isOneToOne: false
-            referencedRelation: "grupo_resultados"
-            referencedColumns: ["id"]
+            foreignKeyName: "prueba_resultados_grupo_resultado_id_fkey";
+            columns: ["grupo_resultado_id"];
+            isOneToOne: false;
+            referencedRelation: "grupo_resultados";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "prueba_resultados_prueba_definicion_id_fkey"
-            columns: ["prueba_definicion_id"]
-            isOneToOne: false
-            referencedRelation: "prueba_definiciones"
-            referencedColumns: ["id"]
+            foreignKeyName: "prueba_resultados_prueba_definicion_id_fkey";
+            columns: ["prueba_definicion_id"];
+            isOneToOne: false;
+            referencedRelation: "prueba_definiciones";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "prueba_resultados_visita_id_fkey"
-            columns: ["visita_id"]
-            isOneToOne: false
-            referencedRelation: "visitas"
-            referencedColumns: ["id"]
+            foreignKeyName: "prueba_resultados_visita_id_fkey";
+            columns: ["visita_id"];
+            isOneToOne: false;
+            referencedRelation: "visitas";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       rol_permisos: {
         Row: {
-          accion: string
-          cargo: string
-          id: string
-          last_modified: string
-          permitido: boolean
-          recurso: string
-          sync_status: string
-        }
+          accion: string;
+          cargo: string;
+          id: string;
+          last_modified: string;
+          permitido: boolean;
+          recurso: string;
+          sync_status: string;
+        };
         Insert: {
-          accion: string
-          cargo: string
-          id?: string
-          last_modified?: string
-          permitido?: boolean
-          recurso: string
-          sync_status?: string
-        }
+          accion: string;
+          cargo: string;
+          id?: string;
+          last_modified?: string;
+          permitido?: boolean;
+          recurso: string;
+          sync_status?: string;
+        };
         Update: {
-          accion?: string
-          cargo?: string
-          id?: string
-          last_modified?: string
-          permitido?: boolean
-          recurso?: string
-          sync_status?: string
-        }
-        Relationships: []
-      }
+          accion?: string;
+          cargo?: string;
+          id?: string;
+          last_modified?: string;
+          permitido?: boolean;
+          recurso?: string;
+          sync_status?: string;
+        };
+        Relationships: [];
+      };
       sala_dimensiones: {
         Row: {
-          alto_m: number | null
-          ancho_m: number | null
-          area_m2: number | null
-          creado_en: string
-          id: string
-          largo_m: number | null
-          last_modified: string
-          plano_url: string | null
-          sync_status: string
-          ubicacion_id: string
-          zona_a_desc: string | null
-          zona_b_desc: string | null
-          zona_c_desc: string | null
-          zona_d_desc: string | null
-        }
+          alto_m: number | null;
+          ancho_m: number | null;
+          area_m2: number | null;
+          creado_en: string;
+          id: string;
+          largo_m: number | null;
+          last_modified: string;
+          plano_url: string | null;
+          sync_status: string;
+          ubicacion_id: string;
+          zona_a_desc: string | null;
+          zona_b_desc: string | null;
+          zona_c_desc: string | null;
+          zona_d_desc: string | null;
+        };
         Insert: {
-          alto_m?: number | null
-          ancho_m?: number | null
-          area_m2?: number | null
-          creado_en?: string
-          id?: string
-          largo_m?: number | null
-          last_modified?: string
-          plano_url?: string | null
-          sync_status?: string
-          ubicacion_id: string
-          zona_a_desc?: string | null
-          zona_b_desc?: string | null
-          zona_c_desc?: string | null
-          zona_d_desc?: string | null
-        }
+          alto_m?: number | null;
+          ancho_m?: number | null;
+          area_m2?: number | null;
+          creado_en?: string;
+          id?: string;
+          largo_m?: number | null;
+          last_modified?: string;
+          plano_url?: string | null;
+          sync_status?: string;
+          ubicacion_id: string;
+          zona_a_desc?: string | null;
+          zona_b_desc?: string | null;
+          zona_c_desc?: string | null;
+          zona_d_desc?: string | null;
+        };
         Update: {
-          alto_m?: number | null
-          ancho_m?: number | null
-          area_m2?: number | null
-          creado_en?: string
-          id?: string
-          largo_m?: number | null
-          last_modified?: string
-          plano_url?: string | null
-          sync_status?: string
-          ubicacion_id?: string
-          zona_a_desc?: string | null
-          zona_b_desc?: string | null
-          zona_c_desc?: string | null
-          zona_d_desc?: string | null
-        }
+          alto_m?: number | null;
+          ancho_m?: number | null;
+          area_m2?: number | null;
+          creado_en?: string;
+          id?: string;
+          largo_m?: number | null;
+          last_modified?: string;
+          plano_url?: string | null;
+          sync_status?: string;
+          ubicacion_id?: string;
+          zona_a_desc?: string | null;
+          zona_b_desc?: string | null;
+          zona_c_desc?: string | null;
+          zona_d_desc?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "sala_dimensiones_ubicacion_id_fkey"
-            columns: ["ubicacion_id"]
-            isOneToOne: false
-            referencedRelation: "ubicaciones_rx"
-            referencedColumns: ["id"]
+            foreignKeyName: "sala_dimensiones_ubicacion_id_fkey";
+            columns: ["ubicacion_id"];
+            isOneToOne: false;
+            referencedRelation: "ubicaciones_rx";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       sedes: {
         Row: {
-          ciudad: string | null
-          cliente_id: string
-          creado_en: string
-          departamento: string | null
-          departamento_id: number | null
-          direccion_sede: string | null
-          email: string | null
-          id: string
-          last_modified: string
-          municipio_id: number | null
-          nombre_sede: string
-          sync_status: string
-          telefono: string | null
-        }
+          ciudad: string | null;
+          cliente_id: string;
+          creado_en: string;
+          departamento: string | null;
+          departamento_id: number | null;
+          direccion_sede: string | null;
+          email: string | null;
+          id: string;
+          last_modified: string;
+          municipio_id: number | null;
+          nombre_sede: string;
+          sync_status: string;
+          telefono: string | null;
+        };
         Insert: {
-          ciudad?: string | null
-          cliente_id: string
-          creado_en?: string
-          departamento?: string | null
-          departamento_id?: number | null
-          direccion_sede?: string | null
-          email?: string | null
-          id?: string
-          last_modified?: string
-          municipio_id?: number | null
-          nombre_sede: string
-          sync_status?: string
-          telefono?: string | null
-        }
+          ciudad?: string | null;
+          cliente_id: string;
+          creado_en?: string;
+          departamento?: string | null;
+          departamento_id?: number | null;
+          direccion_sede?: string | null;
+          email?: string | null;
+          id?: string;
+          last_modified?: string;
+          municipio_id?: number | null;
+          nombre_sede: string;
+          sync_status?: string;
+          telefono?: string | null;
+        };
         Update: {
-          ciudad?: string | null
-          cliente_id?: string
-          creado_en?: string
-          departamento?: string | null
-          departamento_id?: number | null
-          direccion_sede?: string | null
-          email?: string | null
-          id?: string
-          last_modified?: string
-          municipio_id?: number | null
-          nombre_sede?: string
-          sync_status?: string
-          telefono?: string | null
-        }
+          ciudad?: string | null;
+          cliente_id?: string;
+          creado_en?: string;
+          departamento?: string | null;
+          departamento_id?: number | null;
+          direccion_sede?: string | null;
+          email?: string | null;
+          id?: string;
+          last_modified?: string;
+          municipio_id?: number | null;
+          nombre_sede?: string;
+          sync_status?: string;
+          telefono?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "sedes_cliente_id_fkey"
-            columns: ["cliente_id"]
-            isOneToOne: false
-            referencedRelation: "clientes"
-            referencedColumns: ["id"]
+            foreignKeyName: "sedes_cliente_id_fkey";
+            columns: ["cliente_id"];
+            isOneToOne: false;
+            referencedRelation: "clientes";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "sedes_departamento_id_fkey"
-            columns: ["departamento_id"]
-            isOneToOne: false
-            referencedRelation: "departamentos"
-            referencedColumns: ["id"]
+            foreignKeyName: "sedes_departamento_id_fkey";
+            columns: ["departamento_id"];
+            isOneToOne: false;
+            referencedRelation: "departamentos";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "sedes_municipio_id_fkey"
-            columns: ["municipio_id"]
-            isOneToOne: false
-            referencedRelation: "municipios"
-            referencedColumns: ["id"]
+            foreignKeyName: "sedes_municipio_id_fkey";
+            columns: ["municipio_id"];
+            isOneToOne: false;
+            referencedRelation: "municipios";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       solicitudes: {
         Row: {
-          cliente_id: string
-          contacto_programar_id: string | null
-          cotizacion_id: string | null
-          creado_en: string
-          fecha_entrega: string | null
-          fecha_estimada_visita: string | null
-          fecha_real_visita: string | null
-          fecha_solicitud: string | null
-          forma_pago: string | null
-          id: string
-          last_modified: string
-          pago_recibido: boolean
-          pipeline_estado: string
-          sync_status: string
-          tecnico_asignado_id: string | null
-          tipo_servicio: string | null
-          ubicacion_id: string | null
-        }
+          cliente_id: string;
+          contacto_programar_id: string | null;
+          cotizacion_id: string | null;
+          creado_en: string;
+          fecha_entrega: string | null;
+          fecha_estimada_visita: string | null;
+          fecha_real_visita: string | null;
+          fecha_solicitud: string | null;
+          forma_pago: string | null;
+          id: string;
+          last_modified: string;
+          pago_recibido: boolean;
+          pipeline_estado: string;
+          sync_status: string;
+          tecnico_asignado_id: string | null;
+          tipo_servicio: string | null;
+          ubicacion_id: string | null;
+        };
         Insert: {
-          cliente_id: string
-          contacto_programar_id?: string | null
-          cotizacion_id?: string | null
-          creado_en?: string
-          fecha_entrega?: string | null
-          fecha_estimada_visita?: string | null
-          fecha_real_visita?: string | null
-          fecha_solicitud?: string | null
-          forma_pago?: string | null
-          id?: string
-          last_modified?: string
-          pago_recibido?: boolean
-          pipeline_estado?: string
-          sync_status?: string
-          tecnico_asignado_id?: string | null
-          tipo_servicio?: string | null
-          ubicacion_id?: string | null
-        }
+          cliente_id: string;
+          contacto_programar_id?: string | null;
+          cotizacion_id?: string | null;
+          creado_en?: string;
+          fecha_entrega?: string | null;
+          fecha_estimada_visita?: string | null;
+          fecha_real_visita?: string | null;
+          fecha_solicitud?: string | null;
+          forma_pago?: string | null;
+          id?: string;
+          last_modified?: string;
+          pago_recibido?: boolean;
+          pipeline_estado?: string;
+          sync_status?: string;
+          tecnico_asignado_id?: string | null;
+          tipo_servicio?: string | null;
+          ubicacion_id?: string | null;
+        };
         Update: {
-          cliente_id?: string
-          contacto_programar_id?: string | null
-          cotizacion_id?: string | null
-          creado_en?: string
-          fecha_entrega?: string | null
-          fecha_estimada_visita?: string | null
-          fecha_real_visita?: string | null
-          fecha_solicitud?: string | null
-          forma_pago?: string | null
-          id?: string
-          last_modified?: string
-          pago_recibido?: boolean
-          pipeline_estado?: string
-          sync_status?: string
-          tecnico_asignado_id?: string | null
-          tipo_servicio?: string | null
-          ubicacion_id?: string | null
-        }
+          cliente_id?: string;
+          contacto_programar_id?: string | null;
+          cotizacion_id?: string | null;
+          creado_en?: string;
+          fecha_entrega?: string | null;
+          fecha_estimada_visita?: string | null;
+          fecha_real_visita?: string | null;
+          fecha_solicitud?: string | null;
+          forma_pago?: string | null;
+          id?: string;
+          last_modified?: string;
+          pago_recibido?: boolean;
+          pipeline_estado?: string;
+          sync_status?: string;
+          tecnico_asignado_id?: string | null;
+          tipo_servicio?: string | null;
+          ubicacion_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "solicitudes_cliente_id_fkey"
-            columns: ["cliente_id"]
-            isOneToOne: false
-            referencedRelation: "clientes"
-            referencedColumns: ["id"]
+            foreignKeyName: "solicitudes_cliente_id_fkey";
+            columns: ["cliente_id"];
+            isOneToOne: false;
+            referencedRelation: "clientes";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "solicitudes_contacto_programar_id_fkey"
-            columns: ["contacto_programar_id"]
-            isOneToOne: false
-            referencedRelation: "contactos"
-            referencedColumns: ["id"]
+            foreignKeyName: "solicitudes_contacto_programar_id_fkey";
+            columns: ["contacto_programar_id"];
+            isOneToOne: false;
+            referencedRelation: "contactos";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "solicitudes_cotizacion_id_fkey"
-            columns: ["cotizacion_id"]
-            isOneToOne: false
-            referencedRelation: "cotizaciones"
-            referencedColumns: ["id"]
+            foreignKeyName: "solicitudes_cotizacion_id_fkey";
+            columns: ["cotizacion_id"];
+            isOneToOne: false;
+            referencedRelation: "cotizaciones";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "solicitudes_tecnico_asignado_id_fkey"
-            columns: ["tecnico_asignado_id"]
-            isOneToOne: false
-            referencedRelation: "usuarios"
-            referencedColumns: ["id"]
+            foreignKeyName: "solicitudes_tecnico_asignado_id_fkey";
+            columns: ["tecnico_asignado_id"];
+            isOneToOne: false;
+            referencedRelation: "usuarios";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "solicitudes_ubicacion_id_fkey"
-            columns: ["ubicacion_id"]
-            isOneToOne: false
-            referencedRelation: "ubicaciones_rx"
-            referencedColumns: ["id"]
+            foreignKeyName: "solicitudes_ubicacion_id_fkey";
+            columns: ["ubicacion_id"];
+            isOneToOne: false;
+            referencedRelation: "ubicaciones_rx";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       tubos: {
         Row: {
-          creado_en: string
-          equipo_id: string
-          foco_fino_mm: number | null
-          foco_grueso_mm: number | null
-          id: string
-          kv_max: number | null
-          last_modified: string
-          ma_max: number | null
-          marca: string | null
-          mas_max: number | null
-          modelo: string | null
-          numero_serie: string | null
-          sync_status: string
-          tiempo_s: number | null
-          tipo: string | null
-        }
+          creado_en: string;
+          equipo_id: string;
+          foco_fino_mm: number | null;
+          foco_grueso_mm: number | null;
+          id: string;
+          kv_max: number | null;
+          last_modified: string;
+          ma_max: number | null;
+          marca: string | null;
+          mas_max: number | null;
+          modelo: string | null;
+          numero_serie: string | null;
+          sync_status: string;
+          tiempo_s: number | null;
+          tipo: string | null;
+        };
         Insert: {
-          creado_en?: string
-          equipo_id: string
-          foco_fino_mm?: number | null
-          foco_grueso_mm?: number | null
-          id?: string
-          kv_max?: number | null
-          last_modified?: string
-          ma_max?: number | null
-          marca?: string | null
-          mas_max?: number | null
-          modelo?: string | null
-          numero_serie?: string | null
-          sync_status?: string
-          tiempo_s?: number | null
-          tipo?: string | null
-        }
+          creado_en?: string;
+          equipo_id: string;
+          foco_fino_mm?: number | null;
+          foco_grueso_mm?: number | null;
+          id?: string;
+          kv_max?: number | null;
+          last_modified?: string;
+          ma_max?: number | null;
+          marca?: string | null;
+          mas_max?: number | null;
+          modelo?: string | null;
+          numero_serie?: string | null;
+          sync_status?: string;
+          tiempo_s?: number | null;
+          tipo?: string | null;
+        };
         Update: {
-          creado_en?: string
-          equipo_id?: string
-          foco_fino_mm?: number | null
-          foco_grueso_mm?: number | null
-          id?: string
-          kv_max?: number | null
-          last_modified?: string
-          ma_max?: number | null
-          marca?: string | null
-          mas_max?: number | null
-          modelo?: string | null
-          numero_serie?: string | null
-          sync_status?: string
-          tiempo_s?: number | null
-          tipo?: string | null
-        }
+          creado_en?: string;
+          equipo_id?: string;
+          foco_fino_mm?: number | null;
+          foco_grueso_mm?: number | null;
+          id?: string;
+          kv_max?: number | null;
+          last_modified?: string;
+          ma_max?: number | null;
+          marca?: string | null;
+          mas_max?: number | null;
+          modelo?: string | null;
+          numero_serie?: string | null;
+          sync_status?: string;
+          tiempo_s?: number | null;
+          tipo?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "tubos_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "tubos_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       ubicaciones_rx: {
         Row: {
-          alto_m: number | null
-          ancho_m: number | null
-          area_m2: number | null
-          codigo_habilitacion: string | null
-          creado_en: string
-          fecha_expiracion_licencia: string | null
-          horas_x_dia: number | null
-          id: string
-          largo_m: number | null
-          last_modified: string
-          licencia: string | null
-          nombre_servicio: string
-          sede_id: string
-          sync_status: string
-          ubicacion_fisica: string | null
-          zona_a_desc: string | null
-          zona_b_desc: string | null
-          zona_c_desc: string | null
-          zona_d_desc: string | null
-        }
+          alto_m: number | null;
+          ancho_m: number | null;
+          area_m2: number | null;
+          codigo_habilitacion: string | null;
+          creado_en: string;
+          fecha_expiracion_licencia: string | null;
+          horas_x_dia: number | null;
+          id: string;
+          largo_m: number | null;
+          last_modified: string;
+          licencia: string | null;
+          nombre_servicio: string;
+          sede_id: string;
+          sync_status: string;
+          ubicacion_fisica: string | null;
+          zona_a_desc: string | null;
+          zona_b_desc: string | null;
+          zona_c_desc: string | null;
+          zona_d_desc: string | null;
+        };
         Insert: {
-          alto_m?: number | null
-          ancho_m?: number | null
-          area_m2?: number | null
-          codigo_habilitacion?: string | null
-          creado_en?: string
-          fecha_expiracion_licencia?: string | null
-          horas_x_dia?: number | null
-          id?: string
-          largo_m?: number | null
-          last_modified?: string
-          licencia?: string | null
-          nombre_servicio: string
-          sede_id: string
-          sync_status?: string
-          ubicacion_fisica?: string | null
-          zona_a_desc?: string | null
-          zona_b_desc?: string | null
-          zona_c_desc?: string | null
-          zona_d_desc?: string | null
-        }
+          alto_m?: number | null;
+          ancho_m?: number | null;
+          area_m2?: number | null;
+          codigo_habilitacion?: string | null;
+          creado_en?: string;
+          fecha_expiracion_licencia?: string | null;
+          horas_x_dia?: number | null;
+          id?: string;
+          largo_m?: number | null;
+          last_modified?: string;
+          licencia?: string | null;
+          nombre_servicio: string;
+          sede_id: string;
+          sync_status?: string;
+          ubicacion_fisica?: string | null;
+          zona_a_desc?: string | null;
+          zona_b_desc?: string | null;
+          zona_c_desc?: string | null;
+          zona_d_desc?: string | null;
+        };
         Update: {
-          alto_m?: number | null
-          ancho_m?: number | null
-          area_m2?: number | null
-          codigo_habilitacion?: string | null
-          creado_en?: string
-          fecha_expiracion_licencia?: string | null
-          horas_x_dia?: number | null
-          id?: string
-          largo_m?: number | null
-          last_modified?: string
-          licencia?: string | null
-          nombre_servicio?: string
-          sede_id?: string
-          sync_status?: string
-          ubicacion_fisica?: string | null
-          zona_a_desc?: string | null
-          zona_b_desc?: string | null
-          zona_c_desc?: string | null
-          zona_d_desc?: string | null
-        }
+          alto_m?: number | null;
+          ancho_m?: number | null;
+          area_m2?: number | null;
+          codigo_habilitacion?: string | null;
+          creado_en?: string;
+          fecha_expiracion_licencia?: string | null;
+          horas_x_dia?: number | null;
+          id?: string;
+          largo_m?: number | null;
+          last_modified?: string;
+          licencia?: string | null;
+          nombre_servicio?: string;
+          sede_id?: string;
+          sync_status?: string;
+          ubicacion_fisica?: string | null;
+          zona_a_desc?: string | null;
+          zona_b_desc?: string | null;
+          zona_c_desc?: string | null;
+          zona_d_desc?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "ubicaciones_rx_sede_id_fkey"
-            columns: ["sede_id"]
-            isOneToOne: false
-            referencedRelation: "sedes"
-            referencedColumns: ["id"]
+            foreignKeyName: "ubicaciones_rx_sede_id_fkey";
+            columns: ["sede_id"];
+            isOneToOne: false;
+            referencedRelation: "sedes";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       usuarios: {
         Row: {
-          activo: boolean
-          auth_uid: string | null
-          cargo: string | null
-          cedula: string
-          creado_en: string
-          email: string | null
-          id: string
-          last_modified: string
-          nombre: string
-          sync_status: string
-          telefono: string | null
-        }
+          activo: boolean;
+          auth_uid: string | null;
+          cargo: string | null;
+          cedula: string;
+          creado_en: string;
+          email: string | null;
+          id: string;
+          last_modified: string;
+          nombre: string;
+          sync_status: string;
+          telefono: string | null;
+        };
         Insert: {
-          activo?: boolean
-          auth_uid?: string | null
-          cargo?: string | null
-          cedula: string
-          creado_en?: string
-          email?: string | null
-          id?: string
-          last_modified?: string
-          nombre: string
-          sync_status?: string
-          telefono?: string | null
-        }
+          activo?: boolean;
+          auth_uid?: string | null;
+          cargo?: string | null;
+          cedula: string;
+          creado_en?: string;
+          email?: string | null;
+          id?: string;
+          last_modified?: string;
+          nombre: string;
+          sync_status?: string;
+          telefono?: string | null;
+        };
         Update: {
-          activo?: boolean
-          auth_uid?: string | null
-          cargo?: string | null
-          cedula?: string
-          creado_en?: string
-          email?: string | null
-          id?: string
-          last_modified?: string
-          nombre?: string
-          sync_status?: string
-          telefono?: string | null
-        }
-        Relationships: []
-      }
+          activo?: boolean;
+          auth_uid?: string | null;
+          cargo?: string | null;
+          cedula?: string;
+          creado_en?: string;
+          email?: string | null;
+          id?: string;
+          last_modified?: string;
+          nombre?: string;
+          sync_status?: string;
+          telefono?: string | null;
+        };
+        Relationships: [];
+      };
       valores_referencia: {
         Row: {
-          bajo_contraste_ref: number | null
-          cae_comp_1mm_cu: number | null
-          cae_comp_2mm_cu: number | null
-          cae_comp_3mm_cu: number | null
-          cae_comp_60kvp: number | null
-          cae_comp_70kvp: number | null
-          cae_comp_80kvp: number | null
-          cae_sensibilidad_ref: number | null
-          chr_min_mmal: number | null
-          creado_en: string
-          ddi_ref: number | null
-          dosis_receptor_abdomen: number | null
-          dosis_receptor_columna: number | null
-          dosis_receptor_extremidad: number | null
-          dosis_receptor_torax: number | null
-          ei_ref: number | null
-          equipo_id: string
-          id: string
-          kerma_aire_incidente: number | null
-          last_modified: string
-          mtf20_h_ref: number | null
-          mtf20_v_ref: number | null
-          mtf50_h_ref: number | null
-          mtf50_v_ref: number | null
-          pka_ref: number | null
-          pkl_ct_dental: number | null
-          pkl_panoramico: number | null
-          rendimiento_linealidad: number | null
-          rendimiento_ref: number | null
-          rendimiento_repetibilidad: number | null
-          sync_status: string
-          valor_base_patron: string | null
-        }
+          bajo_contraste_ref: number | null;
+          cae_comp_1mm_cu: number | null;
+          cae_comp_2mm_cu: number | null;
+          cae_comp_3mm_cu: number | null;
+          cae_comp_60kvp: number | null;
+          cae_comp_70kvp: number | null;
+          cae_comp_80kvp: number | null;
+          cae_sensibilidad_ref: number | null;
+          chr_min_mmal: number | null;
+          creado_en: string;
+          ddi_ref: number | null;
+          dosis_receptor_abdomen: number | null;
+          dosis_receptor_columna: number | null;
+          dosis_receptor_extremidad: number | null;
+          dosis_receptor_torax: number | null;
+          ei_ref: number | null;
+          equipo_id: string;
+          id: string;
+          kerma_aire_incidente: number | null;
+          last_modified: string;
+          mtf20_h_ref: number | null;
+          mtf20_v_ref: number | null;
+          mtf50_h_ref: number | null;
+          mtf50_v_ref: number | null;
+          pka_ref: number | null;
+          pkl_ct_dental: number | null;
+          pkl_panoramico: number | null;
+          rendimiento_linealidad: number | null;
+          rendimiento_ref: number | null;
+          rendimiento_repetibilidad: number | null;
+          sync_status: string;
+          valor_base_patron: string | null;
+        };
         Insert: {
-          bajo_contraste_ref?: number | null
-          cae_comp_1mm_cu?: number | null
-          cae_comp_2mm_cu?: number | null
-          cae_comp_3mm_cu?: number | null
-          cae_comp_60kvp?: number | null
-          cae_comp_70kvp?: number | null
-          cae_comp_80kvp?: number | null
-          cae_sensibilidad_ref?: number | null
-          chr_min_mmal?: number | null
-          creado_en?: string
-          ddi_ref?: number | null
-          dosis_receptor_abdomen?: number | null
-          dosis_receptor_columna?: number | null
-          dosis_receptor_extremidad?: number | null
-          dosis_receptor_torax?: number | null
-          ei_ref?: number | null
-          equipo_id: string
-          id?: string
-          kerma_aire_incidente?: number | null
-          last_modified?: string
-          mtf20_h_ref?: number | null
-          mtf20_v_ref?: number | null
-          mtf50_h_ref?: number | null
-          mtf50_v_ref?: number | null
-          pka_ref?: number | null
-          pkl_ct_dental?: number | null
-          pkl_panoramico?: number | null
-          rendimiento_linealidad?: number | null
-          rendimiento_ref?: number | null
-          rendimiento_repetibilidad?: number | null
-          sync_status?: string
-          valor_base_patron?: string | null
-        }
+          bajo_contraste_ref?: number | null;
+          cae_comp_1mm_cu?: number | null;
+          cae_comp_2mm_cu?: number | null;
+          cae_comp_3mm_cu?: number | null;
+          cae_comp_60kvp?: number | null;
+          cae_comp_70kvp?: number | null;
+          cae_comp_80kvp?: number | null;
+          cae_sensibilidad_ref?: number | null;
+          chr_min_mmal?: number | null;
+          creado_en?: string;
+          ddi_ref?: number | null;
+          dosis_receptor_abdomen?: number | null;
+          dosis_receptor_columna?: number | null;
+          dosis_receptor_extremidad?: number | null;
+          dosis_receptor_torax?: number | null;
+          ei_ref?: number | null;
+          equipo_id: string;
+          id?: string;
+          kerma_aire_incidente?: number | null;
+          last_modified?: string;
+          mtf20_h_ref?: number | null;
+          mtf20_v_ref?: number | null;
+          mtf50_h_ref?: number | null;
+          mtf50_v_ref?: number | null;
+          pka_ref?: number | null;
+          pkl_ct_dental?: number | null;
+          pkl_panoramico?: number | null;
+          rendimiento_linealidad?: number | null;
+          rendimiento_ref?: number | null;
+          rendimiento_repetibilidad?: number | null;
+          sync_status?: string;
+          valor_base_patron?: string | null;
+        };
         Update: {
-          bajo_contraste_ref?: number | null
-          cae_comp_1mm_cu?: number | null
-          cae_comp_2mm_cu?: number | null
-          cae_comp_3mm_cu?: number | null
-          cae_comp_60kvp?: number | null
-          cae_comp_70kvp?: number | null
-          cae_comp_80kvp?: number | null
-          cae_sensibilidad_ref?: number | null
-          chr_min_mmal?: number | null
-          creado_en?: string
-          ddi_ref?: number | null
-          dosis_receptor_abdomen?: number | null
-          dosis_receptor_columna?: number | null
-          dosis_receptor_extremidad?: number | null
-          dosis_receptor_torax?: number | null
-          ei_ref?: number | null
-          equipo_id?: string
-          id?: string
-          kerma_aire_incidente?: number | null
-          last_modified?: string
-          mtf20_h_ref?: number | null
-          mtf20_v_ref?: number | null
-          mtf50_h_ref?: number | null
-          mtf50_v_ref?: number | null
-          pka_ref?: number | null
-          pkl_ct_dental?: number | null
-          pkl_panoramico?: number | null
-          rendimiento_linealidad?: number | null
-          rendimiento_ref?: number | null
-          rendimiento_repetibilidad?: number | null
-          sync_status?: string
-          valor_base_patron?: string | null
-        }
+          bajo_contraste_ref?: number | null;
+          cae_comp_1mm_cu?: number | null;
+          cae_comp_2mm_cu?: number | null;
+          cae_comp_3mm_cu?: number | null;
+          cae_comp_60kvp?: number | null;
+          cae_comp_70kvp?: number | null;
+          cae_comp_80kvp?: number | null;
+          cae_sensibilidad_ref?: number | null;
+          chr_min_mmal?: number | null;
+          creado_en?: string;
+          ddi_ref?: number | null;
+          dosis_receptor_abdomen?: number | null;
+          dosis_receptor_columna?: number | null;
+          dosis_receptor_extremidad?: number | null;
+          dosis_receptor_torax?: number | null;
+          ei_ref?: number | null;
+          equipo_id?: string;
+          id?: string;
+          kerma_aire_incidente?: number | null;
+          last_modified?: string;
+          mtf20_h_ref?: number | null;
+          mtf20_v_ref?: number | null;
+          mtf50_h_ref?: number | null;
+          mtf50_v_ref?: number | null;
+          pka_ref?: number | null;
+          pkl_ct_dental?: number | null;
+          pkl_panoramico?: number | null;
+          rendimiento_linealidad?: number | null;
+          rendimiento_ref?: number | null;
+          rendimiento_repetibilidad?: number | null;
+          sync_status?: string;
+          valor_base_patron?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "valores_referencia_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "valores_referencia_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       visitas: {
         Row: {
-          creado_en: string
-          devuelto_en: string | null
-          dias_laborados_semana: number | null
-          equipo_id: string | null
-          estado_visita: string
-          fecha_visita: string | null
-          id: string
-          ingeniero_revisor_id: string | null
-          kv_maximo_usado: number | null
-          last_modified: string
-          mas_maximo_usado: number | null
-          max_disparos_paciente: number | null
-          observaciones: string | null
-          observaciones_revision: string | null
-          pacientes_por_semana: number | null
-          porcentaje_rechazo: number | null
-          presion_hpa: number | null
-          radiografias_por_semana: number | null
-          solicitud_id: string
-          sync_status: string
-          tecnico_id: string | null
-          temperatura_c: number | null
-          ubicacion_id: string | null
-        }
+          creado_en: string;
+          devuelto_en: string | null;
+          dias_laborados_semana: number | null;
+          equipo_id: string | null;
+          estado_visita: string;
+          fecha_visita: string | null;
+          id: string;
+          ingeniero_revisor_id: string | null;
+          kv_maximo_usado: number | null;
+          last_modified: string;
+          mas_maximo_usado: number | null;
+          max_disparos_paciente: number | null;
+          observaciones: string | null;
+          observaciones_revision: string | null;
+          pacientes_por_semana: number | null;
+          porcentaje_rechazo: number | null;
+          presion_hpa: number | null;
+          radiografias_por_semana: number | null;
+          solicitud_id: string;
+          sync_status: string;
+          tecnico_id: string | null;
+          temperatura_c: number | null;
+          ubicacion_id: string | null;
+        };
         Insert: {
-          creado_en?: string
-          devuelto_en?: string | null
-          dias_laborados_semana?: number | null
-          equipo_id?: string | null
-          estado_visita?: string
-          fecha_visita?: string | null
-          id?: string
-          ingeniero_revisor_id?: string | null
-          kv_maximo_usado?: number | null
-          last_modified?: string
-          mas_maximo_usado?: number | null
-          max_disparos_paciente?: number | null
-          observaciones?: string | null
-          observaciones_revision?: string | null
-          pacientes_por_semana?: number | null
-          porcentaje_rechazo?: number | null
-          presion_hpa?: number | null
-          radiografias_por_semana?: number | null
-          solicitud_id: string
-          sync_status?: string
-          tecnico_id?: string | null
-          temperatura_c?: number | null
-          ubicacion_id?: string | null
-        }
+          creado_en?: string;
+          devuelto_en?: string | null;
+          dias_laborados_semana?: number | null;
+          equipo_id?: string | null;
+          estado_visita?: string;
+          fecha_visita?: string | null;
+          id?: string;
+          ingeniero_revisor_id?: string | null;
+          kv_maximo_usado?: number | null;
+          last_modified?: string;
+          mas_maximo_usado?: number | null;
+          max_disparos_paciente?: number | null;
+          observaciones?: string | null;
+          observaciones_revision?: string | null;
+          pacientes_por_semana?: number | null;
+          porcentaje_rechazo?: number | null;
+          presion_hpa?: number | null;
+          radiografias_por_semana?: number | null;
+          solicitud_id: string;
+          sync_status?: string;
+          tecnico_id?: string | null;
+          temperatura_c?: number | null;
+          ubicacion_id?: string | null;
+        };
         Update: {
-          creado_en?: string
-          devuelto_en?: string | null
-          dias_laborados_semana?: number | null
-          equipo_id?: string | null
-          estado_visita?: string
-          fecha_visita?: string | null
-          id?: string
-          ingeniero_revisor_id?: string | null
-          kv_maximo_usado?: number | null
-          last_modified?: string
-          mas_maximo_usado?: number | null
-          max_disparos_paciente?: number | null
-          observaciones?: string | null
-          observaciones_revision?: string | null
-          pacientes_por_semana?: number | null
-          porcentaje_rechazo?: number | null
-          presion_hpa?: number | null
-          radiografias_por_semana?: number | null
-          solicitud_id?: string
-          sync_status?: string
-          tecnico_id?: string | null
-          temperatura_c?: number | null
-          ubicacion_id?: string | null
-        }
+          creado_en?: string;
+          devuelto_en?: string | null;
+          dias_laborados_semana?: number | null;
+          equipo_id?: string | null;
+          estado_visita?: string;
+          fecha_visita?: string | null;
+          id?: string;
+          ingeniero_revisor_id?: string | null;
+          kv_maximo_usado?: number | null;
+          last_modified?: string;
+          mas_maximo_usado?: number | null;
+          max_disparos_paciente?: number | null;
+          observaciones?: string | null;
+          observaciones_revision?: string | null;
+          pacientes_por_semana?: number | null;
+          porcentaje_rechazo?: number | null;
+          presion_hpa?: number | null;
+          radiografias_por_semana?: number | null;
+          solicitud_id?: string;
+          sync_status?: string;
+          tecnico_id?: string | null;
+          temperatura_c?: number | null;
+          ubicacion_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "visitas_equipo_id_fkey"
-            columns: ["equipo_id"]
-            isOneToOne: false
-            referencedRelation: "equipos"
-            referencedColumns: ["id"]
+            foreignKeyName: "visitas_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "visitas_ingeniero_revisor_id_fkey"
-            columns: ["ingeniero_revisor_id"]
-            isOneToOne: false
-            referencedRelation: "usuarios"
-            referencedColumns: ["id"]
+            foreignKeyName: "visitas_ingeniero_revisor_id_fkey";
+            columns: ["ingeniero_revisor_id"];
+            isOneToOne: false;
+            referencedRelation: "usuarios";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "visitas_solicitud_id_fkey"
-            columns: ["solicitud_id"]
-            isOneToOne: false
-            referencedRelation: "solicitudes"
-            referencedColumns: ["id"]
+            foreignKeyName: "visitas_solicitud_id_fkey";
+            columns: ["solicitud_id"];
+            isOneToOne: false;
+            referencedRelation: "solicitudes";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "visitas_tecnico_id_fkey"
-            columns: ["tecnico_id"]
-            isOneToOne: false
-            referencedRelation: "usuarios"
-            referencedColumns: ["id"]
+            foreignKeyName: "visitas_tecnico_id_fkey";
+            columns: ["tecnico_id"];
+            isOneToOne: false;
+            referencedRelation: "usuarios";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "visitas_ubicacion_id_fkey"
-            columns: ["ubicacion_id"]
-            isOneToOne: false
-            referencedRelation: "ubicaciones_rx"
-            referencedColumns: ["id"]
+            foreignKeyName: "visitas_ubicacion_id_fkey";
+            columns: ["ubicacion_id"];
+            isOneToOne: false;
+            referencedRelation: "ubicaciones_rx";
+            referencedColumns: ["id"];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
-      get_usuario_id: { Args: never; Returns: string }
-      is_admin: { Args: never; Returns: boolean }
-    }
+      get_usuario_id: { Args: never; Returns: string };
+      is_admin: { Args: never; Returns: boolean };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+    : never;
 
 export const Constants = {
   graphql_public: {
@@ -2782,4 +2774,4 @@ export const Constants = {
   public: {
     Enums: {},
   },
-} as const
+} as const;

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,0 +1,115 @@
+// Fábricas de entidades para tests.
+//
+// Cada `makeX(overrides?)` devuelve un objeto de dominio VÁLIDO con
+// defaults sensatos y un `id` nuevo (crypto.randomUUID). NO tocan la base:
+// son objetos puros. Para escribir un grafo conectado a Dexie usá
+// `seedGraph()` de ./seed.
+//
+// Convención: por defecto las filas nacen `sync_status: "synced"` (estado
+// "ya sincronizado con el servidor"). Para simular una edición local sin
+// subir todavía, pasá `{ sync_status: "pending" }` en overrides.
+
+import { randomUUID } from "@/lib/uuid";
+import type {
+  Cliente,
+  Sede,
+  UbicacionRx,
+  Equipo,
+  Solicitud,
+  VisitaEjecucion,
+  Tubo,
+  TipoEquipo,
+  EstadoVisita,
+  SyncStatus,
+} from "@/lib/db/types";
+
+const now = () => new Date().toISOString();
+const sync = (s: SyncStatus = "synced") => ({ sync_status: s, last_modified: now() });
+
+export function makeCliente(overrides: Partial<Cliente> = {}): Cliente {
+  return {
+    id: randomUUID(),
+    nombre_cliente: "Clínica de Prueba S.A.S.",
+    nit: "900123456",
+    ...sync(),
+    ...overrides,
+  };
+}
+
+export function makeSede(cliente_id: string, overrides: Partial<Sede> = {}): Sede {
+  return {
+    id: randomUUID(),
+    cliente_id,
+    nombre_sede: "Sede Principal",
+    ciudad: "Bogotá",
+    departamento: "Cundinamarca",
+    ...sync(),
+    ...overrides,
+  };
+}
+
+export function makeUbicacion(sede_id: string, overrides: Partial<UbicacionRx> = {}): UbicacionRx {
+  return {
+    id: randomUUID(),
+    sede_id,
+    nombre_servicio: "Radiología Convencional",
+    ancho_m: 4,
+    largo_m: 5,
+    alto_m: 3,
+    area_m2: 20,
+    ...sync(),
+    ...overrides,
+  };
+}
+
+export function makeEquipo(ubicacion_id: string, overrides: Partial<Equipo> = {}): Equipo {
+  return {
+    id: randomUUID(),
+    ubicacion_id,
+    tipo_equipo: "CONVENCIONAL" as TipoEquipo,
+    planilla_espacial: false,
+    marca: "Siemens",
+    modelo: "Multix",
+    numero_serie: "SN-0001",
+    ...sync(),
+    ...overrides,
+  };
+}
+
+export function makeTubo(equipo_id: string, overrides: Partial<Tubo> = {}): Tubo {
+  return {
+    id: randomUUID(),
+    equipo_id,
+    marca: "Siemens",
+    modelo: "Opti 150",
+    numero_serie: "TUBO-0001",
+    ...sync(),
+    ...overrides,
+  };
+}
+
+export function makeSolicitud(cliente_id: string, overrides: Partial<Solicitud> = {}): Solicitud {
+  return {
+    id: randomUUID(),
+    cliente_id,
+    pago_recibido: false,
+    pipeline_estado: "programacion",
+    tipo_servicio: "control_calidad",
+    fecha_solicitud: now(),
+    ...sync(),
+    ...overrides,
+  };
+}
+
+export function makeVisita(
+  solicitud_id: string,
+  overrides: Partial<VisitaEjecucion> = {}
+): VisitaEjecucion {
+  return {
+    id: randomUUID(),
+    solicitud_id,
+    estado_visita: "asignada" as EstadoVisita,
+    ...sync(),
+    ...overrides,
+  };
+}

--- a/src/test/fake-supabase.test.ts
+++ b/src/test/fake-supabase.test.ts
@@ -1,0 +1,54 @@
+// Smoke tests de las capacidades NUEVAS del FakeSupabaseClient (Tier 0).
+// Las capacidades previas (paginación, maxRows, failOnCall) ya están
+// cubiertas de forma indirecta por sync-engine.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { createFakeSupabaseClient } from "@/test/fake-supabase";
+
+describe("FakeSupabaseClient — capacidades nuevas", () => {
+  it("throwOnCall hace que la llamada LANCE (no que devuelva {error})", async () => {
+    const c = createFakeSupabaseClient();
+    c.throwOnCall("clientes", "select", 1, { message: "network down", code: "ECONNREFUSED" });
+
+    await expect(c.from("clientes").select("*")).rejects.toThrow("network down");
+  });
+
+  it("failOnCall hace que la llamada DEVUELVA {error} sin lanzar", async () => {
+    const c = createFakeSupabaseClient();
+    c.failOnCall("clientes", "upsert", 1, { message: "duplicate key", code: "23505" });
+
+    const res = await c.from("clientes").upsert({ id: "a" });
+    expect(res.error?.code).toBe("23505");
+    expect(res.data).toBeNull();
+  });
+
+  it("stampServerTimestamps pisa last_modified con hora del servidor al upsert", async () => {
+    const c = createFakeSupabaseClient({ stampServerTimestamps: true });
+    const clienteClock = "2000-01-01T00:00:00.000Z"; // reloj del dispositivo atrasado
+
+    await c.from("clientes").upsert({ id: "a", last_modified: clienteClock });
+
+    const row = c.getServerRow("clientes", "a");
+    expect(row?.last_modified).not.toBe(clienteClock);
+    expect(new Date(row?.last_modified as string).getFullYear()).toBeGreaterThan(2000);
+  });
+
+  it("_version se incrementa en cada upsert de la misma fila", async () => {
+    const c = createFakeSupabaseClient();
+    await c.from("clientes").upsert({ id: "a", nombre_cliente: "v1" });
+    await c.from("clientes").upsert({ id: "a", nombre_cliente: "v2" });
+
+    expect(c.getServerRow("clientes", "a")?._version).toBe(2);
+    expect(c.getServerRow("clientes", "a")?.nombre_cliente).toBe("v2");
+  });
+
+  it("patchServerRow deja una fila del servidor más nueva que la local", async () => {
+    const c = createFakeSupabaseClient();
+    c.seedTable("clientes", [{ id: "a", last_modified: "2026-01-01T00:00:00.000Z" }]);
+
+    c.patchServerRow("clientes", "a", { last_modified: "2026-06-01T00:00:00.000Z" });
+
+    expect(c.getServerRow("clientes", "a")?.last_modified).toBe("2026-06-01T00:00:00.000Z");
+    expect(() => c.patchServerRow("clientes", "inexistente", {})).toThrow();
+  });
+});

--- a/src/test/fake-supabase.ts
+++ b/src/test/fake-supabase.ts
@@ -9,11 +9,27 @@
  * - Truncamiento programable por tabla (`maxRows`), replicando el límite
  *   `max_rows` de PostgREST (`supabase/config.toml`) que trunca resultados
  *   silenciosamente sin devolver error.
- * - Fallos programables por llamada (`failOnCall`), para simular una página
- *   intermedia que falla durante la paginación.
+ * - Fallos programables por llamada:
+ *     · `failOnCall`  → la llamada DEVUELVE `{ data: null, error }` (5xx/429
+ *                        y muchos códigos PG llegan así en supabase-js).
+ *     · `throwOnCall` → la llamada LANZA (fetch caído / Supabase inalcanzable).
+ *   La distinción importa: `proxy.ts` se ramifica por throw-vs-`{error}`.
+ * - Timestamps de servidor opcionales (`stampServerTimestamps`): al upsert,
+ *   pisa `last_modified` con la hora "del servidor". Sirve para probar que
+ *   una vez que el watermark se calcule server-side, el reloj desfasado del
+ *   dispositivo deja de romper el pull (hallazgo #5).
+ * - Versión por fila (`_version`): se incrementa en cada upsert. Permite
+ *   detectar updates perdidos (hallazgo #4).
+ * - Mutación puntual de una fila "del servidor" (`patchServerRow`) para
+ *   simular que otro dispositivo la dejó más nueva (hallazgo #3).
  */
 
 export type FakeRow = Record<string, unknown>;
+
+export interface FakeSupabaseClientOptions {
+  /** Al upsert, pisa `last_modified` con la hora del servidor (Date.now). */
+  stampServerTimestamps?: boolean;
+}
 
 export interface FakeSupabaseError {
   message: string;
@@ -32,6 +48,8 @@ interface FailureSpec {
   method: FakeMethod;
   callIndex: number;
   error: FakeSupabaseError;
+  /** true => la llamada lanza; false/undefined => devuelve { error }. */
+  throws?: boolean;
 }
 
 interface FakeFilter {
@@ -102,21 +120,34 @@ class FakeQueryBuilder implements PromiseLike<FakeQueryResult> {
   private async executeUpsert(): Promise<FakeQueryResult> {
     const callIndex = this.client._nextCallIndex(this.table, "upsert");
     const failure = this.client._takeFailure(this.table, "upsert", callIndex);
-    if (failure) return { data: null, error: failure };
+    if (failure?.throws) throw Object.assign(new Error(failure.error.message), failure.error);
+    if (failure) return { data: null, error: failure.error };
 
     const cfg = this.client._tableConfig(this.table);
+    const written: FakeRow[] = [];
     for (const row of this.upsertRows ?? []) {
       const idx = cfg.rows.findIndex((r) => r.id === row.id);
-      if (idx >= 0) cfg.rows[idx] = { ...cfg.rows[idx], ...row };
-      else cfg.rows.push({ ...row });
+      const prevVersion = idx >= 0 ? ((cfg.rows[idx]._version as number) ?? 0) : 0;
+      const merged: FakeRow = {
+        ...(idx >= 0 ? cfg.rows[idx] : {}),
+        ...row,
+        _version: prevVersion + 1,
+      };
+      if (this.client._stampServerTimestamps) {
+        merged.last_modified = new Date().toISOString();
+      }
+      if (idx >= 0) cfg.rows[idx] = merged;
+      else cfg.rows.push(merged);
+      written.push(merged);
     }
-    return { data: this.upsertRows ?? [], error: null };
+    return { data: written, error: null };
   }
 
   private async executeSelect(): Promise<FakeQueryResult> {
     const callIndex = this.client._nextCallIndex(this.table, "select");
     const failure = this.client._takeFailure(this.table, "select", callIndex);
-    if (failure) return { data: null, error: failure };
+    if (failure?.throws) throw Object.assign(new Error(failure.error.message), failure.error);
+    if (failure) return { data: null, error: failure.error };
 
     const cfg = this.client._tableConfig(this.table);
     let rows = cfg.rows.filter((row) =>
@@ -159,13 +190,20 @@ export class FakeSupabaseClient {
   private callCounts = new Map<string, number>();
   private currentUser: { id: string } | null = { id: "fake-user-id" };
 
+  /** @internal usado por FakeQueryBuilder */
+  readonly _stampServerTimestamps: boolean;
+
+  constructor(opts: FakeSupabaseClientOptions = {}) {
+    this._stampServerTimestamps = opts.stampServerTimestamps ?? false;
+  }
+
   auth = {
     getUser: async () => ({ data: { user: this.currentUser } }),
   };
 
   /** Carga filas simuladas para una tabla remota, con truncamiento opcional. */
   seedTable(table: string, rows: FakeRow[], opts?: { maxRows?: number }): void {
-    this.tables.set(table, { rows: [...rows], maxRows: opts?.maxRows });
+    this.tables.set(table, { rows: rows.map((r) => ({ ...r })), maxRows: opts?.maxRows });
   }
 
   /** Controla si `auth.getUser()` devuelve un usuario autenticado. */
@@ -174,12 +212,47 @@ export class FakeSupabaseClient {
   }
 
   /**
-   * Programa un fallo para la N-ésima llamada (`callIndex`, 1-based) a
-   * `method` sobre `table`. Útil para simular que una página intermedia de
-   * paginación falla.
+   * Programa un fallo DEVUELTO (`{ data: null, error }`) para la N-ésima
+   * llamada (`callIndex`, 1-based) a `method` sobre `table`. Así llegan en
+   * supabase-js los 5xx/429 y muchos códigos PG (PGRST204, 23505, ...).
    */
   failOnCall(table: string, method: FakeMethod, callIndex: number, error: FakeSupabaseError): void {
     this.failures.push({ table, method, callIndex, error });
+  }
+
+  /**
+   * Como `failOnCall` pero la llamada LANZA en vez de devolver `{ error }`
+   * — simula fetch caído / Supabase inalcanzable (red total).
+   */
+  throwOnCall(
+    table: string,
+    method: FakeMethod,
+    callIndex: number,
+    error: FakeSupabaseError
+  ): void {
+    this.failures.push({ table, method, callIndex, error, throws: true });
+  }
+
+  /**
+   * Muta en el lugar una fila "del servidor" ya sembrada (por id). Simula
+   * que otro dispositivo la actualizó — típicamente para dejar su
+   * `last_modified` por delante de la copia local (hallazgo #3).
+   */
+  patchServerRow(table: string, id: string, patch: FakeRow): void {
+    const cfg = this._tableConfig(table);
+    const idx = cfg.rows.findIndex((r) => r.id === id);
+    if (idx === -1) throw new Error(`patchServerRow: no existe ${table}#${id}`);
+    cfg.rows[idx] = { ...cfg.rows[idx], ...patch };
+  }
+
+  /** Lee una fila "del servidor" para asserts. */
+  getServerRow(table: string, id: string): FakeRow | undefined {
+    return this._tableConfig(table).rows.find((r) => r.id === id);
+  }
+
+  /** Todas las filas "del servidor" de una tabla (copia). */
+  getServerRows(table: string): FakeRow[] {
+    return this._tableConfig(table).rows.map((r) => ({ ...r }));
   }
 
   from(table: string): FakeQueryBuilder {
@@ -205,15 +278,20 @@ export class FakeSupabaseClient {
     return next;
   }
 
-  _takeFailure(table: string, method: FakeMethod, callIndex: number): FakeSupabaseError | null {
+  _takeFailure(
+    table: string,
+    method: FakeMethod,
+    callIndex: number
+  ): { error: FakeSupabaseError; throws?: boolean } | null {
     const idx = this.failures.findIndex(
       (f) => f.table === table && f.method === method && f.callIndex === callIndex
     );
     if (idx === -1) return null;
-    return this.failures[idx].error;
+    const spec = this.failures[idx];
+    return { error: spec.error, throws: spec.throws };
   }
 }
 
-export function createFakeSupabaseClient(): FakeSupabaseClient {
-  return new FakeSupabaseClient();
+export function createFakeSupabaseClient(opts?: FakeSupabaseClientOptions): FakeSupabaseClient {
+  return new FakeSupabaseClient(opts);
 }

--- a/src/test/helpers.test.ts
+++ b/src/test/helpers.test.ts
@@ -1,0 +1,106 @@
+// Smoke tests de los helpers compartidos (factories / seed / net / roles).
+// Si esto falla, los tests de módulos que dependen de estos helpers están
+// en riesgo.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { makeCliente, makeEquipo, makeVisita } from "@/test/factories";
+import { seedGraph } from "@/test/seed";
+import { withOffline, withOnline, withClockSkew } from "@/test/net";
+import { makeRole } from "@/test/roles";
+
+describe("factories", () => {
+  it("makeCliente da un objeto válido con id y sync_status", () => {
+    const c = makeCliente();
+    expect(c.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(c.nombre_cliente).toBeTruthy();
+    expect(c.sync_status).toBe("synced");
+  });
+
+  it("los overrides pisan los defaults", () => {
+    expect(makeCliente({ nombre_cliente: "X" }).nombre_cliente).toBe("X");
+    expect(makeEquipo("ubi-1", { tipo_equipo: "MAMOGRAFO" }).tipo_equipo).toBe("MAMOGRAFO");
+    expect(makeVisita("sol-1", { estado_visita: "en_revision" }).estado_visita).toBe("en_revision");
+  });
+
+  it("ids distintos en cada llamada", () => {
+    expect(makeCliente().id).not.toBe(makeCliente().id);
+  });
+});
+
+describe("seedGraph", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("escribe la cadena completa enlazada por FKs", async () => {
+    const g = await seedGraph();
+
+    expect(await db.clientes.get(g.cliente.id!)).toBeDefined();
+    expect((await db.sedes.get(g.sede.id!))?.cliente_id).toBe(g.cliente.id);
+    expect((await db.ubicaciones_rx.get(g.ubicacion.id!))?.sede_id).toBe(g.sede.id);
+    expect((await db.equipos.get(g.equipo.id!))?.ubicacion_id).toBe(g.ubicacion.id);
+    expect((await db.tubos.get(g.tubo!.id!))?.equipo_id).toBe(g.equipo.id);
+    expect((await db.solicitudes.get(g.solicitud!.id!))?.cliente_id).toBe(g.cliente.id);
+    expect((await db.visitas.get(g.visita!.id!))?.solicitud_id).toBe(g.solicitud!.id);
+    expect((await db.visitas.get(g.visita!.id!))?.equipo_id).toBe(g.equipo.id);
+  });
+
+  it("respeta las opciones (sin visita, sync_status pending, tipo de equipo)", async () => {
+    const g = await seedGraph({ conVisita: false, syncStatus: "pending", tipoEquipo: "CT" });
+    expect(g.visita).toBeUndefined();
+    expect((await db.equipos.get(g.equipo.id!))?.tipo_equipo).toBe("CT");
+    expect((await db.equipos.get(g.equipo.id!))?.sync_status).toBe("pending");
+  });
+});
+
+describe("net", () => {
+  it("withOffline / withOnline fijan navigator.onLine y restauran", async () => {
+    const before = navigator.onLine;
+    await withOffline(async () => {
+      expect(navigator.onLine).toBe(false);
+    });
+    await withOnline(async () => {
+      expect(navigator.onLine).toBe(true);
+    });
+    expect(navigator.onLine).toBe(before);
+  });
+
+  it("withClockSkew desplaza el reloj y lo restaura", async () => {
+    const real = Date.now();
+    await withClockSkew(60 * 60 * 1000, async () => {
+      expect(Date.now()).toBeGreaterThan(real + 59 * 60 * 1000);
+    });
+    expect(Date.now()).toBeGreaterThanOrEqual(real);
+    expect(Date.now()).toBeLessThan(real + 60 * 1000);
+  });
+});
+
+describe("roles", () => {
+  it("coordinador es admin y puede todo", () => {
+    const r = makeRole("coordinador");
+    expect(r.isAdmin).toBe(true);
+    expect(r.hasPermission("clientes", "eliminar")).toBe(true);
+  });
+
+  it("tecnico no ve clientes pero ejecuta visitas", () => {
+    const r = makeRole("tecnico");
+    expect(r.isAdmin).toBe(false);
+    expect(r.hasPermission("clientes")).toBe(false);
+    expect(r.hasPermission("visitas", "editar")).toBe(true);
+    expect(r.hasPermission("visitas", "eliminar")).toBe(false);
+  });
+
+  it("deny/allow pisan el default", () => {
+    expect(
+      makeRole("coordinador", { deny: [["clientes", "eliminar"]] }).hasPermission(
+        "clientes",
+        "eliminar"
+      )
+    ).toBe(false);
+    expect(makeRole("tecnico", { allow: [["clientes", "ver"]] }).hasPermission("clientes")).toBe(
+      true
+    );
+  });
+});

--- a/src/test/net.ts
+++ b/src/test/net.ts
@@ -1,0 +1,49 @@
+// Helpers de conectividad y reloj para tests del motor de sync.
+//
+// El sync-engine y useAutoSync se ramifican por `navigator.onLine` y usan
+// `new Date()` para el watermark de pull. Estos wrappers permiten forzar
+// esas condiciones de forma acotada y con restauración garantizada.
+
+import { vi } from "vitest";
+
+/**
+ * Fija `navigator.onLine` y dispara el evento `online`/`offline` en window,
+ * ejecuta `fn`, y restaura el valor original al terminar (incluso si lanza).
+ */
+async function withConnectivity<T>(online: boolean, fn: () => T | Promise<T>): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(navigator, "onLine");
+  Object.defineProperty(navigator, "onLine", { configurable: true, value: online });
+  window.dispatchEvent(new Event(online ? "online" : "offline"));
+  try {
+    return await fn();
+  } finally {
+    if (original) Object.defineProperty(navigator, "onLine", original);
+    else Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
+  }
+}
+
+export const withOnline = <T>(fn: () => T | Promise<T>) => withConnectivity(true, fn);
+export const withOffline = <T>(fn: () => T | Promise<T>) => withConnectivity(false, fn);
+
+/**
+ * Corre `fn` con el reloj del sistema desplazado `offsetMs` respecto de
+ * `base` (default: ahora). Sirve para reproducir el bug del watermark con
+ * reloj de dispositivo desfasado (hallazgo #5 del plan).
+ *
+ * Solo fake-ea `Date` — NO `setTimeout`/`setInterval`, porque los timers
+ * falsos completos cuelgan las transacciones de fake-indexeddb (mismo
+ * motivo por el que sync-retry.test.ts usa `toFake: ["Date"]`).
+ */
+export async function withClockSkew<T>(
+  offsetMs: number,
+  fn: () => T | Promise<T>,
+  base: Date = new Date()
+): Promise<T> {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date(base.getTime() + offsetMs));
+  try {
+    return await fn();
+  } finally {
+    vi.useRealTimers();
+  }
+}

--- a/src/test/roles.ts
+++ b/src/test/roles.ts
@@ -1,0 +1,75 @@
+// Helper para simular el rol activo en tests de componentes.
+//
+// El RoleProvider real hace consultas a Dexie + verificación de sesión
+// contra Supabase, demasiado para un test unitario. `makeRole()` arma un
+// valor de contexto válido usando la MISMA lógica de permisos que produce
+// (resolverPermiso + la matriz por defecto), para que `hasPermission` se
+// comporte igual que en producción.
+//
+// Uso típico (el vi.mock va en el archivo de test, no acá — es hoisted):
+//
+//   import { makeRole } from "@/test/roles";
+//   const role = makeRole("tecnico");
+//   vi.mock("@/components/role-provider", () => ({ useRole: () => role }));
+//
+// Para negar un permiso puntual:
+//   makeRole("coordinador", { deny: [["clientes", "eliminar"]] })
+
+import {
+  permisoDefault,
+  resolverPermiso,
+  type RolUsuario,
+  type RolPermiso,
+  type AccionPermiso,
+  type ModuloApp,
+} from "@/lib/db/types";
+
+export interface MakeRoleOptions {
+  usuarioId?: string;
+  nombre?: string;
+  /** Pares [modulo, accion] que se fuerzan a `false` sobre el default. */
+  deny?: Array<[string, AccionPermiso?]>;
+  /** Pares [modulo, accion] que se fuerzan a `true` sobre el default. */
+  allow?: Array<[string, AccionPermiso?]>;
+}
+
+export interface RoleContextValue {
+  role: { usuarioId: string; nombre: string; cargo: RolUsuario } | null;
+  isAdmin: boolean;
+  isReady: boolean;
+  hasPermission: (modulo: string, accion?: AccionPermiso) => boolean;
+}
+
+export function makeRole(cargo: RolUsuario, opts: MakeRoleOptions = {}): RoleContextValue {
+  const { usuarioId = "user-test", nombre = "Usuario Test", deny = [], allow = [] } = opts;
+
+  const key = (m: string, a: AccionPermiso) => `${m}:${a}`;
+  const denySet = new Set(deny.map(([m, a]) => key(m, a ?? "ver")));
+  const allowSet = new Set(allow.map(([m, a]) => key(m, a ?? "ver")));
+
+  const hasPermission = (modulo: string, accion: AccionPermiso = "ver"): boolean => {
+    if (denySet.has(key(modulo, accion))) return false;
+    if (allowSet.has(key(modulo, accion))) return true;
+    // Sintetiza la fila `rol_permisos` que `seedRolPermisos` habría escrito
+    // desde la matriz. Pasar `undefined` NO sirve: accionesEfectivas lee
+    // `ver` como `permiso?.activo ?? false`, así que sin fila el "ver"
+    // siempre da false y ninguna acción pasa.
+    const def = permisoDefault(cargo, modulo as ModuloApp);
+    const permiso: RolPermiso = {
+      rol: cargo,
+      modulo: modulo as ModuloApp,
+      activo: def.ver,
+      crear: def.crear,
+      editar: def.editar,
+      eliminar: def.eliminar,
+    };
+    return resolverPermiso(permiso, cargo, modulo as ModuloApp, accion);
+  };
+
+  return {
+    role: { usuarioId, nombre, cargo },
+    isAdmin: cargo === "coordinador",
+    isReady: true,
+    hasPermission,
+  };
+}

--- a/src/test/seed.ts
+++ b/src/test/seed.ts
@@ -1,0 +1,86 @@
+// Siembra un grafo de dominio CONECTADO en Dexie para tests de integración.
+//
+//   cliente → sede → ubicación → equipo (→ tubo) → solicitud → visita
+//
+// Todas las filas quedan enlazadas por sus FKs reales. Devuelve los objetos
+// creados para que el test pueda referenciar ids sin volver a leerlos.
+//
+// Requiere una base ya reseteada (`await resetTestDb()` en beforeEach).
+//
+// NO auto-genera grupo_resultados / prueba_resultados: eso depende del
+// catálogo sembrado (grupo_pruebas / prueba_definiciones) y se arma en los
+// tests de Tier 4 (visita-service / module-completeness), no acá.
+
+import { db } from "@/lib/db";
+import type { SyncStatus, TipoEquipo, EstadoVisita } from "@/lib/db/types";
+import {
+  makeCliente,
+  makeSede,
+  makeUbicacion,
+  makeEquipo,
+  makeTubo,
+  makeSolicitud,
+  makeVisita,
+} from "./factories";
+
+export interface SeedGraphOptions {
+  /** Tipo de equipo. Default: CONVENCIONAL (el único con paquete implementado). */
+  tipoEquipo?: TipoEquipo;
+  /** Estado inicial de la visita. Default: "asignada". */
+  estadoVisita?: EstadoVisita;
+  /** sync_status con el que nacen TODAS las filas. Default: "synced". */
+  syncStatus?: SyncStatus;
+  /** Crear también una fila en `tubos` para el equipo. Default: true. */
+  conTubo?: boolean;
+  /** Crear la solicitud. Default: true. */
+  conSolicitud?: boolean;
+  /** Crear la visita (implica conSolicitud). Default: true. */
+  conVisita?: boolean;
+}
+
+export async function seedGraph(opts: SeedGraphOptions = {}) {
+  const {
+    tipoEquipo = "CONVENCIONAL",
+    estadoVisita = "asignada",
+    syncStatus = "synced",
+    conTubo = true,
+    conSolicitud = true,
+    conVisita = true,
+  } = opts;
+
+  const s = { sync_status: syncStatus };
+
+  const cliente = makeCliente(s);
+  const sede = makeSede(cliente.id!, s);
+  const ubicacion = makeUbicacion(sede.id!, s);
+  const equipo = makeEquipo(ubicacion.id!, { tipo_equipo: tipoEquipo, ...s });
+
+  await db.clientes.add(cliente);
+  await db.sedes.add(sede);
+  await db.ubicaciones_rx.add(ubicacion);
+  await db.equipos.add(equipo);
+
+  const tubo = conTubo ? makeTubo(equipo.id!, s) : undefined;
+  if (tubo) await db.tubos.add(tubo);
+
+  const necesitaSolicitud = conSolicitud || conVisita;
+  const solicitud = necesitaSolicitud
+    ? makeSolicitud(cliente.id!, { ubicacion_id: ubicacion.id, ...s })
+    : undefined;
+  if (solicitud) await db.solicitudes.add(solicitud);
+
+  const visita =
+    conVisita && solicitud
+      ? makeVisita(solicitud.id!, {
+          equipo_id: equipo.id,
+          ubicacion_id: ubicacion.id,
+          estado_visita: estadoVisita,
+          ...s,
+        })
+      : undefined;
+  if (visita) await db.visitas.add(visita);
+
+  return { cliente, sede, ubicacion, equipo, tubo, solicitud, visita };
+}
+
+export type SeededGraph = Awaited<ReturnType<typeof seedGraph>>;

--- a/src/test/setup.test.ts
+++ b/src/test/setup.test.ts
@@ -1,0 +1,25 @@
+// Verifica que el andamiaje de test (src/test/setup.ts) esté bien enchufado.
+// Si este archivo falla, TODOS los tests de componentes están en riesgo.
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
+
+describe("andamiaje de test", () => {
+  it("los matchers de jest-dom están disponibles", () => {
+    render(createElement("button", { disabled: true }, "Guardar"));
+    const boton = screen.getByRole("button", { name: "Guardar" });
+
+    // Estos matchers vienen de @testing-library/jest-dom; si no está
+    // enchufado en setup.ts, esta línea lanza "toBeDisabled is not a function".
+    expect(boton).toBeInTheDocument();
+    expect(boton).toBeDisabled();
+    expect(boton).toHaveTextContent("Guardar");
+  });
+
+  it("cleanup() desmonta el DOM entre tests", () => {
+    // El test anterior renderizó un <button>. Si cleanup() del afterEach
+    // no corriera, seguiría en el document acá.
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,23 @@
+// Archivo de setup global de Vitest — se ejecuta una vez antes de cada
+// archivo de test (referenciado en vitest.config.ts -> test.setupFiles).
+//
+// Qué hace:
+//  1. Enchufa @testing-library/jest-dom para habilitar matchers legibles
+//     sobre el DOM: toBeInTheDocument(), toBeDisabled(), toHaveValue(),
+//     toHaveTextContent(), etc. Sin esto, los tests caen en aserciones
+//     crudas tipo `expect(el.disabled).toBe(true)`.
+//  2. Corre cleanup() de @testing-library/react después de cada test para
+//     desmontar los componentes montados y evitar que el DOM de un test
+//     se filtre al siguiente (happy-dom no aísla entre tests por sí solo).
+//
+// fake-indexeddb/auto se sigue cargando aparte, primero en la lista de
+// setupFiles, para que el polyfill de IndexedDB esté disponible antes de
+// que cualquier import toque Dexie.
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,8 +4,48 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "happy-dom",
-    setupFiles: ["fake-indexeddb/auto"],
+    // Orden importa: el polyfill de IndexedDB primero, después nuestro setup
+    // (jest-dom + cleanup de React). Ver src/test/setup.ts.
+    setupFiles: ["fake-indexeddb/auto", "./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      // Solo medimos código de producción bajo src/. Se excluye lo que no
+      // tiene sentido cubrir con tests unitarios: definiciones de tipos,
+      // el propio andamiaje de test, componentes shadcn sin lógica propia,
+      // y las rutas/layouts de Next (se cubren a nivel integración en Tier 7).
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.d.ts",
+        "src/test/**",
+        "src/components/ui/**",
+        "src/app/**/layout.tsx",
+        "src/app/**/loading.tsx",
+        "src/lib/supabase/types.ts",
+      ],
+      // Umbrales de "trinquete": son el piso de cobertura actual, redondeado
+      // un par de puntos hacia abajo para tolerar el ruido entre corridas.
+      // Nunca deben bajar. A medida que se certifica cada módulo (ver plan),
+      // se sube el número de sus archivos aquí.
+      //
+      // El umbral global es bajísimo a propósito: hoy la mayor parte del
+      // árbol (páginas, PDF, visita-modulos) no tiene tests. Aun así atrapa
+      // el caso de que alguien borre una suite entera. Los globs por archivo
+      // son los que ajustan fino sobre lo que YA está testeado en serio.
+      thresholds: {
+        lines: 12,
+        statements: 12,
+        functions: 9,
+        branches: 12,
+        "src/lib/equipos/engine.ts": { lines: 83, functions: 85, branches: 77 },
+        "src/lib/supabase/sync-retry.ts": { lines: 94, functions: 100, branches: 86 },
+        "src/lib/supabase/sync-lock.ts": { lines: 65, functions: 66, branches: 60 },
+        "src/lib/supabase/sync-engine.ts": { lines: 70, functions: 86, branches: 60 },
+        "src/proxy.ts": { lines: 72, functions: 40, branches: 54 },
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Segundo paso de la intervención (el primero fue #31). Prepara el andamiaje sobre el que se va a auditar módulo por módulo.

## Qué trae

| Commit | Qué |
|---|---|
| `chore(test)` infra | `src/test/setup.ts` (enchufa `jest-dom` → `toBeDisabled()`, `toBeInTheDocument()`... + `cleanup()` de RTL entre tests); `@testing-library/user-event`; cobertura v8 con **umbrales de trinquete** fijados al piso actual (`engine.ts` 83%, `sync-retry.ts` 94%...); scripts `typecheck` y `verify` |
| `chore(lint)` baseline | ignora `coverage/`; `react-hooks/set-state-in-effect` error→warn (14 casos en hooks/`visita-modulos`, rastreados por tier, **no es exención permanente** — cada módulo re-escala la regla en su ruta); ignora identificadores `_` |
| `style` formato | 9 archivos con deuda de formato preexistente formateados (solo Prettier) |
| `ci` | el workflow ahora corre `lint`, `format:check` y `test:coverage` además de `tsc` + `build` |
| `test` helpers | `factories.ts` (make*), `seed.ts` (`seedGraph()` — cadena cliente→…→visita enlazada por FKs), `net.ts` (`withOffline`/`withOnline`/`withClockSkew`), `roles.ts` (`makeRole()`) + smoke tests |
| `test(supabase)` fake | `FakeSupabaseClient`: `throwOnCall` (lanza vs `failOnCall` que devuelve `{error}`), `stampServerTimestamps`, `_version` por fila, `patchServerRow` — para tests de conflicto/red de Tier 2. Retrocompatible |
| `test(supabase)` guard | exporta `SYNC_TABLES`/`MASTER_TABLES`; test que falla si una tabla de Dexie no está clasificada (SYNC/MASTER/LOCAL_ONLY) |

## Hallazgo detectado por el guard

`elementos_proteccion` (tabla legacy) tiene contraparte en Supabase pero **no está en `SYNC_TABLES` → nunca sincroniza**; `generar-pre-informe.ts:140` todavía la lee. Marcada `LOCAL_ONLY` con TODO para Tier 5.

## Verificación

`npm run verify` — **exit 0**: typecheck limpio · lint **0 errores** (44 warnings rastreados) · format 100% limpio · **210 tests / 22 archivos** verdes.