### PR TITLE
Tier 1 completo — db, permisos, auth (src/lib/db, src/lib/auth, proxy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Supabase — cliente (públicas, se exponen al navegador)
+NEXT_PUBLIC_SUPABASE_URL=https://<tu-proyecto>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key>
+
+# Supabase — servidor (NUNCA exponer al cliente)
+SUPABASE_SERVICE_ROLE_KEY=<service role key>
+
+# Secreto de firma de JWT (Supabase → Settings → API → JWT Secret).
+# Lo usa proxy.ts para verificar la firma del token de sesión en el
+# fallback offline. Opcional pero recomendado — sin esto el gate offline
+# no verifica firmas (ver docs/modules/03-auth.md).
+SUPABASE_JWT_SECRET=<jwt secret>

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docs/modules/01-db.manual-S09-S10.md
+++ b/docs/modules/01-db.manual-S09-S10.md
@@ -1,0 +1,55 @@
+# Prueba manual: `src/lib/db/` — db-S09 / db-S10 (multi-pestaña)
+
+> Los únicos escenarios del Módulo 1 que no se pueden automatizar con
+> `fake-indexeddb` (necesitan dos contextos de navegador reales compartiendo
+> el mismo IndexedDB). Estado: **pendiente de ejecución** en un entorno con
+> la app corriendo.
+
+## Precondiciones
+
+- App corriendo (`npm run dev`) en un navegador real (Chrome/Firefox).
+- DevTools → Application → IndexedDB → `SievertEyC` visible.
+- Un solo perfil de navegador, **dos pestañas** apuntando a la app.
+- La DB local ya migrada a v15 (instalación normal).
+
+---
+
+## db-S09 — `versionchange`: una pestaña nueva fuerza a la vieja a recargar
+
+Simula el momento en que se despliega una versión de la app con una migración
+de esquema y el técnico tiene una pestaña vieja abierta.
+
+| #   | Paso                                                                                                                 | Esperado UI                                                                                             | Esperado Dexie / consola                                                   |
+| --- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 1   | Abrí la app en la **pestaña A**. Esperá a que cargue el dashboard.                                                   | Dashboard normal                                                                                        | `SievertEyC` abierta, versión 15                                           |
+| 2   | En DevTools de la pestaña A, consola: `indexedDB.open("SievertEyC", 99)` (fuerza una "versión futura" desde afuera). | —                                                                                                       | La pestaña A recibe el evento `versionchange`                              |
+| 3   | Observá la pestaña A.                                                                                                | La pestaña A **se recarga sola** (`db.on("versionchange")` → `db.close()` + `window.location.reload()`) | Tras recargar, vuelve a abrir en v15 (la v99 del paso 2 nunca se concreta) |
+
+**Veredicto:** [ ] pasa · [ ] falla → hallazgo
+
+> Variante realista (si hay un build con `version(16)`): abrir la pestaña B con
+> ese build mientras A tiene el build viejo. B dispara el upgrade a v16 → A
+> recibe `versionchange` → A recarga.
+
+---
+
+## db-S10 — `blocked`: una pestaña vieja bloquea el upgrade de otra
+
+| #   | Paso                                                                                                                                                                                                           | Esperado UI                                                                                                   | Esperado consola                   |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 1   | Pestaña A abierta en la app. En su consola, **NO** registres el handler de `versionchange` (o comentá temporalmente el `db.close()` en `index.ts` y recargá) para simular una pestaña que no cede la conexión. | Dashboard                                                                                                     | DB abierta                         |
+| 2   | En la pestaña B, abrí la app con un build que tenga una `version()` más alta.                                                                                                                                  | La pestaña B queda esperando (el upgrade no puede empezar mientras A tiene la DB abierta en la versión vieja) | B: evento `blocked` en la conexión |
+| 3   | Con el código real (handler activo): la pestaña A debería cerrar y recargar, desbloqueando a B.                                                                                                                | A recarga; B completa el upgrade y carga                                                                      | A: `db.on("blocked")` → `reload()` |
+
+**Veredicto:** [ ] pasa · [ ] falla → hallazgo
+
+---
+
+## Notas
+
+- Los handlers están en `src/lib/db/index.ts` (`db.on("blocked")` /
+  `db.on("versionchange")`), ambos con guard `typeof window !== "undefined"`.
+- Riesgo conocido: si `reload()` falla o el usuario tiene muchas pestañas, el
+  upgrade puede quedar trabado. Es comportamiento estándar de IndexedDB; la
+  mitigación de la app es recargar agresivamente.
+- Si S09/S10 fallan, es un hallazgo nuevo (no está en los 23 originales).

--- a/docs/modules/01-db.md
+++ b/docs/modules/01-db.md
@@ -24,16 +24,16 @@ Todo lo demás lee/escribe estas tablas y estos tipos. 56 archivos importan
 
 ## 2. API pública
 
-| Export | Firma | Efectos | Error | Idempotente |
-|---|---|---|---|---|
-| `db` | singleton `EyCDatabase` | abre IndexedDB al primer acceso / `db.open()` | `db.open()` **lanza** si la migración falla | — |
-| `permisoDefault(rol, modulo)` | → `AccionesPermiso` | ninguno (puro) | no lanza; módulo sin default → `SIN_ACCESO` | sí |
-| `accionesEfectivas(permiso?, rol, modulo)` | → `AccionesPermiso` | ninguno (puro) | no lanza | sí |
-| `resolverPermiso(permiso?, rol, modulo, accion="ver")` | → `boolean` | ninguno (puro) | no lanza | sí |
-| `seedRolPermisos()` | `Promise<void>` | escribe `rol_permisos` si está vacía | no lanza (salvo fallo Dexie) | **sí** (no-op si `count > 0`) |
-| `seedPruebaDefiniciones()` | `Promise<void>` | llama `seedRolPermisos`, luego escribe `prueba_definiciones` si vacía | idem | **sí** |
-| `seedFromPackage(pkg)` | `Promise<void>` | escribiría `grupo_pruebas` + defs enriquecidas | idem | sí — **pero nunca se invoca** (llamada comentada en `seedPruebaDefiniciones`) |
-| `resetAllLocalData()` | `Promise<void>` | `t.clear()` en TODAS las tablas (vacía contenido, conserva esquema) | no lanza | sí — **pero ningún archivo de `src/` lo llama** (solo uso manual por consola) |
+| Export                                                 | Firma                   | Efectos                                                               | Error                                       | Idempotente                                                                   |
+| ------------------------------------------------------ | ----------------------- | --------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------- |
+| `db`                                                   | singleton `EyCDatabase` | abre IndexedDB al primer acceso / `db.open()`                         | `db.open()` **lanza** si la migración falla | —                                                                             |
+| `permisoDefault(rol, modulo)`                          | → `AccionesPermiso`     | ninguno (puro)                                                        | no lanza; módulo sin default → `SIN_ACCESO` | sí                                                                            |
+| `accionesEfectivas(permiso?, rol, modulo)`             | → `AccionesPermiso`     | ninguno (puro)                                                        | no lanza                                    | sí                                                                            |
+| `resolverPermiso(permiso?, rol, modulo, accion="ver")` | → `boolean`             | ninguno (puro)                                                        | no lanza                                    | sí                                                                            |
+| `seedRolPermisos()`                                    | `Promise<void>`         | escribe `rol_permisos` si está vacía                                  | no lanza (salvo fallo Dexie)                | **sí** (no-op si `count > 0`)                                                 |
+| `seedPruebaDefiniciones()`                             | `Promise<void>`         | llama `seedRolPermisos`, luego escribe `prueba_definiciones` si vacía | idem                                        | **sí**                                                                        |
+| `seedFromPackage(pkg)`                                 | `Promise<void>`         | escribiría `grupo_pruebas` + defs enriquecidas                        | idem                                        | sí — **pero nunca se invoca** (llamada comentada en `seedPruebaDefiniciones`) |
+| `resetAllLocalData()`                                  | `Promise<void>`         | `t.clear()` en TODAS las tablas (vacía contenido, conserva esquema)   | no lanza                                    | sí — **pero ningún archivo de `src/` lo llama** (solo uso manual por consola) |
 
 ### ⚠️ Sutileza del motor de permisos (anclada en Tier 0)
 
@@ -46,12 +46,12 @@ justamente por esto.
 
 ## 3. Modelo de datos
 
-- **Tablas propias**: todas. Este módulo es dueño del *esquema*; los módulos de
-  workflow/captura son dueños de la *escritura de contenido*.
+- **Tablas propias**: todas. Este módulo es dueño del _esquema_; los módulos de
+  workflow/captura son dueños de la _escritura de contenido_.
 - **`deleted_at`**: **NO está declarado en `types.ts`**. No está en `SyncFields`
   ni en ninguna interfaz de tabla maestra (`Cliente`, `Sede`, `Equipo`,
   `VisitaEjecucion`, …). Solo aparece en `@/lib/equipos/convencional/db/types.ts`
-  (tablas `conv_*`). Lo escribe `deleteAndSync` (sync-engine) sobre *cualquier*
+  (tablas `conv_*`). Lo escribe `deleteAndSync` (sync-engine) sobre _cualquier_
   tabla; lo filtran a mano solo los consumidores `conv_*` (grupo-a..e, PDF,
   evaluacion). → **Hallazgo #14** (ver Apéndice B).
 - **`last_modified`**: lo setea quien escribe (form-dialogs, `updateAndSync`,
@@ -147,13 +147,13 @@ Comportamiento confirmado (Dexie 4.4.2, sonda ejecutada):
 
 ## 9. Modos de falla conocidos
 
-| Falla | Efecto | Manejo actual |
-|---|---|---|
-| Upgrade v13 con datos | `db.open()` lanza `UpgradeError` | `DbProvider` → `error` state, mensaje crudo. Sin recuperación. |
-| `randomUUID` no disponible (contexto inseguro) | seeds y escrituras lanzan | `DbProvider` → `error` state |
-| Seed interrumpido | catálogo/permisos incompletos para siempre | ninguno (el `count > 0` lo da por completo) |
-| Otra pestaña con versión más nueva | `blocked` / `versionchange` | `window.location.reload()` |
-| `db.table("sync_status")` sobre tabla maestra | Dexie lanza | sync-engine lo captura y loguea (esperado) |
+| Falla                                          | Efecto                                     | Manejo actual                                                  |
+| ---------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------- |
+| Upgrade v13 con datos                          | `db.open()` lanza `UpgradeError`           | `DbProvider` → `error` state, mensaje crudo. Sin recuperación. |
+| `randomUUID` no disponible (contexto inseguro) | seeds y escrituras lanzan                  | `DbProvider` → `error` state                                   |
+| Seed interrumpido                              | catálogo/permisos incompletos para siempre | ninguno (el `count > 0` lo da por completo)                    |
+| Otra pestaña con versión más nueva             | `blocked` / `versionchange`                | `window.location.reload()`                                     |
+| `db.table("sync_status")` sobre tabla maestra  | Dexie lanza                                | sync-engine lo captura y loguea (esperado)                     |
 
 ## 10. Preguntas abiertas / smells
 
@@ -171,21 +171,29 @@ Comportamiento confirmado (Dexie 4.4.2, sonda ejecutada):
 
 ## Apéndice B — Log de decisiones (triage de hallazgos)
 
-| # | Descripción | Decisión | Razón |
-|---|---|---|---|
-| #14 (parte db) | `deleted_at` no tipado; filtrado a mano | **fix-ahora (parcial)**: agregar `deleted_at?: string` a `SyncFields`. Filtro de `conv_inspeccion_items` se arregla en su consumidor (`cargarTablasConv`, Tier 3/4). Listas maestras → backlog con test-guard. | Tipar el contrato es barato y lo hace visible; el resto necesita decisión de diseño mayor. |
-| v13 UpgradeError | Upgrade con datos brickea la app | **backlog + guardia interina**: helper `detectResetRequired()` en `src/lib/db/` que reconoce el `UpgradeError`; `db-provider` muestra UI de "borrá datos locales y recargá" en vez del mensaje crudo. Test que fija el comportamiento de la sonda. | v13 ya está shippeado; los usuarios afectados ya migraron o ya están rotos. El valor es no repetirlo y dar recuperación. |
-| Seed no atómico | seed interrumpido queda incompleto | **aceptar + pin**: documentar la invariante #3, test que fija el comportamiento idempotente actual. | Riesgo bajo (el seed es rápido y local); rediseñarlo a "versión de seed" es desproporcionado ahora. |
-| `SyncStatus` `"conflict"` muerto | valor de enum sin uso | **backlog**: quitar en la limpieza del sync-engine (Tier 2). | Cambio trivial pero pertenece al módulo que lo dejó de usar. |
-| `resetAllLocalData` / `seedFromPackage` muertos | código sin caller | **backlog**: decidir en Tier 4 (`seedFromPackage` se relaciona con el catálogo agrupado). | `seedFromPackage` puede resucitar con #7. |
+| #                                               | Descripción                             | Decisión                                                                                                                                                                                                                                           | Razón                                                                                                                    |
+| ----------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| #14 (parte db)                                  | `deleted_at` no tipado; filtrado a mano | **fix-ahora (parcial)**: agregar `deleted_at?: string` a `SyncFields`. Filtro de `conv_inspeccion_items` se arregla en su consumidor (`cargarTablasConv`, Tier 3/4). Listas maestras → backlog con test-guard.                                     | Tipar el contrato es barato y lo hace visible; el resto necesita decisión de diseño mayor.                               |
+| v13 UpgradeError                                | Upgrade con datos brickea la app        | **backlog + guardia interina**: helper `detectResetRequired()` en `src/lib/db/` que reconoce el `UpgradeError`; `db-provider` muestra UI de "borrá datos locales y recargá" en vez del mensaje crudo. Test que fija el comportamiento de la sonda. | v13 ya está shippeado; los usuarios afectados ya migraron o ya están rotos. El valor es no repetirlo y dar recuperación. |
+| Seed no atómico                                 | seed interrumpido queda incompleto      | **aceptar + pin**: documentar la invariante #3, test que fija el comportamiento idempotente actual.                                                                                                                                                | Riesgo bajo (el seed es rápido y local); rediseñarlo a "versión de seed" es desproporcionado ahora.                      |
+| `SyncStatus` `"conflict"` muerto                | valor de enum sin uso                   | **backlog**: quitar en la limpieza del sync-engine (Tier 2).                                                                                                                                                                                       | Cambio trivial pero pertenece al módulo que lo dejó de usar.                                                             |
+| `resetAllLocalData` / `seedFromPackage` muertos | código sin caller                       | **backlog**: decidir en Tier 4 (`seedFromPackage` se relaciona con el catálogo agrupado).                                                                                                                                                          | `seedFromPackage` puede resucitar con #7.                                                                                |
 
 ## Apéndice C — Estado de salida (Fase 6)
 
-- [x] Doc completo (10 secciones)
-- [ ] Matriz de escenarios ejecutada
-- [ ] `deleted_at` en `SyncFields` + verify verde
-- [ ] `detectResetRequired()` + test de la sonda v13
-- [ ] Issues creados para los backlog
-- [ ] Cobertura `db/types.ts` ≥ umbral Tier 0
-- [ ] `npm run verify` limpio
+- [x] Doc completo (10 secciones) — `01-db.md`
+- [x] Matriz de escenarios enumerada — `01-db.scenarios.md` (26 escenarios)
+- [x] Escenarios ejecutados: 22 auto (`migrations`/`seed`/`deleted-at`/`env`/
+      `recovery`.test.ts + `db-provider.test.tsx`, 48 tests), 4 pin, 2 aceptar.
+- [ ] **Pendiente manual**: db-S09/S10 (multi-pestaña) — script en
+      `01-db.manual-S09-S10.md`, requiere entorno con la app corriendo.
+- [x] `deleted_at` en `SyncFields` (opcional, con invariante documentada)
+- [x] `needsLocalReset()` + `resetAndReopen()` + pantalla en `DbProvider` +
+      tests que fijan la sonda v13
+- [x] Issues de backlog creados: #34 (`deleted_at` listas maestras),
+      #35 (`SyncStatus."conflict"` muerto), #36 (código muerto
+      `resetAllLocalData`/`seedFromPackage`)
+- [ ] Cobertura `db/types.ts` ≥ umbral Tier 0 (subir el umbral al certificar
+      el Módulo 2 — el motor de permisos vive en ese archivo)
+- [x] `npm run verify` limpio (238 tests, 0 errores de lint, formato ok)
 - [ ] Sign-off del dueño

--- a/docs/modules/01-db.md
+++ b/docs/modules/01-db.md
@@ -1,0 +1,191 @@
+# Módulo: `src/lib/db/` — esquema local y tipos de dominio
+
+> Estado: 🟡 en curso (Tier 1) · Última actualización: 2026-08-28
+> Archivos: `index.ts` (esquema Dexie), `types.ts` (tipos + motor de permisos),
+> `seed.ts` (catálogos), `reset.ts` (limpieza). Tests: `permisos.test.ts`,
+> `sync-classification.test.ts` (Tier 0), `migrations.test.ts` (Tier 1, nuevo).
+
+---
+
+## 1. Responsabilidad
+
+`src/lib/db/` es la **única fuente de verdad del almacenamiento local**. Define:
+
+- El esquema de IndexedDB (`EyCDatabase extends Dexie`, nombre `"SievertEyC"`),
+  ~50 tablas, 15 versiones de migración.
+- Los tipos de dominio de toda la app (`Cliente`, `VisitaEjecucion`, …) y los
+  enums (`TIPOS_EQUIPO`, `RolUsuario`, `EstadoVisita`, `SyncStatus`, …).
+- El **motor de permisos**: `permisoDefault`, `accionesEfectivas`,
+  `resolverPermiso` + la matriz `PERMISOS_DEFAULT_MATRIZ`.
+- Los seeds de catálogo (`prueba_definiciones`, `rol_permisos`).
+
+Todo lo demás lee/escribe estas tablas y estos tipos. 56 archivos importan
+`@/lib/db`; 31 importan `@/lib/db/types`.
+
+## 2. API pública
+
+| Export | Firma | Efectos | Error | Idempotente |
+|---|---|---|---|---|
+| `db` | singleton `EyCDatabase` | abre IndexedDB al primer acceso / `db.open()` | `db.open()` **lanza** si la migración falla | — |
+| `permisoDefault(rol, modulo)` | → `AccionesPermiso` | ninguno (puro) | no lanza; módulo sin default → `SIN_ACCESO` | sí |
+| `accionesEfectivas(permiso?, rol, modulo)` | → `AccionesPermiso` | ninguno (puro) | no lanza | sí |
+| `resolverPermiso(permiso?, rol, modulo, accion="ver")` | → `boolean` | ninguno (puro) | no lanza | sí |
+| `seedRolPermisos()` | `Promise<void>` | escribe `rol_permisos` si está vacía | no lanza (salvo fallo Dexie) | **sí** (no-op si `count > 0`) |
+| `seedPruebaDefiniciones()` | `Promise<void>` | llama `seedRolPermisos`, luego escribe `prueba_definiciones` si vacía | idem | **sí** |
+| `seedFromPackage(pkg)` | `Promise<void>` | escribiría `grupo_pruebas` + defs enriquecidas | idem | sí — **pero nunca se invoca** (llamada comentada en `seedPruebaDefiniciones`) |
+| `resetAllLocalData()` | `Promise<void>` | `t.clear()` en TODAS las tablas (vacía contenido, conserva esquema) | no lanza | sí — **pero ningún archivo de `src/` lo llama** (solo uso manual por consola) |
+
+### ⚠️ Sutileza del motor de permisos (anclada en Tier 0)
+
+`resolverPermiso(undefined, rol, modulo, accion)` **siempre devuelve `false`**.
+`accionesEfectivas` lee `ver` como `permiso?.activo ?? false` — NO cae al default
+de la matriz para el bit "ver". En producción `hasPermission` solo funciona
+porque `seedRolPermisos()` materializó una fila `rol_permisos` por
+(rol × módulo). El helper de test `makeRole` sintetiza esa fila desde la matriz
+justamente por esto.
+
+## 3. Modelo de datos
+
+- **Tablas propias**: todas. Este módulo es dueño del *esquema*; los módulos de
+  workflow/captura son dueños de la *escritura de contenido*.
+- **`deleted_at`**: **NO está declarado en `types.ts`**. No está en `SyncFields`
+  ni en ninguna interfaz de tabla maestra (`Cliente`, `Sede`, `Equipo`,
+  `VisitaEjecucion`, …). Solo aparece en `@/lib/equipos/convencional/db/types.ts`
+  (tablas `conv_*`). Lo escribe `deleteAndSync` (sync-engine) sobre *cualquier*
+  tabla; lo filtran a mano solo los consumidores `conv_*` (grupo-a..e, PDF,
+  evaluacion). → **Hallazgo #14** (ver Apéndice B).
+- **`last_modified`**: lo setea quien escribe (form-dialogs, `updateAndSync`,
+  state-machine) con `new Date().toISOString()` — reloj del **cliente**. El
+  esquema no lo genera ni valida. → alimenta el hallazgo #5 (sync).
+- **Índices `sync_status`**: presentes en las tablas bidireccionales desde v5
+  (maestras) / v13 (`conv_*`) / v14 (`equipo_movimientos`). Las maestras
+  descargables (`departamentos`, `municipios`, `usuarios`, `prueba_definiciones`,
+  …) **no** tienen índice `sync_status` — por eso el sync-engine envuelve en
+  try/catch la lectura `.where("sync_status")` sobre ellas.
+- **Clases de tabla para sync**: definidas en `sync-engine.ts` (`SYNC_TABLES` /
+  `MASTER_TABLES`), verificadas por `sync-classification.test.ts`. `sync_meta`,
+  `sync_retry`, `change_logs` y `elementos_proteccion` son local-only (el último
+  por deuda, no por diseño — ver Tier 5).
+
+## 4. Flujo de control
+
+### Apertura y migración (al iniciar la app)
+
+1. `DbProvider` (cliente) monta → `await db.open()`.
+2. Dexie compara la versión de la DB del navegador con la 15 declarada y corre
+   en orden las migraciones que falten.
+3. `DbProvider` verifica a mano que exista el índice `sync_status` en `clientes`
+   (proxy de "migró al menos hasta v5"). Si no → `needsReload = true`.
+4. `await seedPruebaDefiniciones()` → `seedRolPermisos()` + catálogo genérico
+   (ambos no-op si ya hay datos).
+5. `isReady = true`. Si algo lanzó → `error` state (mensaje crudo).
+
+### Migraciones con transformación de datos
+
+Solo **v4** transforma datos: dropea `tecnicos` (`tecnicos: null`), crea
+`usuarios`, y en `.upgrade()` copia fila por fila remapeando `cargo`
+(`fisico_tecnico|ingeniero|tecnologo` → `tecnico`).
+
+El resto son aditivas (tablas/índices nuevos) **excepto v13**.
+
+### v13 — cambio de clave primaria (el punto delicado)
+
+v13 cambia ~30 tablas de `++id` (auto-increment numérico) a `id` (string UUID
+generado en cliente). `departamentos`/`municipios` NO se migran (IDs = códigos
+DANE). **v13 no tiene `.upgrade()`.**
+
+Comportamiento confirmado (Dexie 4.4.2, sonda ejecutada):
+
+- **Instalación nueva / DB vacía → v15**: funciona. Todas las tablas quedan con
+  PK `id` string. Es el camino común.
+- **Upgrade desde una versión previa CON datos**: `db.open()` **lanza**
+  `UpgradeError: Not yet support for changing primary key`. Los datos no se
+  borran, pero **la base no abre** → `DbProvider` cae al `error` state con el
+  mensaje crudo. La app queda inutilizable para ese usuario hasta que borre el
+  IndexedDB del navegador a mano. No hay guardia ni UI de recuperación.
+
+## 5. Comportamiento offline / online
+
+- 100% offline: apertura, migración, seeds, lecturas, escrituras. El módulo no
+  toca la red.
+- Encola para push: nada directamente — este módulo define el esquema; el
+  encolado lo hacen los escritores (`sync_status: "pending"`).
+- Exige red: nada.
+- Al reconectar: nada propio.
+
+## 6. Interacción con sync
+
+- El módulo no sincroniza. Aporta: los índices `sync_status` que el sync-engine
+  necesita para seleccionar pendientes, y los tipos que `prepareForRemote`
+  recorta.
+- `SyncStatus` incluye `"conflict"` como valor legal del tipo, pero desde el
+  PR #31 el sync-engine ya no lo escribe (deja las filas en `"pending"`). El
+  valor sigue en el enum → candidato a limpieza (Apéndice B).
+
+## 7. Rol / permisos
+
+- El módulo **define** el motor de permisos pero no chequea nada él mismo.
+- `role-provider.tsx` consume `resolverPermiso`; `seedRolPermisos` materializa la
+  matriz. La UI de Configuración edita `rol_permisos` en vivo.
+- `rol_permisos` es `MASTER_TABLE` (download-only en sync) → la persistencia
+  remota de cambios de permisos depende de `persistirPermisoRemoto` (fuera de
+  este módulo).
+
+## 8. Invariantes y supuestos
+
+1. **La DB del cliente arranca vacía en la primera carga post-v13.** Si no, la
+   app no abre (ver §4). Contrato operativo, sin refuerzo en código.
+2. `crypto.randomUUID()` disponible (contexto seguro / HTTPS o localhost).
+3. `seedRolPermisos` / `seedPruebaDefiniciones` son idempotentes por el chequeo
+   `count > 0` — asumen que "hay ≥1 fila" ⇒ "el seed completo corrió". Un seed
+   interrumpido a la mitad queda permanentemente incompleto.
+4. El catálogo **agrupado** (`grupo_pruebas`) nunca se siembra
+   (`seedFromPackage` comentado) → las visitas no pueden auto-generar
+   `grupo_resultados`/`prueba_resultados` por el camino agrupado. Conecta con
+   hallazgos #6/#7 (Tier 4).
+5. `deleted_at` es un contrato no tipado (§3).
+
+## 9. Modos de falla conocidos
+
+| Falla | Efecto | Manejo actual |
+|---|---|---|
+| Upgrade v13 con datos | `db.open()` lanza `UpgradeError` | `DbProvider` → `error` state, mensaje crudo. Sin recuperación. |
+| `randomUUID` no disponible (contexto inseguro) | seeds y escrituras lanzan | `DbProvider` → `error` state |
+| Seed interrumpido | catálogo/permisos incompletos para siempre | ninguno (el `count > 0` lo da por completo) |
+| Otra pestaña con versión más nueva | `blocked` / `versionchange` | `window.location.reload()` |
+| `db.table("sync_status")` sobre tabla maestra | Dexie lanza | sync-engine lo captura y loguea (esperado) |
+
+## 10. Preguntas abiertas / smells
+
+- ¿Vale una UI de recuperación para el `UpgradeError` de v13 (botón "borrar datos
+  locales y recargar")? El código de detección podría vivir acá y `db-provider`
+  llamarlo.
+- `resetAllLocalData` y `seedFromPackage` son código muerto — ¿borrar o cablear?
+- `SyncStatus` conserva `"conflict"` sin uso.
+- El chequeo de "DB migrada" en `db-provider` mira el índice de v5, no el de v13
+  ni v15 — no detecta una DB parada entre v5 y v13.
+- `deleted_at` debería estar en `SyncFields` para que el contrato sea tipado y
+  grepeable.
+
+---
+
+## Apéndice B — Log de decisiones (triage de hallazgos)
+
+| # | Descripción | Decisión | Razón |
+|---|---|---|---|
+| #14 (parte db) | `deleted_at` no tipado; filtrado a mano | **fix-ahora (parcial)**: agregar `deleted_at?: string` a `SyncFields`. Filtro de `conv_inspeccion_items` se arregla en su consumidor (`cargarTablasConv`, Tier 3/4). Listas maestras → backlog con test-guard. | Tipar el contrato es barato y lo hace visible; el resto necesita decisión de diseño mayor. |
+| v13 UpgradeError | Upgrade con datos brickea la app | **backlog + guardia interina**: helper `detectResetRequired()` en `src/lib/db/` que reconoce el `UpgradeError`; `db-provider` muestra UI de "borrá datos locales y recargá" en vez del mensaje crudo. Test que fija el comportamiento de la sonda. | v13 ya está shippeado; los usuarios afectados ya migraron o ya están rotos. El valor es no repetirlo y dar recuperación. |
+| Seed no atómico | seed interrumpido queda incompleto | **aceptar + pin**: documentar la invariante #3, test que fija el comportamiento idempotente actual. | Riesgo bajo (el seed es rápido y local); rediseñarlo a "versión de seed" es desproporcionado ahora. |
+| `SyncStatus` `"conflict"` muerto | valor de enum sin uso | **backlog**: quitar en la limpieza del sync-engine (Tier 2). | Cambio trivial pero pertenece al módulo que lo dejó de usar. |
+| `resetAllLocalData` / `seedFromPackage` muertos | código sin caller | **backlog**: decidir en Tier 4 (`seedFromPackage` se relaciona con el catálogo agrupado). | `seedFromPackage` puede resucitar con #7. |
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc completo (10 secciones)
+- [ ] Matriz de escenarios ejecutada
+- [ ] `deleted_at` en `SyncFields` + verify verde
+- [ ] `detectResetRequired()` + test de la sonda v13
+- [ ] Issues creados para los backlog
+- [ ] Cobertura `db/types.ts` ≥ umbral Tier 0
+- [ ] `npm run verify` limpio
+- [ ] Sign-off del dueño

--- a/docs/modules/01-db.scenarios.md
+++ b/docs/modules/01-db.scenarios.md
@@ -1,0 +1,79 @@
+# Módulo `src/lib/db/` — Matriz de escenarios (Fase 2)
+
+Estado por escenario: **auto** = cubierto por test automático · **manual** =
+requiere navegador real · **pin** = test que fija el comportamiento actual
+(aunque sea imperfecto) para que no cambie en silencio.
+
+El motor de permisos (`types.ts`) se enumera aparte en el Módulo 2.
+
+---
+
+## A — Migraciones de esquema
+
+| ID     | Escenario                                                                      | Esperado                                                              | Estado                                                                                                                                                         |
+| ------ | ------------------------------------------------------------------------------ | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| db-S01 | Instalación nueva (DB inexistente) → `db.open()`                               | Abre en v15; todas las tablas presentes                               | auto (`migrations.test.ts`)                                                                                                                                    |
+| db-S02 | Tablas de dominio tras migrar                                                  | PK = `id` string, `auto=false` (no `++id`)                            | auto                                                                                                                                                           |
+| db-S03 | `departamentos` / `municipios`                                                 | PK numérica (código DANE), no migran                                  | auto                                                                                                                                                           |
+| db-S04 | Tablas bidireccionales                                                         | tienen índice `sync_status`                                           | auto                                                                                                                                                           |
+| db-S05 | Upgrade `++id → id` (v13) con **DB vacía**                                     | Migra sin error                                                       | auto                                                                                                                                                           |
+| db-S06 | Upgrade `++id → id` (v13) con **datos** y sin `.upgrade()`                     | `db.open()` lanza `UpgradeError` — la app no abre                     | auto (pin)                                                                                                                                                     |
+| db-S07 | v4: `tecnicos` → `usuarios` con remapeo de `cargo`                             | `fisico_tecnico\|ingeniero\|tecnologo` → `tecnico`; resto se conserva | **aceptar** — migración v1→v3, shippeada hace tiempo, sin usuarios en ese rango; la lógica de remapeo está inline en el constructor (extraerla sería refactor) |
+| db-S08 | v14/v15 aditivas (índice `equipo_movimientos.sync_status`, tabla `sync_retry`) | Migran sin tocar datos existentes                                     | auto (`migrations.test.ts`)                                                                                                                                    |
+| db-S09 | Otra pestaña abre una versión más nueva                                        | pestaña vieja: `versionchange` → `db.close()` + `reload()`            | manual (2 pestañas)                                                                                                                                            |
+| db-S10 | Pestaña vieja bloquea el upgrade de otra                                       | `blocked` → `reload()`                                                | manual (2 pestañas)                                                                                                                                            |
+
+## B — Seed de catálogos
+
+| ID     | Escenario                                                     | Esperado                                                                                                        | Estado                                          |
+| ------ | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| db-S11 | Primera carga, DB vacía                                       | `seedRolPermisos` escribe 4 roles × 9 módulos = 36 filas; `seedPruebaDefiniciones` escribe el catálogo genérico | auto (nuevo)                                    |
+| db-S12 | Segunda carga (ya sembrado)                                   | Ambos seeds son no-op (`count > 0`) — no duplican                                                               | auto (nuevo)                                    |
+| db-S13 | `rol_permisos` con 1 fila, resto faltante (seed interrumpido) | `seedRolPermisos` **no completa** — se queda como está (guard `count > 0`)                                      | auto (pin — comportamiento imperfecto conocido) |
+| db-S14 | `prueba_definiciones` vacía pero `rol_permisos` ya poblada    | `seedPruebaDefiniciones` siembra pruebas; `seedRolPermisos` interno es no-op                                    | auto (nuevo)                                    |
+| db-S15 | `grupo_pruebas` (catálogo agrupado)                           | **nunca se siembra** (`seedFromPackage` comentado) → queda vacío                                                | auto (pin — conecta con #6/#7 Tier 4)           |
+
+## C — Invariante `deleted_at`
+
+| ID     | Escenario                                                 | Esperado (comportamiento ACTUAL)                    | Estado                                  |
+| ------ | --------------------------------------------------------- | --------------------------------------------------- | --------------------------------------- |
+| db-S16 | `db.clientes.toArray()` con una fila `deleted_at` seteado | **La devuelve** (no se filtra) — bug latente #14    | auto (pin)                              |
+| db-S17 | Query de tabla `conv_*` filtrada por su consumidor        | Excluye `deleted_at` (los grupos lo filtran a mano) | (se verifica en Tier 3/4, consumidores) |
+| db-S18 | `deleted_at` está en el tipo `SyncFields`                 | Sí, opcional (arreglado en este PR)                 | auto                                    |
+
+## D — Recuperación ante migración imposible
+
+| ID      | Escenario                                             | Esperado                                                                                       | Estado                        |
+| ------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------- |
+| db-S19  | `db.open()` lanza `UpgradeError` real (v13 con datos) | `needsLocalReset(err) === true`                                                                | auto (`recovery.test.ts`)     |
+| db-S20  | Error con `name` `UpgradeError` / `VersionError`      | `needsLocalReset === true`                                                                     | auto                          |
+| db-S21  | Error de cuota / red / `undefined` / string           | `needsLocalReset === false` (no borra datos por un error ajeno)                                | auto                          |
+| db-S22  | `resetAndReopen()`                                    | Borra IndexedDB, reabre vacío en v15, `db.isOpen()`                                            | auto                          |
+| db-S23  | `DbProvider` recibe un `UpgradeError` al iniciar      | Renderiza la pantalla "Borrar datos locales y recargar" (no el mensaje crudo ni `error` state) | auto (`db-provider.test.tsx`) |
+| db-S24  | Click en "Borrar datos locales y recargar"            | Llama `resetAndReopen()`, luego `window.location.reload()`                                     | auto (`db-provider.test.tsx`) |
+| db-S23b | `DbProvider` recibe un error ajeno (cuota, etc.)      | NO muestra la pantalla de reset                                                                | auto                          |
+
+## E — Entorno
+
+| ID     | Escenario                                                                 | Esperado                                                                                                      | Estado                   |
+| ------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| db-S25 | `crypto.randomUUID` no disponible (contexto inseguro / HTTP no-localhost) | `randomUUID()` lanza → seeds/escrituras fallan → `DbProvider` cae a `error` state (NO a la pantalla de reset) | auto (nuevo — se simula) |
+| db-S26 | `db.on("blocked")` sin `window` (SSR / test)                              | No hace `reload()` (guard `typeof window !== "undefined"`)                                                    | auto (nuevo)             |
+
+---
+
+## Resumen de cobertura
+
+- **auto**: db-S01..06, S08, S11..16, S18..25, S23b → tests en
+  `migrations.test.ts`, `recovery.test.ts`, `seed.test.ts`,
+  `deleted-at.test.ts`, `env.test.ts`, `db-provider.test.tsx`.
+  (45 tests en `src/lib/db/` + 3 en `db-provider.test.tsx`.)
+- **pin** (fija comportamiento imperfecto para que no cambie en silencio):
+  S06 (v13 brickea), S13 (seed no atómico), S15 (`grupo_pruebas` sin sembrar),
+  S16 (listas maestras no filtran `deleted_at`).
+- **aceptar**: S07 (migración v4 vieja), S26 (guard `typeof window`, por
+  inspección).
+- **manual — pendiente de ejecución** (requiere 2 pestañas reales, no
+  automatizable con fake-indexeddb): **S09, S10** — ver
+  `01-db.manual-S09-S10.md`.
+- **diferido a consumidores** (Tier 3/4): S17.

--- a/docs/modules/02-permisos.md
+++ b/docs/modules/02-permisos.md
@@ -1,0 +1,133 @@
+# Módulo: motor de permisos (`src/lib/db/types.ts`)
+
+> Estado: 🟡 en curso (Tier 1 · pasada ligera) · 2026-08-28
+> Ya bien cubierto por `src/lib/db/permisos.test.ts` (3 bloques, ~30 asserts).
+> Esta pasada: doc + pin de la matriz completa + subir umbral de cobertura.
+
+---
+
+## 1. Responsabilidad
+
+Es la **única fuente de verdad de "¿este rol puede hacer esta acción sobre
+este módulo?"**. Tres funciones puras + una matriz de defaults, todo en
+`src/lib/db/types.ts`. No toca la base ni la red.
+
+- **Roles** (`RolUsuario` / `ROLES_DISPONIBLES`): `coordinador`, `programador`,
+  `tecnico`, `comercial`.
+- **Módulos** (`MODULOS_APP` / `ModuloApp`): `dashboard`, `clientes`,
+  `solicitudes`, `visitas`, `revision`, `equipos`, `informes`, `sync`,
+  `configuracion`.
+- **Acciones** (`AccionPermiso`): `ver`, `crear`, `editar`, `eliminar`.
+
+## 2. API pública
+
+| Export                                                 | Firma               | Efectos                                                   | Error                                                      | Idempotente |
+| ------------------------------------------------------ | ------------------- | --------------------------------------------------------- | ---------------------------------------------------------- | ----------- |
+| `permisoDefault(rol, modulo)`                          | → `AccionesPermiso` | ninguno                                                   | no lanza; módulo sin entrada → `SIN_ACCESO` (todo `false`) | sí          |
+| `accionesEfectivas(permiso?, rol, modulo)`             | → `AccionesPermiso` | ninguno                                                   | no lanza                                                   | sí          |
+| `resolverPermiso(permiso?, rol, modulo, accion="ver")` | → `boolean`         | ninguno                                                   | no lanza                                                   | sí          |
+| `PERMISOS_DEFAULT_MATRIZ`                              | —                   | **no exportada** (privada); el acceso es `permisoDefault` | —                                                          | —           |
+
+### Semántica
+
+- `permisoDefault` → los presets de la matriz por rol/módulo. Presets:
+  `ACCESO_TOTAL` (CRUD), `SOLO_VER`, `GESTIONAR` (ver+crear+editar, sin
+  eliminar), `EJECUTAR` (ver+editar), `SIN_ACCESO`.
+- `accionesEfectivas(permiso, rol, modulo)` → los 4 bits "crudos" de un
+  registro `rol_permisos`:
+  - `ver` = `permiso?.activo ?? false` — **NO cae al default de la matriz**.
+  - `crear`/`editar`/`eliminar` = valor del registro, o el default del rol si
+    es `null`/`undefined` (datos previos a permisos granulares).
+  - Expone los overrides aunque `ver` esté en `false` (para que la UI de
+    Configuración no los pierda al apagar "ver").
+- `resolverPermiso` = `accionesEfectivas` + la regla **"sin `ver` no hay
+  ninguna acción"**. `accion` por defecto `"ver"`.
+
+## 3. Modelo de datos
+
+- No es dueño de ninguna tabla. Define el tipo `RolPermiso` y la matriz.
+- La tabla `rol_permisos` se siembra con `seedRolPermisos()` (Módulo 1):
+  36 filas = 4 roles × 9 módulos, materializando `PERMISOS_DEFAULT_MATRIZ`.
+- `rol_permisos` es `MASTER_TABLE` en sync (solo baja). Los cambios locales de
+  la UI de Configuración se replican a Supabase por `persistirPermisoRemoto`
+  (fuera de este módulo).
+
+## 4. Flujo de control
+
+`role-provider.hasPermission(modulo, accion)` (consumidor principal):
+
+1. `if (!role) return false` — sin rol activo, nada.
+2. Busca en la lista viva de `db.rol_permisos` la fila `(role.cargo, modulo)`.
+3. `resolverPermiso(fila, role.cargo, modulo, accion)`.
+
+## 5. Comportamiento offline / online
+
+- 100% puro y offline. `hasPermission` depende de la lista de `rol_permisos`
+  en Dexie, que se sembró/sincronizó antes.
+
+## 6. Interacción con sync
+
+- Ninguna directa. `rol_permisos` baja del servidor; los edits de la UI de
+  Configuración se persisten aparte.
+
+## 7. Rol / permisos
+
+- Es _el_ módulo de permisos.
+- **`isAdmin` NO pasa por acá**: `role-provider` lo calcula como
+  `role.cargo === "coordinador"`, hardcodeado. Un coordinador es admin aunque
+  se le editen los `rol_permisos`.
+
+## 8. Invariantes y supuestos
+
+1. **`resolverPermiso(undefined, …)` siempre da `false`.** Sin una fila
+   `rol_permisos` para `(rol, modulo)`, ese módulo es invisible. En producción
+   funciona solo porque `seedRolPermisos()` creó las 36 filas. Si la UI de
+   Configuración borrara una fila, o el seed no corrió, ese permiso cae a
+   `false` en silencio.
+2. La matriz `PERMISOS_DEFAULT_MATRIZ` asume que todo módulo listado en
+   `MODULOS_APP` tiene entrada para `coordinador` (los demás roles pueden
+   omitir módulos → `SIN_ACCESO`).
+3. `accionesEfectivas` asume que "no `ver`" es una decisión explícita del
+   registro, no un default.
+
+## 9. Modos de falla conocidos
+
+| Falla                                                              | Efecto                                                               | Manejo actual                                    |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------- | ------------------------------------------------ |
+| `rol_permisos` no sembrada / fila faltante                         | el módulo desaparece de la UI para ese rol                           | ninguno — `resolverPermiso(undefined)` → `false` |
+| Módulo nuevo en `MODULOS_APP` sin entrada en la matriz para un rol | ese rol no lo ve (por diseño `?? SIN_ACCESO`)                        | correcto, pero silencioso                        |
+| `accion` con string arbitrario                                     | TS lo previene; en runtime `efectivas[accion]` → `undefined` → falsy | aceptable                                        |
+
+## 10. Preguntas abiertas / smells
+
+- La asimetría de `ver` (no cae al default) vs `crear/editar/eliminar` (sí
+  caen) es sutil y ya nos mordió (helper `makeRole` de Tier 0). ¿Vale
+  documentarla en el JSDoc de `accionesEfectivas`?
+- `isAdmin` hardcodeado — si algún día se quiere un "coordinador junior", hay
+  que tocar `role-provider`, no la matriz.
+- `PERMISOS_DEFAULT_MATRIZ` privada: los tests la validan solo a través de
+  `permisoDefault`. Ok, pero un pin de la matriz completa (36×4) hace visible
+  cualquier cambio accidental.
+
+---
+
+## Apéndice B — Log de decisiones
+
+| #                                    | Descripción                      | Decisión                                                                                                                                      | Razón                                                                                                         |
+| ------------------------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `resolverPermiso(undefined)` → false | asimetría de `ver`               | **aceptar + pin + doc**: ya cubierto por `permisos.test.ts` ("sin registro, ninguna acción"); se agrega nota al JSDoc de `accionesEfectivas`. | Cambiar la semántica ahora rompería la UI de Configuración (que necesita distinguir "sin ver" de "sin fila"). |
+| Matriz sin pin completo              | spot-checks, no snapshot literal | **fix-ahora**: `permisos-matriz.test.ts` con las 144 decisiones explícitas.                                                                   | Barato y atrapa cualquier edición accidental de la matriz.                                                    |
+| `isAdmin` hardcodeado                | fuera del motor                  | **aceptar + doc**                                                                                                                             | Es una decisión de producto, no un bug.                                                                       |
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc completo
+- [x] Matriz de escenarios (rol × módulo × acción) — pin completo en
+      `permisos-matriz.test.ts` (144 celdas, 37 tests)
+- [x] Cobertura: `permisos.test.ts` + el pin cubren las 3 funciones y la matriz.
+      `types.ts` no lo mide v8 (archivo casi todo tipos) — cubierto de hecho.
+- [x] Umbrales de `vitest.config.ts` subidos (global 12→13; `src/lib/db/*`
+      con piso por archivo: `recovery.ts` 95, `seed.ts` 65, `index.ts` 63)
+- [x] JSDoc de `accionesEfectivas` documenta la asimetría de `ver`
+- [x] `npm run verify` limpio
+- [ ] Sign-off del dueño

--- a/docs/modules/03-auth.md
+++ b/docs/modules/03-auth.md
@@ -1,0 +1,195 @@
+# Módulo: Auth (`src/proxy.ts`, `src/lib/auth/`, `role-provider`, `/login`)
+
+> Estado: 🟡 en curso (Tier 1 · Módulo 3) · 2026-08-28
+> Archivos: `src/proxy.ts` (gate server-side), `src/lib/auth/session.ts` (nuevo —
+> helpers puros), `src/components/role-provider.tsx` (rol activo, cliente),
+> `src/app/login/page.tsx`. Tests: `proxy.test.ts`, `src/lib/auth/session.test.ts`.
+
+---
+
+## 1. Responsabilidad
+
+Responder dos preguntas, en dos capas:
+
+- **Servidor (`proxy.ts`)**: "¿hay una sesión válida?" — antes de renderizar
+  cualquier ruta `/dashboard/*`. Redirige a `/login` si no.
+- **Cliente (`role-provider`)**: "¿qué usuario y qué rol está activo?" — cruza la
+  sesión de Supabase con la fila `usuarios` de Dexie. Alimenta `hasPermission`
+  (Módulo 2).
+
+La autorización por módulo es **toda del lado del cliente**. El único chequeo de
+rol server-enforced es `/api/usuarios` (Tier 7). La barrera real de datos es
+**Row Level Security en Supabase** (a verificar en este módulo).
+
+## 2. Las tres capas de "offline"
+
+| Situación                                   | ¿Corre `proxy.ts`?                       | Quién sostiene la sesión                                                                                                          |
+| ------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Sin red total                               | **No** (el navegador no llega al server) | Service Worker sirve el HTML cacheado (que ya pasó por `proxy.ts` antes); `role-provider` resuelve rol desde Dexie + sesión local |
+| Con red, Supabase caído/lento (5xx/timeout) | Sí                                       | `proxy.ts` → chequeo de sesión local                                                                                              |
+| Todo online                                 | Sí                                       | `proxy.ts` valida contra Supabase                                                                                                 |
+
+`proxy.ts` solo importa para la fila del medio y para los parpadeos de conexión.
+
+## 3. Hallazgos (estado ANTES de este módulo)
+
+| #          | Qué                                                                                                                                                                                                                                                                                                                   | Severidad |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| #2         | El fallback offline decodifica el JWT y lee `exp` **sin verificar la firma**. Un `{alg:"none"}` + `exp` futuro pasa el gate cuando Supabase parece inalcanzable.                                                                                                                                                      | alta      |
+| #16        | supabase-js devuelve `{error}` (no lanza) para 5xx/429. `proxy.ts` trata _cualquier_ `{error}` como "sesión inválida" → `/login`. Un pico de carga de Supabase desloguea a todos.                                                                                                                                     | alta      |
+| #3 (nuevo) | El access token dura ~1h y no se puede refrescar offline. `hasValidSessionCookie` chequea `exp` con margen de 60s → un técnico >1h offline es mandado a `/login`, donde tampoco puede loguearse.                                                                                                                      | alta      |
+| #4 (nuevo) | `@supabase/ssr` 0.10.3 escribe el valor de la cookie como `base64-<base64url(JSON)>`. `hasValidSessionCookie` no quita ese prefijo → `JSON.parse` falla → `decodeJwtPayload` recibe `base64-…` → `parts.length !== 3` → devuelve `false`. **El fallback offline probablemente no funciona hoy para sesiones reales.** | alta      |
+
+## 4. Diseño (decidido con el dueño)
+
+**Opción A** (elegida): agregar `SUPABASE_JWT_SECRET` al entorno y **verificar la
+firma HS256 offline** con Web Crypto (Edge-compatible). **Gracia offline: 7 días.**
+
+### `proxy.ts` — clasificación en TRES, no en dos
+
+```
+try {
+  const { data, error } = await getUser()
+  if (!error)                          → user = data.user          // AUTENTICADO
+  else if (isAuthRejection(error))     → user = null               // RECHAZADO → /login
+  else                                 → indeterminado             // 5xx/429/desconocido
+} catch {                              → indeterminado             // excepción de red
+}
+
+if (!user && indeterminado) {
+  const s = readSupabaseSession(cookies)              // maneja base64- + chunks
+  const payload = s && verifyHS256(s.accessToken, JWT_SECRET)
+  if (payload && s.refreshToken) {
+    const expiradoHace = now - payload.exp
+    if (expiradoHace < 7 días)  → dejar pasar         // gracia offline
+  }
+}
+```
+
+- **`isAuthRejection(error)`**: `status` 401/403, o mensajes conocidos de
+  supabase-js (`invalid JWT`, `invalid claim`, `token is expired`,
+  `session_not_found`, `refresh_token_not_found`, `bad_jwt`). Todo lo demás →
+  indeterminado.
+- **`verifyHS256`**: `crypto.subtle.importKey('raw', secret, {name:'HMAC',
+hash:'SHA-256'}, false, ['verify'])` + `crypto.subtle.verify`. Devuelve el
+  payload solo si la firma valida. Un `alg:none` o firma incorrecta → `null`.
+- **Gracia**: se mide desde `payload.exp`. Un token válidamente firmado que
+  expiró hace menos de 7 días + con `refresh_token` presente = "tuvo sesión
+  real, no estuvo online para refrescar". Al volver la conexión, supabase-js
+  refresca solo.
+- Si `SUPABASE_JWT_SECRET` no está configurado: `proxy.ts` loguea un warning y
+  cae al comportamiento Opción B (barrera blanda + confianza en RLS) — no
+  rompe con un 500 en cada request.
+
+### Defensa en profundidad
+
+Verificar (fuera de código, con el dueño) que **RLS está activo en todas las
+tablas de Supabase**, para que un token falsificado que pase el gate offline no
+pueda leer ni escribir datos reales.
+
+## 5. Flujo de control (`proxy.ts`, implementado)
+
+1. Construye el cliente SSR de Supabase con las cookies de la request.
+2. `getUser()` — clasifica en tres:
+   - sin error → `user = data.user` (**autenticado**).
+   - error y `isAuthRejection(error)` → `user` queda `null` (**rechazo**).
+   - error y NO es rechazo (5xx/429/timeout/desconocido) → `indeterminado = true`.
+   - excepción (catch) → `indeterminado = true`.
+3. Si `!user && indeterminado` → `hasAcceptableLocalSession(cookies, secret)`:
+   - `readSupabaseSession` reconstruye `{ accessToken, refreshToken, expiresAt }`
+     (maneja `base64-` + chunks).
+   - **Con `SUPABASE_JWT_SECRET`**: `verifyHS256`; exige firma válida + `exp`
+     presente + `refreshToken` presente + `(now - exp) < 7 días`.
+   - **Sin el secreto**: warning (una vez) + acepta JWT bien formado y no
+     expirado (margen 60s). RLS es la barrera real.
+   - Si acepta → `return response` (pasa).
+4. `pathname.startsWith("/dashboard") && !user` → redirect a `/login?redirect=…`.
+5. `pathname === "/login" && user` → redirect a `/dashboard`.
+6. Si no, `return response`.
+
+## 6. Comportamiento offline / online
+
+| Estado                                                  | Resultado                                                              |
+| ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Online, sesión válida                                   | pasa (Supabase confirma)                                               |
+| Online, token expirado/revocado (Supabase responde 401) | → `/login`, **sin** fallback                                           |
+| Online, Supabase 5xx/429                                | indeterminado → sesión local: si firma OK y dentro de gracia → pasa    |
+| Sin red (excepción)                                     | indeterminado → igual que arriba                                       |
+| Sin red total                                           | `proxy.ts` no corre; SW sirve HTML cacheado                            |
+| >1h offline (access token expirado)                     | pasa si `(now - exp) < 7 días` y hay refresh token — la gracia offline |
+| >7 días offline                                         | → `/login` al volver la conexión                                       |
+
+## 7. Rol / permisos
+
+- `proxy.ts` NO chequea rol, solo "hay sesión". El rol lo resuelve
+  `role-provider` en el cliente (Módulo 2).
+- El `matcher` no excluye `/api/*`: esas rutas pasan por el gate pero, al no ser
+  `/dashboard` ni `/login`, devuelven `response` sin enforcement. El único
+  chequeo de rol server-side sigue siendo el que hace `/api/usuarios` internamente.
+
+## 8. Invariantes y supuestos
+
+1. `SUPABASE_JWT_SECRET` (si está) es el secreto HS256 correcto del proyecto. Un
+   secreto equivocado haría que TODA sesión offline falle la verificación → todos
+   a `/login` en cuanto Supabase tenga un hipo. **Verificar al configurarlo.**
+2. Supabase firma los JWT con HS256 (proyectos "classic"). Si el proyecto migra a
+   claves asimétricas (ES256/RS256 + JWKS), `verifyHS256` devuelve `null` para
+   todo y se cae a barrera blanda. → issue de seguimiento.
+3. La cookie de sesión contiene `refresh_token` cuando hay sesión real (lo pone
+   `@supabase/ssr`). Sin él, la gracia no aplica (evita aceptar un access token
+   suelto sin sesión detrás).
+4. RLS activo en Supabase (defensa en profundidad).
+
+## 9. Modos de falla conocidos
+
+| Falla                                           | Efecto                                     | Manejo                         |
+| ----------------------------------------------- | ------------------------------------------ | ------------------------------ |
+| `SUPABASE_JWT_SECRET` sin configurar            | gate offline no verifica firma             | warning + barrera blanda + RLS |
+| Secreto configurado mal                         | toda sesión offline → `/login`             | ninguno — verificar al setear  |
+| Proyecto Supabase con firma asimétrica          | idem anterior                              | → issue de seguimiento         |
+| Supabase 5xx sostenido + token dentro de gracia | el técnico sigue trabajando offline-first  | correcto (era el objetivo)     |
+| Reloj del servidor desfasado                    | la gracia se corre; con ±minutos es inocuo | aceptable                      |
+
+## 10. Preguntas abiertas
+
+- `role-provider` (cliente): `catch {}` vacío en `loadUser` (línea ~98). Offline
+  es esperado, pero conviene un `logger.debug`. → Tier 6.
+- `login/page.tsx`: `router.push` + `fullSync()` fire-and-forget. El race del
+  login inicial ya se atacó (getAuthenticatedUser retry). → verificar acá.
+- El `matcher` de `config` no excluye `/api/*` — las rutas API pasan por el gate
+  pero como no son `/dashboard` ni `/login`, simplemente devuelven `response`
+  (sin enforcement). Documentar.
+
+---
+
+## Apéndice B — Log de decisiones
+
+| #                                   | Descripción                    | Decisión                                                                                  | Razón                                                                                   |
+| ----------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| #2 firma sin verificar              | `alg:none` pasaba offline      | **fix-ahora**: `verifyHS256` con `SUPABASE_JWT_SECRET`. Test: `forgedAlgNone` → `/login`. | Cierra el bypass de raíz.                                                               |
+| #16 5xx desloguea                   | cualquier `{error}` → `/login` | **fix-ahora**: `isAuthRejection` clasifica; 5xx/429/timeout → indeterminado.              | Mantiene offline-first justo cuando el backend está frágil.                             |
+| #3 token expira offline             | >1h offline → `/login`         | **fix-ahora**: gracia de 7 días desde `exp` si hay refresh token.                         | El técnico no puede refrescar sin red; punir mid-visita es peor que el riesgo marginal. |
+| #4 cookie `base64-`                 | el parser viejo no la entendía | **fix-ahora**: `readSupabaseSession` quita el prefijo + arma chunks.                      | El fallback offline no funcionaba para sesiones reales.                                 |
+| Firma asimétrica                    | `verifyHS256` solo HS256       | **backlog**: issue de seguimiento; hoy el proyecto es HS256.                              | —                                                                                       |
+| `role-provider` catch vacío         | offline esperado, sin log      | **backlog Tier 6**                                                                        | Es cliente, no `proxy.ts`.                                                              |
+| `/api/*` sin enforcement en el gate | documentado en §7              | **aceptar** — `/api/usuarios` valida rol internamente                                     | El gate es de _sesión_, no de rol.                                                      |
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc completo (10 secciones)
+- [x] `SUPABASE_JWT_SECRET` en `env.ts` (opcional) + `.env.example` (nuevo) +
+      placeholder en `.env.local` — **el dueño debe pegar el valor real**
+      (Supabase → Settings → API → JWT Secret) en `.env.local` y en Vercel.
+- [x] `src/lib/auth/session.ts` + `session.test.ts` (17 tests): `verifyHS256`,
+      `readSupabaseSession`, `isAuthRejection`, `decodeJwtPayload`,
+      `SESSION_GRACE_MS`
+- [x] `proxy.ts` reescrito — clasificación en 3 + gracia 7 días + degradación
+      sin secreto
+- [x] `proxy.test.ts` — matriz completa (26 casos: respuesta Supabase × estado
+      cookie × con/sin secreto + rutas)
+- [ ] **Pendiente dueño**: pegar el `SUPABASE_JWT_SECRET` real (local + Vercel)
+- [ ] **Pendiente dueño**: confirmar que RLS está activo en todas las tablas de
+      Supabase (defensa en profundidad)
+- [ ] Issue de seguimiento: firma asimétrica
+- [x] `npm run verify` limpio (314 tests)
+- [ ] Sign-off del dueño

--- a/docs/modules/_MANUAL-TEST-TEMPLATE.md
+++ b/docs/modules/_MANUAL-TEST-TEMPLATE.md
@@ -11,17 +11,17 @@
 
 ## Pasos y resultado esperado
 
-| # | Paso (acción UI) | Esperado UI | Esperado Dexie (`SievertEyC`) | Esperado servidor (Supabase) |
-|---|---|---|---|---|
-| 1 | | | fila `<tabla>#<id>`: `<estado>` / `sync_status=<>` | fila coincide con local / n/a offline |
-| 2 | | | | |
+| #   | Paso (acción UI) | Esperado UI | Esperado Dexie (`SievertEyC`)                      | Esperado servidor (Supabase)          |
+| --- | ---------------- | ----------- | -------------------------------------------------- | ------------------------------------- |
+| 1   |                  |             | fila `<tabla>#<id>`: `<estado>` / `sync_status=<>` | fila coincide con local / n/a offline |
+| 2   |                  |             |                                                    |                                       |
 
 ## Resultado real
 
-| # | ¿Coincide? | Observación |
-|---|---|---|
-| 1 | ✅ / ❌ | |
-| 2 | | |
+| #   | ¿Coincide? | Observación |
+| --- | ---------- | ----------- |
+| 1   | ✅ / ❌    |             |
+| 2   |            |             |
 
 ## Veredicto
 

--- a/docs/modules/_MANUAL-TEST-TEMPLATE.md
+++ b/docs/modules/_MANUAL-TEST-TEMPLATE.md
@@ -1,0 +1,34 @@
+# Prueba manual: `<módulo>` — `<escenario ID>`
+
+> Ejecutado por: `<nombre>` · Fecha: `<fecha>` · Build/commit: `<sha>`
+
+## Precondiciones
+
+- Estado semilla: `<qué seed / reset se usó>`
+- Rol logueado: `<coordinador | programador | tecnico | comercial>`
+- DevTools → Network: `<Online | Offline | throttle>`
+- Perfil(es) de navegador: `<uno | dos perfiles para test de concurrencia>`
+
+## Pasos y resultado esperado
+
+| # | Paso (acción UI) | Esperado UI | Esperado Dexie (`SievertEyC`) | Esperado servidor (Supabase) |
+|---|---|---|---|---|
+| 1 | | | fila `<tabla>#<id>`: `<estado>` / `sync_status=<>` | fila coincide con local / n/a offline |
+| 2 | | | | |
+
+## Resultado real
+
+| # | ¿Coincide? | Observación |
+|---|---|---|
+| 1 | ✅ / ❌ | |
+| 2 | | |
+
+## Veredicto
+
+- [ ] Escenario pasa tal como se esperaba
+- [ ] Pasa con desviación menor (anotar arriba)
+- [ ] Falla → hallazgo `#<n>` (link al issue / test que lo reproduce)
+
+## Notas / evidencia
+
+`<capturas, dumps de IndexedDB, logs del logger, etc.>`

--- a/docs/modules/_TEMPLATE.md
+++ b/docs/modules/_TEMPLATE.md
@@ -1,0 +1,86 @@
+# Módulo: `<nombre>`
+
+> Estado: 🔴 sin certificar · 🟡 en curso · 🟢 certificado (Tier N)
+> Última actualización: `<fecha>` · Responsable: `<nombre>`
+
+Doc producido por el protocolo de intervención (ver
+`~/.claude/plans/en-dias-anteriores-he-cheerful-hopcroft.md`). Las 10 secciones
+son obligatorias. El apéndice "Log de decisiones" registra el triage de hallazgos.
+
+---
+
+## 1. Responsabilidad
+
+Un párrafo: de qué es este módulo la **única fuente de verdad**.
+
+## 2. API pública
+
+| Función / Export | Firma | Efectos | Convención de error | ¿Idempotente? |
+|---|---|---|---|---|
+| | | | throw / return `{ok:false}` / … | |
+
+## 3. Modelo de datos
+
+- **Tablas propias** (dueño de escritura):
+- **Dependencias solo-lectura**:
+- **`deleted_at`**: ¿se filtra en las lecturas? ¿dónde no?
+- **`last_modified`**: ¿quién lo setea y cuándo?
+- **Tablas Supabase involucradas** y su clase (`SYNC_TABLES` / `MASTER_TABLES` / local-only):
+
+## 4. Flujo de control
+
+Camino(s) principal(es) como secuencia numerada. Diagrama de estados si aplica.
+
+## 5. Comportamiento offline / online
+
+- Funciona 100% offline:
+- Encola para push:
+- Exige red:
+- Al reconectar:
+
+## 6. Interacción con sync
+
+- Qué writes encolan push:
+- Comportamiento de conflicto (hoy: local gana, silencioso):
+- Campos de watermark:
+
+## 7. Rol / permisos
+
+- Claves de permiso chequeadas:
+- ¿Chequeo cliente o server-enforced?
+- Qué ve un usuario sin permiso:
+
+## 8. Invariantes y supuestos
+
+- Ej: "asume exactamente un `informe` por visita", "asume reloj del dispositivo correcto", …
+
+## 9. Modos de falla conocidos
+
+- Falla → efecto → manejo actual (o falta de).
+
+## 10. Preguntas abiertas / smells
+
+- Alimenta el triage de la Fase 5.
+
+---
+
+## Apéndice A — Matriz de escenarios
+
+Ver `docs/modules/<nombre>.scenarios.md` (o inline si son pocos).
+
+## Apéndice B — Log de decisiones (triage de hallazgos)
+
+| # Hallazgo | Descripción | Decisión | Razón | Sign-off |
+|---|---|---|---|---|
+| | | fix-ahora / backlog / aceptar | | |
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [ ] Doc completo (10 secciones)
+- [ ] Matriz de escenarios 100% ejecutada, resultados commiteados
+- [ ] Hallazgos fix-ahora cerrados con test verde
+- [ ] Hallazgos backlog con issue + test que reproduce
+- [ ] Cobertura del módulo ≥ umbral (pure-logic 90% / resto 80%)
+- [ ] `npm run verify` limpio
+- [ ] Sin `eslint-disable` nuevo sin justificación
+- [ ] Sign-off del dueño

--- a/docs/modules/_TEMPLATE.md
+++ b/docs/modules/_TEMPLATE.md
@@ -15,9 +15,9 @@ Un párrafo: de qué es este módulo la **única fuente de verdad**.
 
 ## 2. API pública
 
-| Función / Export | Firma | Efectos | Convención de error | ¿Idempotente? |
-|---|---|---|---|---|
-| | | | throw / return `{ok:false}` / … | |
+| Función / Export | Firma | Efectos | Convención de error             | ¿Idempotente? |
+| ---------------- | ----- | ------- | ------------------------------- | ------------- |
+|                  |       |         | throw / return `{ok:false}` / … |               |
 
 ## 3. Modelo de datos
 
@@ -70,9 +70,9 @@ Ver `docs/modules/<nombre>.scenarios.md` (o inline si son pocos).
 
 ## Apéndice B — Log de decisiones (triage de hallazgos)
 
-| # Hallazgo | Descripción | Decisión | Razón | Sign-off |
-|---|---|---|---|---|
-| | | fix-ahora / backlog / aceptar | | |
+| # Hallazgo | Descripción | Decisión                      | Razón | Sign-off |
+| ---------- | ----------- | ----------------------------- | ----- | -------- |
+|            |             | fix-ahora / backlog / aceptar |       |          |
 
 ## Apéndice C — Estado de salida (Fase 6)
 

--- a/src/components/db-provider.test.tsx
+++ b/src/components/db-provider.test.tsx
@@ -1,0 +1,90 @@
+// Escenarios db-S23 / db-S24: ante un UpgradeError al iniciar, DbProvider
+// muestra la pantalla "Borrar datos locales y recargar" (no el mensaje crudo),
+// y el botón dispara resetAndReopen() + reload().
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const open = vi.fn();
+const resetAndReopen = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/lib/db", () => ({ db: { open: () => open(), backendDB: () => null } }));
+vi.mock("@/lib/db/seed", () => ({ seedPruebaDefiniciones: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/hooks/use-auto-sync", () => ({ useAutoSync: vi.fn() }));
+vi.mock("@/lib/db/recovery", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/db/recovery")>();
+  return { ...actual, resetAndReopen: () => resetAndReopen() };
+});
+
+import { DbProvider } from "./db-provider";
+
+function upgradeError() {
+  const e = new Error("Not yet support for changing primary key");
+  e.name = "UpgradeError";
+  return e;
+}
+
+describe("DbProvider — recuperación ante migración imposible", () => {
+  beforeEach(() => {
+    open.mockReset();
+    resetAndReopen.mockClear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("db-S23: UpgradeError → pantalla de reset, no mensaje crudo", async () => {
+    open.mockRejectedValue(upgradeError());
+
+    render(
+      <DbProvider>
+        <div>contenido app</div>
+      </DbProvider>
+    );
+
+    expect(await screen.findByText(/Hay que actualizar los datos locales/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Borrar datos locales y recargar/i })
+    ).toBeInTheDocument();
+    // No debe mostrar el string crudo de Dexie
+    expect(screen.queryByText(/changing primary key/i)).not.toBeInTheDocument();
+    // Y no renderiza los children
+    expect(screen.queryByText("contenido app")).not.toBeInTheDocument();
+  });
+
+  it("db-S24: el botón dispara resetAndReopen()", async () => {
+    open.mockRejectedValue(upgradeError());
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    render(
+      <DbProvider>
+        <div>x</div>
+      </DbProvider>
+    );
+
+    const btn = await screen.findByRole("button", { name: /Borrar datos locales y recargar/i });
+    await userEvent.click(btn);
+
+    await waitFor(() => expect(resetAndReopen).toHaveBeenCalledOnce());
+    await waitFor(() => expect(reload).toHaveBeenCalled());
+  });
+
+  it("un error ajeno (no UpgradeError) NO muestra la pantalla de reset", async () => {
+    open.mockRejectedValue(new Error("QuotaExceededError"));
+
+    render(
+      <DbProvider>
+        <div>y</div>
+      </DbProvider>
+    );
+
+    // Cae al comportamiento previo: no hay pantalla de reset. Los children
+    // se renderizan (isReady queda false pero el provider no bloquea salvo
+    // needsReload/needsReset).
+    await waitFor(() => expect(open).toHaveBeenCalled());
+    expect(screen.queryByText(/Borrar datos locales y recargar/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/db-provider.tsx
+++ b/src/components/db-provider.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, createContext, useContext } from "react";
 import { db } from "@/lib/db";
 import { seedPruebaDefiniciones } from "@/lib/db/seed";
+import { needsLocalReset, resetAndReopen } from "@/lib/db/recovery";
 import { useAutoSync } from "@/hooks/use-auto-sync";
 
 interface DbContextValue {
@@ -31,6 +32,10 @@ export function DbProvider({ children }: { children: React.ReactNode }) {
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [needsReload, setNeedsReload] = useState(false);
+  // La migración de esquema no se puede aplicar sobre la DB local existente
+  // (típico: v13, cambio de PK a UUID sobre una DB con datos previos).
+  const [needsReset, setNeedsReset] = useState(false);
+  const [resetting, setResetting] = useState(false);
 
   // Auto-sync: push pendientes cada 5 min + al recuperar conexión
   useAutoSync();
@@ -56,12 +61,60 @@ export function DbProvider({ children }: { children: React.ReactNode }) {
         setIsReady(true);
       } catch (err) {
         console.error("[DbProvider] Error al inicializar DB:", err);
+        if (needsLocalReset(err)) {
+          // db.open() no pudo migrar el esquema local. El único arreglo es
+          // borrar el IndexedDB y re-sincronizar desde el servidor.
+          setNeedsReset(true);
+          return;
+        }
         setError(err instanceof Error ? err.message : "Error desconocido en la DB");
       }
     }
 
     initDb();
   }, []);
+
+  if (needsReset) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 p-8 text-center">
+        <div className="bg-amber-100 p-4 rounded-2xl">
+          <svg
+            className="w-10 h-10 text-amber-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </div>
+        <h2 className="text-xl font-black text-slate-900">Hay que actualizar los datos locales</h2>
+        <p className="text-slate-500 font-medium max-w-md">
+          Esta versión de la aplicación cambió la forma de guardar los datos y no puede migrar los
+          que ya tenés en este dispositivo. Se van a borrar los datos locales y volver a descargar
+          del servidor. Asegurate de haber sincronizado antes de continuar.
+        </p>
+        <button
+          className="mt-2 px-6 py-3 bg-primary text-white font-black rounded-xl hover:bg-primary/90 transition-colors disabled:opacity-60"
+          disabled={resetting}
+          onClick={async () => {
+            setResetting(true);
+            try {
+              await resetAndReopen();
+            } finally {
+              window.location.reload();
+            }
+          }}
+        >
+          {resetting ? "Borrando…" : "Borrar datos locales y recargar"}
+        </button>
+      </div>
+    );
+  }
 
   if (needsReload) {
     return (

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  decodeJwtPayload,
+  verifyHS256,
+  readSupabaseSession,
+  isAuthRejection,
+  SESSION_GRACE_MS,
+} from "./session";
+
+// ─── helpers de test: firmar un JWT HS256 de verdad ───
+
+function b64url(bytes: Uint8Array | string): string {
+  const arr = typeof bytes === "string" ? new TextEncoder().encode(bytes) : bytes;
+  let bin = "";
+  for (const b of arr) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function signHS256(payload: Record<string, unknown>, secret: string): Promise<string> {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = b64url(JSON.stringify(payload));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${header}.${body}`))
+  );
+  return `${header}.${body}.${b64url(sig)}`;
+}
+
+function jwtAlgNone(payload: Record<string, unknown>): string {
+  return `${b64url(JSON.stringify({ alg: "none", typ: "JWT" }))}.${b64url(
+    JSON.stringify(payload)
+  )}.forjada`;
+}
+
+const SECRET = "super-secret-jwt-signing-key-for-tests";
+const future = Math.floor(Date.now() / 1000) + 3600;
+
+// ─── decodeJwtPayload ───
+
+describe("decodeJwtPayload", () => {
+  it("lee el payload sin verificar firma", async () => {
+    const token = await signHS256({ sub: "u1", exp: future }, SECRET);
+    expect(decodeJwtPayload(token)).toMatchObject({ sub: "u1", exp: future });
+  });
+  it("null si no tiene 3 segmentos", () => {
+    expect(decodeJwtPayload("a.b")).toBeNull();
+    expect(decodeJwtPayload("basura")).toBeNull();
+  });
+});
+
+// ─── verifyHS256 ───
+
+describe("verifyHS256", () => {
+  it("devuelve el payload si la firma valida", async () => {
+    const token = await signHS256({ sub: "u1", exp: future }, SECRET);
+    expect(await verifyHS256(token, SECRET)).toMatchObject({ sub: "u1" });
+  });
+
+  it("null si la firma es de otro secreto", async () => {
+    const token = await signHS256({ sub: "u1", exp: future }, SECRET);
+    expect(await verifyHS256(token, "otro-secreto")).toBeNull();
+  });
+
+  it("null para alg:none (el ataque del bug #2)", async () => {
+    expect(await verifyHS256(jwtAlgNone({ sub: "atacante", exp: future }), SECRET)).toBeNull();
+  });
+
+  it("null si el secreto está vacío o el token es basura", async () => {
+    expect(await verifyHS256("x.y.z", SECRET)).toBeNull();
+    const token = await signHS256({ sub: "u1" }, SECRET);
+    expect(await verifyHS256(token, "")).toBeNull();
+  });
+});
+
+// ─── readSupabaseSession ───
+
+describe("readSupabaseSession", () => {
+  const mkCookie = (name: string, value: string) => ({ name, value });
+
+  it("formato base64- (el real de @supabase/ssr)", () => {
+    const session = { access_token: "AT", refresh_token: "RT", expires_at: 123 };
+    const encoded = "base64-" + b64url(JSON.stringify(session));
+    const s = readSupabaseSession([mkCookie("sb-abc-auth-token", encoded)]);
+    expect(s).toEqual({ accessToken: "AT", refreshToken: "RT", expiresAt: 123 });
+  });
+
+  it("JSON plano (sin prefijo)", () => {
+    const s = readSupabaseSession([
+      mkCookie("sb-abc-auth-token", JSON.stringify({ access_token: "AT", refresh_token: "RT" })),
+    ]);
+    expect(s).toEqual({ accessToken: "AT", refreshToken: "RT", expiresAt: null });
+  });
+
+  it("cookie fragmentada en chunks .0 .1", () => {
+    const json = JSON.stringify({ access_token: "AAAA", refresh_token: "RRRR" });
+    const encoded = "base64-" + b64url(json);
+    const mid = Math.ceil(encoded.length / 2);
+    const s = readSupabaseSession([
+      mkCookie("sb-abc-auth-token.1", encoded.slice(mid)),
+      mkCookie("sb-abc-auth-token.0", encoded.slice(0, mid)),
+    ]);
+    expect(s?.accessToken).toBe("AAAA");
+  });
+
+  it("formato viejo: el valor ES el JWT", () => {
+    const s = readSupabaseSession([mkCookie("sb-abc-auth-token", "header.payload.sig")]);
+    expect(s).toEqual({ accessToken: "header.payload.sig", refreshToken: null, expiresAt: null });
+  });
+
+  it("null si no hay cookie de sesión", () => {
+    expect(readSupabaseSession([mkCookie("otra", "x")])).toBeNull();
+    expect(readSupabaseSession([])).toBeNull();
+  });
+
+  it("null si el JSON no tiene access_token", () => {
+    expect(
+      readSupabaseSession([mkCookie("sb-abc-auth-token", JSON.stringify({ foo: 1 }))])
+    ).toBeNull();
+  });
+});
+
+// ─── isAuthRejection ───
+
+describe("isAuthRejection", () => {
+  it("401/403 → rechazo", () => {
+    expect(isAuthRejection({ status: 401 })).toBe(true);
+    expect(isAuthRejection({ status: 403 })).toBe(true);
+  });
+
+  it("5xx / 429 / 408 → NO rechazo (transitorio, bug #16)", () => {
+    expect(isAuthRejection({ status: 500 })).toBe(false);
+    expect(isAuthRejection({ status: 503 })).toBe(false);
+    expect(isAuthRejection({ status: 429 })).toBe(false);
+    expect(isAuthRejection({ status: 408 })).toBe(false);
+  });
+
+  it("mensajes conocidos de token inválido → rechazo", () => {
+    expect(isAuthRejection({ message: "invalid JWT: token is expired" })).toBe(true);
+    expect(isAuthRejection({ code: "bad_jwt" })).toBe(true);
+    expect(
+      isAuthRejection({ message: "Session from session_id claim in JWT does not exist" })
+    ).toBe(true);
+    expect(isAuthRejection({ code: "refresh_token_not_found" })).toBe(true);
+  });
+
+  it("error de red / desconocido → NO rechazo", () => {
+    expect(isAuthRejection({ message: "fetch failed" })).toBe(false);
+    expect(isAuthRejection({ message: "network error" })).toBe(false);
+    expect(isAuthRejection({ message: "algo raro pasó" })).toBe(false);
+    expect(isAuthRejection(null)).toBe(false);
+    expect(isAuthRejection(undefined)).toBe(false);
+  });
+});
+
+describe("SESSION_GRACE_MS", () => {
+  it("son 7 días", () => {
+    expect(SESSION_GRACE_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,178 @@
+// Helpers puros de sesión para el gate server-side (`proxy.ts`).
+// Edge-compatible: solo Web Crypto y utilidades de string. No importa
+// `@/lib/env` (que lanza si faltan variables) — el secreto se pasa por
+// parámetro.
+
+/** Ventana de gracia offline: un access token válidamente firmado que
+ * expiró hace menos que esto se sigue aceptando si Supabase está
+ * inalcanzable (el cliente no puede refrescar sin red). Decidido con el
+ * dueño: 7 días. */
+export const SESSION_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface JwtPayload {
+  exp?: number;
+  iat?: number;
+  sub?: string;
+  [k: string]: unknown;
+}
+
+export interface SupabaseSession {
+  accessToken: string;
+  refreshToken: string | null;
+  /** epoch segundos, si viene en la cookie */
+  expiresAt: number | null;
+}
+
+const BASE64_PREFIX = "base64-";
+
+function base64UrlToBytes(b64url: string): Uint8Array<ArrayBuffer> {
+  const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64.length % 4 === 0 ? "" : "=".repeat(4 - (b64.length % 4));
+  const bin = atob(b64 + pad);
+  const bytes = new Uint8Array(new ArrayBuffer(bin.length));
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToString(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+/** Decodifica el payload de un JWT SIN verificar la firma. Para leer `exp`
+ * cuando la verificación no aplica (o como paso previo a verificarla). */
+export function decodeJwtPayload(token: string): JwtPayload | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    return JSON.parse(bytesToString(base64UrlToBytes(parts[1])));
+  } catch {
+    return null;
+  }
+}
+
+/** Verifica la firma HS256 de un JWT con el secreto compartido de Supabase.
+ * Devuelve el payload SOLO si la firma valida (y el alg es HS256).
+ * Un `alg: "none"` o una firma incorrecta → null. */
+export async function verifyHS256(token: string, secret: string): Promise<JwtPayload | null> {
+  if (!secret) return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [headerB64, payloadB64, sigB64] = parts;
+
+  let header: { alg?: string };
+  try {
+    header = JSON.parse(bytesToString(base64UrlToBytes(headerB64)));
+  } catch {
+    return null;
+  }
+  if (header.alg !== "HS256") return null;
+
+  try {
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["verify"]
+    );
+    const ok = await crypto.subtle.verify(
+      "HMAC",
+      key,
+      base64UrlToBytes(sigB64),
+      new TextEncoder().encode(`${headerB64}.${payloadB64}`)
+    );
+    if (!ok) return null;
+    return JSON.parse(bytesToString(base64UrlToBytes(payloadB64)));
+  } catch {
+    return null;
+  }
+}
+
+/** Reconstruye la sesión de Supabase desde las cookies de la request.
+ * Maneja el fragmentado en chunks (`.0`, `.1`, …) y el prefijo `base64-`
+ * que usa `@supabase/ssr` >= 0.x. */
+export function readSupabaseSession(
+  cookies: { name: string; value: string }[]
+): SupabaseSession | null {
+  const authCookies = cookies.filter(
+    (c) => c.name.startsWith("sb-") && c.name.includes("-auth-token")
+  );
+  if (authCookies.length === 0) return null;
+
+  const base = authCookies.find((c) => !/\.\d+$/.test(c.name));
+  let raw: string;
+  if (base) {
+    raw = base.value;
+  } else {
+    raw = authCookies
+      .filter((c) => /\.\d+$/.test(c.name))
+      .sort(
+        (a, b) =>
+          parseInt(a.name.match(/\.(\d+)$/)?.[1] ?? "0", 10) -
+          parseInt(b.name.match(/\.(\d+)$/)?.[1] ?? "0", 10)
+      )
+      .map((c) => c.value)
+      .join("");
+  }
+  if (!raw) return null;
+
+  if (raw.startsWith(BASE64_PREFIX)) {
+    try {
+      raw = bytesToString(base64UrlToBytes(raw.slice(BASE64_PREFIX.length)));
+    } catch {
+      return null;
+    }
+  }
+
+  let parsed: {
+    access_token?: string;
+    refresh_token?: string;
+    expires_at?: number;
+  };
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Formato viejo: el valor ES el JWT directamente.
+    return { accessToken: raw, refreshToken: null, expiresAt: null };
+  }
+
+  if (!parsed.access_token) return null;
+  return {
+    accessToken: parsed.access_token,
+    refreshToken: parsed.refresh_token ?? null,
+    expiresAt: typeof parsed.expires_at === "number" ? parsed.expires_at : null,
+  };
+}
+
+const REJECTION_PATTERNS = [
+  "invalid jwt",
+  "invalid claim",
+  "jwt expired",
+  "token is expired",
+  "token has expired",
+  "bad_jwt",
+  "session_not_found",
+  "session from session_id claim in jwt does not exist",
+  "refresh_token_not_found",
+  "user from sub claim in jwt does not exist",
+  "invalid_grant",
+];
+
+/** ¿El error de `getUser()` es un rechazo de autenticación explícito
+ * (token inválido/expirado, sesión revocada) — vs un error transitorio
+ * del servidor (5xx/429/desconocido)?
+ *
+ * Rechazo → redirigir a /login. Indeterminado → chequeo de sesión local. */
+export function isAuthRejection(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { status?: number; code?: string; message?: string; name?: string };
+
+  if (e.status === 401 || e.status === 403) return true;
+  // 5xx / 429 / 408 → transitorio, NO es rechazo.
+  if (typeof e.status === "number" && e.status >= 500) return false;
+  if (e.status === 429 || e.status === 408) return false;
+
+  const haystack = `${e.code ?? ""} ${e.message ?? ""} ${e.name ?? ""}`.toLowerCase();
+  if (haystack.includes("fetch failed") || haystack.includes("network")) return false;
+  return REJECTION_PATTERNS.some((p) => haystack.includes(p));
+}

--- a/src/lib/db/deleted-at.test.ts
+++ b/src/lib/db/deleted-at.test.ts
@@ -1,0 +1,54 @@
+// Invariante deleted_at (borrado suave). Escenarios db-S16 / db-S18.
+//
+// El sync-engine escribe `deleted_at` sobre cualquier tabla vía deleteAndSync.
+// La regla es "toda lectura que arma una lista filtra !deleted_at". Hoy eso
+// NO se cumple para las tablas maestras: `db.clientes.toArray()` y similares
+// devuelven las filas borradas. Este test FIJA ese comportamiento imperfecto
+// para que cualquier cambio (bueno o malo) sea visible. Ver hallazgo #14.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "./index";
+import { resetTestDb } from "@/test/db-reset";
+import { makeCliente } from "@/test/factories";
+
+describe("deleted_at — comportamiento actual (pin)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("db-S16: db.clientes.toArray() DEVUELVE las filas con deleted_at (no filtra)", async () => {
+    await db.clientes.add(makeCliente({ id: "vivo", nombre_cliente: "Vivo" }));
+    await db.clientes.add(
+      makeCliente({
+        id: "borrado",
+        nombre_cliente: "Borrado",
+        deleted_at: new Date().toISOString(),
+      })
+    );
+
+    const todos = await db.clientes.toArray();
+
+    // Comportamiento ACTUAL: devuelve las 2. Cuando se arregle el hallazgo
+    // #14, este test debe actualizarse a `toHaveLength(1)`.
+    expect(todos).toHaveLength(2);
+    expect(todos.map((c) => c.id).sort()).toEqual(["borrado", "vivo"]);
+  });
+
+  it("un filtro manual !deleted_at sí las excluye (patrón que usan los conv_*)", async () => {
+    await db.clientes.add(makeCliente({ id: "vivo" }));
+    await db.clientes.add(makeCliente({ id: "borrado", deleted_at: new Date().toISOString() }));
+
+    const vivos = (await db.clientes.toArray()).filter((c) => !c.deleted_at);
+
+    expect(vivos).toHaveLength(1);
+    expect(vivos[0].id).toBe("vivo");
+  });
+
+  it("db-S18: deleted_at es parte del tipo (opcional) en filas sincronizables", async () => {
+    // Compila ⇒ el campo existe en el tipo. En runtime, se persiste y se lee.
+    const c = makeCliente({ id: "x", deleted_at: "2026-01-01T00:00:00.000Z" });
+    await db.clientes.add(c);
+    const back = await db.clientes.get("x");
+    expect(back?.deleted_at).toBe("2026-01-01T00:00:00.000Z");
+  });
+});

--- a/src/lib/db/env.test.ts
+++ b/src/lib/db/env.test.ts
@@ -1,0 +1,28 @@
+// Escenario de entorno db-S25: crypto.randomUUID no disponible (contexto
+// inseguro / HTTP fuera de localhost). db-S26 (guards typeof window en los
+// handlers blocked/versionchange) queda como verificación por inspección de
+// código — el guard está inline en index.ts y todos los demás tests importan
+// el módulo sin romper.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { randomUUID } from "@/lib/uuid";
+
+describe("db-S25: crypto.randomUUID no disponible (contexto inseguro)", () => {
+  const cryptoObj = globalThis.crypto as { randomUUID?: () => string };
+  const original = cryptoObj.randomUUID;
+
+  afterEach(() => {
+    cryptoObj.randomUUID = original;
+  });
+
+  it("randomUUID() lanza si el runtime no lo expone", () => {
+    cryptoObj.randomUUID = undefined;
+    expect(() => randomUUID()).toThrow();
+  });
+
+  it("con randomUUID disponible devuelve un UUID v4 válido", () => {
+    expect(randomUUID()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+  });
+});

--- a/src/lib/db/migrations.test.ts
+++ b/src/lib/db/migrations.test.ts
@@ -1,0 +1,86 @@
+// Tests de las migraciones del esquema (src/lib/db/index.ts).
+//
+// Cubren:
+//  - Instalación nueva: la DB abre en la versión declarada y las tablas
+//    migradas a UUID tienen PK string (no auto-increment).
+//  - El catálogo DIVIPOLA (departamentos/municipios) conserva PK numérica.
+//  - v13 (cambio de PK ++id -> id): comportamiento FIJADO. Un upgrade con
+//    datos sin .upgrade() lanza UpgradeError en Dexie 4.x — la app queda
+//    sin abrir hasta que el usuario borre el IndexedDB. Ver
+//    docs/modules/01-db.md §4.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import Dexie from "dexie";
+import { db } from "./index";
+import { resetTestDb } from "@/test/db-reset";
+
+describe("esquema — instalación nueva", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("abre en la versión 15", () => {
+    expect(db.verno).toBe(15);
+  });
+
+  it("las tablas de dominio tienen PK string 'id' (migración v13 a UUID)", () => {
+    for (const name of ["clientes", "sedes", "equipos", "visitas", "prueba_resultados"]) {
+      const pk = db.table(name).schema.primKey;
+      expect(pk.name, `${name}.primKey.name`).toBe("id");
+      // auto es true cuando Dexie genera la clave (++id). Con UUID de cliente
+      // debe ser false.
+      expect(pk.auto, `${name}.primKey.auto`).toBe(false);
+    }
+  });
+
+  it("departamentos/municipios conservan PK numérica (código DANE, no migran)", () => {
+    for (const name of ["departamentos", "municipios"]) {
+      const pk = db.table(name).schema.primKey;
+      expect(pk.name).toBe("id");
+      expect(pk.auto).toBe(false);
+    }
+  });
+
+  it("las tablas bidireccionales tienen índice sync_status", () => {
+    for (const name of ["clientes", "visitas", "conv_mediciones", "equipo_movimientos"]) {
+      const idx = db.table(name).schema.indexes.map((i) => i.name);
+      expect(idx, `${name} indexes`).toContain("sync_status");
+    }
+  });
+});
+
+describe("esquema — migración v13 (cambio de PK) con datos", () => {
+  it("FIJADO: upgrade ++id -> id sin .upgrade() lanza UpgradeError (app no abre)", async () => {
+    const name = "mig-v13-" + Math.random().toString(36).slice(2);
+
+    // Estado previo: tabla con PK auto-increment y datos.
+    const dbOld = new Dexie(name);
+    dbOld.version(12).stores({ foo: "++id, name" });
+    await dbOld.open();
+    await dbOld.table("foo").bulkAdd([{ name: "A" }, { name: "B" }]);
+    dbOld.close();
+
+    // Nuevo esquema: misma tabla, PK ahora 'id' string, sin .upgrade().
+    const dbNew = new Dexie(name);
+    dbNew.version(12).stores({ foo: "++id, name" });
+    dbNew.version(13).stores({ foo: "id, name" });
+
+    await expect(dbNew.open()).rejects.toThrow(/changing primary key/i);
+
+    dbNew.close();
+    await Dexie.delete(name);
+  });
+
+  it("DB vacía sí migra sin problema (camino de instalación nueva)", async () => {
+    const name = "mig-v13-empty-" + Math.random().toString(36).slice(2);
+    const d = new Dexie(name);
+    d.version(12).stores({ foo: "++id, name" });
+    d.version(13).stores({ foo: "id, name" });
+
+    await expect(d.open()).resolves.toBeDefined();
+    expect(d.table("foo").schema.primKey.auto).toBe(false);
+
+    d.close();
+    await Dexie.delete(name);
+  });
+});

--- a/src/lib/db/migrations.test.ts
+++ b/src/lib/db/migrations.test.ts
@@ -47,6 +47,25 @@ describe("esquema — instalación nueva", () => {
       expect(idx, `${name} indexes`).toContain("sync_status");
     }
   });
+
+  it("db-S08: v15 agregó sync_retry con clave compuesta [table_name+record_id]", () => {
+    const pk = db.table("sync_retry").schema.primKey;
+    expect(pk.keyPath).toEqual(["table_name", "record_id"]);
+    expect(pk.auto).toBe(false);
+  });
+
+  it("db-S08: v14 dejó equipo_movimientos con índice sync_status (aditivo, sin perder datos)", async () => {
+    await db.equipo_movimientos.add({
+      id: "m1",
+      equipo_id: "e1",
+      ubicacion_nueva_id: "u2",
+      fecha_movimiento: new Date().toISOString(),
+      sync_status: "pending",
+      last_modified: new Date().toISOString(),
+    });
+    const pendientes = await db.equipo_movimientos.where("sync_status").equals("pending").toArray();
+    expect(pendientes).toHaveLength(1);
+  });
 });
 
 describe("esquema — migración v13 (cambio de PK) con datos", () => {

--- a/src/lib/db/permisos-matriz.test.ts
+++ b/src/lib/db/permisos-matriz.test.ts
@@ -1,0 +1,49 @@
+// Pin COMPLETO de la matriz de permisos por defecto (4 roles × 9 módulos ×
+// 4 acciones = 144 decisiones). `permisos.test.ts` valida patrones; esto fija
+// cada celda para que cualquier edición accidental de PERMISOS_DEFAULT_MATRIZ
+// salte. Ver docs/modules/02-permisos.md.
+
+import { describe, it, expect } from "vitest";
+import { permisoDefault, MODULOS_APP, ROLES_DISPONIBLES } from "./types";
+import type { AccionesPermiso } from "./types";
+
+// Presets (mismos que en types.ts): [ver, crear, editar, eliminar]
+const TOTAL: AccionesPermiso = { ver: true, crear: true, editar: true, eliminar: true };
+const VER: AccionesPermiso = { ver: true, crear: false, editar: false, eliminar: false };
+const NADA: AccionesPermiso = { ver: false, crear: false, editar: false, eliminar: false };
+const GEST: AccionesPermiso = { ver: true, crear: true, editar: true, eliminar: false };
+const EJEC: AccionesPermiso = { ver: true, crear: false, editar: true, eliminar: false };
+
+// Matriz esperada. Orden de módulos = MODULOS_APP:
+// dashboard, clientes, solicitudes, visitas, revision, equipos, informes, sync, configuracion
+const ESPERADO: Record<string, AccionesPermiso[]> = {
+  coordinador: [TOTAL, TOTAL, TOTAL, TOTAL, TOTAL, TOTAL, TOTAL, TOTAL, TOTAL],
+  programador: [VER, VER, GEST, GEST, VER, VER, VER, VER, NADA],
+  tecnico: [VER, NADA, NADA, EJEC, VER, EJEC, VER, VER, NADA],
+  comercial: [VER, GEST, GEST, NADA, NADA, NADA, NADA, NADA, NADA],
+};
+
+describe("PERMISOS_DEFAULT_MATRIZ — pin completo (144 celdas)", () => {
+  it("MODULOS_APP tiene el orden que asume ESPERADO", () => {
+    expect(MODULOS_APP).toEqual([
+      "dashboard",
+      "clientes",
+      "solicitudes",
+      "visitas",
+      "revision",
+      "equipos",
+      "informes",
+      "sync",
+      "configuracion",
+    ]);
+    expect(ROLES_DISPONIBLES).toEqual(["coordinador", "programador", "tecnico", "comercial"]);
+  });
+
+  for (const rol of ROLES_DISPONIBLES) {
+    MODULOS_APP.forEach((modulo, i) => {
+      it(`${rol} · ${modulo}`, () => {
+        expect(permisoDefault(rol, modulo)).toEqual(ESPERADO[rol][i]);
+      });
+    });
+  }
+});

--- a/src/lib/db/recovery.test.ts
+++ b/src/lib/db/recovery.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Dexie from "dexie";
+import { db } from "./index";
+import { resetTestDb } from "@/test/db-reset";
+import { needsLocalReset, resetAndReopen } from "./recovery";
+
+describe("needsLocalReset", () => {
+  it("reconoce el UpgradeError real de cambio de PK (v13)", async () => {
+    const name = "rec-" + Math.random().toString(36).slice(2);
+    const dbOld = new Dexie(name);
+    dbOld.version(12).stores({ foo: "++id" });
+    await dbOld.open();
+    await dbOld.table("foo").add({ x: 1 });
+    dbOld.close();
+
+    const dbNew = new Dexie(name);
+    dbNew.version(12).stores({ foo: "++id" });
+    dbNew.version(13).stores({ foo: "id" });
+
+    let caught: unknown;
+    try {
+      await dbNew.open();
+    } catch (e) {
+      caught = e;
+    }
+    dbNew.close();
+    await Dexie.delete(name);
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(needsLocalReset(caught)).toBe(true);
+  });
+
+  it("por name (UpgradeError / VersionError) y por mensaje", () => {
+    const up = new Error("boom");
+    up.name = "UpgradeError";
+    expect(needsLocalReset(up)).toBe(true);
+
+    const ver = new Error("boom");
+    ver.name = "VersionError";
+    expect(needsLocalReset(ver)).toBe(true);
+
+    expect(needsLocalReset(new Error("Not yet support for changing primary key"))).toBe(true);
+  });
+
+  it("NO marca errores ajenos (cuota, red, undefined)", () => {
+    const quota = new Error("quota exceeded");
+    quota.name = "QuotaExceededError";
+    expect(needsLocalReset(quota)).toBe(false);
+    expect(needsLocalReset(new Error("network"))).toBe(false);
+    expect(needsLocalReset(undefined)).toBe(false);
+    expect(needsLocalReset("string")).toBe(false);
+  });
+});
+
+describe("resetAndReopen", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("borra el contenido y deja la DB abierta en la versión actual", async () => {
+    await db.clientes.add({ id: "c1", nombre_cliente: "X", nit: "1" });
+    expect(await db.clientes.count()).toBe(1);
+
+    await resetAndReopen();
+
+    expect(db.isOpen()).toBe(true);
+    expect(db.verno).toBe(15);
+    expect(await db.clientes.count()).toBe(0);
+  });
+});

--- a/src/lib/db/recovery.ts
+++ b/src/lib/db/recovery.ts
@@ -1,0 +1,41 @@
+// Recuperación ante una migración de esquema que Dexie no puede aplicar.
+//
+// El caso concreto es v13 (cambio de PK ++id -> id): si la DB del navegador
+// tiene datos de una versión previa, `db.open()` lanza
+// `UpgradeError: Not yet support for changing primary key` y la app no abre
+// (ver docs/modules/01-db.md §4). El único arreglo real es borrar el
+// IndexedDB local y volver a bajar los datos del servidor.
+//
+// `db-provider` debería llamar `needsLocalReset(err)` en su catch y, si es
+// true, ofrecer un botón "borrar datos locales y recargar" que invoque
+// `resetAndReopen()` — en vez de mostrar el mensaje crudo de Dexie.
+
+import Dexie from "dexie";
+import { db } from "./index";
+
+/**
+ * ¿El error de `db.open()` indica que el esquema local no se puede migrar y
+ * hace falta borrar el IndexedDB? Cubre el `UpgradeError` de cambio de PK
+ * (v13) y, en general, cualquier `Dexie.UpgradeError` / `VersionError`.
+ */
+export function needsLocalReset(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const name = err.name;
+  if (name === "UpgradeError" || name === "VersionError") return true;
+  // Algunos entornos envuelven el mensaje sin conservar `name`.
+  return /changing primary key|not yet support/i.test(err.message);
+}
+
+/**
+ * Borra el IndexedDB local y lo vuelve a abrir vacío en la versión actual.
+ * Después de esto hay que re-sincronizar desde el servidor (fullSync).
+ * Pensado para ejecutarse detrás de una confirmación del usuario.
+ */
+export async function resetAndReopen(): Promise<void> {
+  if (db.isOpen()) db.close();
+  await db.delete();
+  await db.open();
+}
+
+// Re-export para tests / callers que quieran el tipo de error de Dexie.
+export const DexieErrors = Dexie.errnames;

--- a/src/lib/db/seed.test.ts
+++ b/src/lib/db/seed.test.ts
@@ -1,0 +1,95 @@
+// Tests de los seeds de catálogo (src/lib/db/seed.ts).
+// Escenarios db-S11..S15 (ver docs/modules/01-db.scenarios.md).
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "./index";
+import { resetTestDb } from "@/test/db-reset";
+import { seedRolPermisos, seedPruebaDefiniciones } from "./seed";
+import { ROLES_DISPONIBLES, MODULOS_APP } from "./types";
+
+describe("seedRolPermisos", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("db-S11: DB vacía → escribe una fila por (rol × módulo)", async () => {
+    await seedRolPermisos();
+
+    const total = await db.rol_permisos.count();
+    expect(total).toBe(ROLES_DISPONIBLES.length * MODULOS_APP.length);
+
+    // spot check: coordinador.configuracion.ver = true; tecnico.clientes.ver = false
+    const coordCfg = await db.rol_permisos
+      .where({ rol: "coordinador", modulo: "configuracion" })
+      .first();
+    expect(coordCfg?.activo).toBe(true);
+    const tecCli = await db.rol_permisos.where({ rol: "tecnico", modulo: "clientes" }).first();
+    expect(tecCli?.activo).toBe(false);
+  });
+
+  it("db-S12: segunda llamada es no-op (no duplica)", async () => {
+    await seedRolPermisos();
+    const after1 = await db.rol_permisos.count();
+    await seedRolPermisos();
+    const after2 = await db.rol_permisos.count();
+    expect(after2).toBe(after1);
+  });
+
+  it("db-S13 (pin): con datos parciales NO completa lo que falta", async () => {
+    // Simula un seed interrumpido: solo 1 fila.
+    await db.rol_permisos.add({
+      id: "solo-una",
+      rol: "coordinador",
+      modulo: "dashboard",
+      activo: true,
+    });
+
+    await seedRolPermisos();
+
+    // El guard `count > 0` lo da por completo → sigue con 1 fila.
+    expect(await db.rol_permisos.count()).toBe(1);
+  });
+});
+
+describe("seedPruebaDefiniciones", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("db-S11: DB vacía → siembra el catálogo genérico y los permisos", async () => {
+    await seedPruebaDefiniciones();
+
+    expect(await db.prueba_definiciones.count()).toBeGreaterThan(0);
+    expect(await db.rol_permisos.count()).toBe(ROLES_DISPONIBLES.length * MODULOS_APP.length);
+  });
+
+  it("db-S12: segunda llamada no duplica pruebas", async () => {
+    await seedPruebaDefiniciones();
+    const after1 = await db.prueba_definiciones.count();
+    await seedPruebaDefiniciones();
+    expect(await db.prueba_definiciones.count()).toBe(after1);
+  });
+
+  it("db-S14: rol_permisos ya poblada → siembra pruebas, permisos no-op", async () => {
+    await seedRolPermisos();
+    const permisosAntes = await db.rol_permisos.count();
+
+    await seedPruebaDefiniciones();
+
+    expect(await db.prueba_definiciones.count()).toBeGreaterThan(0);
+    expect(await db.rol_permisos.count()).toBe(permisosAntes);
+  });
+
+  it("db-S15 (pin): el catálogo agrupado (grupo_pruebas) NO se siembra", async () => {
+    await seedPruebaDefiniciones();
+    // seedFromPackage está comentado → grupo_pruebas queda vacío.
+    expect(await db.grupo_pruebas.count()).toBe(0);
+  });
+
+  it("codigo es único en el catálogo sembrado", async () => {
+    await seedPruebaDefiniciones();
+    const rows = await db.prueba_definiciones.toArray();
+    const codigos = rows.map((r) => r.codigo);
+    expect(new Set(codigos).size).toBe(codigos.length);
+  });
+});

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -10,6 +10,14 @@ export type SyncStatus = "pending" | "synced" | "conflict" | "error" | "failed";
 export interface SyncFields {
   sync_status: SyncStatus;
   last_modified: string; // ISO timestamp
+  /**
+   * Borrado suave. Se setea con `deleteAndSync` y se propaga por sync.
+   * INVARIANTE: toda lectura que arma una lista debe filtrar
+   * `!deleted_at`. Hoy solo lo cumplen los consumidores `conv_*`
+   * (grupo-a..e, PDF, evaluacion); las listas de tablas maestras NO
+   * — ver docs/modules/01-db.md, hallazgo #14.
+   */
+  deleted_at?: string | null;
 }
 
 // ─── Retry con backoff exponencial ───

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -438,6 +438,12 @@ export function permisoDefault(rol: RolUsuario, modulo: ModuloApp): AccionesPerm
  * Nota: no aplica la regla "sin ver no hay acciones" — eso lo hace
  * `resolverPermiso`; aquí se exponen los valores crudos para que la
  * UI de configuración pueda editarlos sin perder overrides.
+ *
+ * ⚠️ ASIMETRÍA: `ver` se lee como `permiso?.activo ?? false` — NO cae
+ * al default de la matriz. `crear/editar/eliminar` SÍ caen al default
+ * si son null/undefined. Consecuencia: `resolverPermiso(undefined, …)`
+ * siempre da `false` (sin fila `rol_permisos`, el módulo es invisible).
+ * En producción funciona porque `seedRolPermisos()` crea las 36 filas.
  */
 export function accionesEfectivas(
   permiso: RolPermiso | undefined,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -7,6 +7,13 @@ const clientSchema = z.object({
 
 const serverSchema = z.object({
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  /**
+   * Secreto de firma de JWT del proyecto Supabase (Settings → API → JWT Secret).
+   * Opcional: si falta, `proxy.ts` no puede verificar la firma del token en el
+   * fallback offline y cae a una barrera blanda (ver docs/modules/03-auth.md).
+   * Recomendado configurarlo.
+   */
+  SUPABASE_JWT_SECRET: z.string().min(1).optional(),
 });
 
 function validateEnv<T>(schema: z.ZodType<T>, source: Record<string, unknown>, label: string): T {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,111 +1,219 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 // ============================================================
 //  proxy — gate de autenticación server-side para /dashboard/*
 //
-//  Bug: `hasValidSessionCookie` decodifica el payload del JWT SIN
-//  verificar su firma (solo lee `exp`). El fallback a esa cookie
-//  no verificada estaba activo tanto cuando `getUser()` lanza una
-//  excepción real de red (Supabase inalcanzable) como cuando
-//  Supabase responde normalmente con un error de autenticación
-//  explícito (JWT inválido/forjado/expirado). Un atacante podía
-//  fabricar una cookie `sb-*-auth-token` con un JWT sin firma válida
-//  y `exp` futuro para pasar el gate sin sesión real.
+//  Matriz completa: (respuesta de Supabase) × (estado de la cookie de
+//  sesión) → ¿pasa o redirige a /login?
+//
+//  Diseño (ver docs/modules/03-auth.md):
+//   - autenticado   → pasa
+//   - rechazo (401 / "invalid JWT" / sesión revocada) → /login, sin fallback
+//   - indeterminado (5xx / 429 / excepción de red) → chequeo de sesión local:
+//       · con SUPABASE_JWT_SECRET: verifica firma HS256 + gracia offline 7 días
+//       · sin el secreto: barrera blanda (JWT bien formado + no expirado)
 // ============================================================
 
 let getUserImpl: () => Promise<{
   data: { user: { id: string } | null };
-  error: { message: string } | null;
+  error: unknown;
 }>;
 
-// `proxy.ts` valida NEXT_PUBLIC_SUPABASE_* al importarse (vía `clientEnv`);
-// `vi.hoisted` garantiza que estos valores existan antes de que el import
-// estático de más abajo dispare esa validación.
 vi.hoisted(() => {
   process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://test.supabase.co";
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
 });
 
 vi.mock("@supabase/ssr", () => ({
-  createServerClient: () => ({
-    auth: {
-      getUser: () => getUserImpl(),
-    },
-  }),
+  createServerClient: () => ({ auth: { getUser: () => getUserImpl() } }),
 }));
 
 import { proxy } from "./proxy";
 
-/** JWT con firma inválida ("forjada-sin-firma-valida") pero `exp` futuro. */
-function jwtForjadoConExpFuturo(): string {
-  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
-  const payload = Buffer.from(
-    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600, sub: "atacante" })
-  ).toString("base64url");
-  return `${header}.${payload}.forjada-sin-firma-valida`;
+const SECRET = "test-jwt-signing-secret-0123456789";
+
+// ─── firmar / forjar tokens ───
+
+function b64url(s: string | Uint8Array): string {
+  const arr = typeof s === "string" ? new TextEncoder().encode(s) : s;
+  let bin = "";
+  for (const b of arr) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
-function requestConCookie(path: string, jwt: string): NextRequest {
-  const req = new NextRequest(new URL(path, "http://localhost:3000"));
-  req.cookies.set("sb-test-auth-token", jwt);
+async function signHS256(payload: Record<string, unknown>): Promise<string> {
+  const h = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const p = b64url(JSON.stringify(payload));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${h}.${p}`))
+  );
+  return `${h}.${p}.${b64url(sig)}`;
+}
+
+function forgedAlgNone(payload: Record<string, unknown>): string {
+  return `${b64url(JSON.stringify({ alg: "none", typ: "JWT" }))}.${b64url(
+    JSON.stringify(payload)
+  )}.x`;
+}
+
+/** Empaqueta un access token en el formato de cookie de @supabase/ssr. */
+function sessionCookie(accessToken: string, withRefresh = true): string {
+  const json = JSON.stringify({
+    access_token: accessToken,
+    refresh_token: withRefresh ? "RT-valido" : undefined,
+    expires_at: 0,
+  });
+  return "base64-" + b64url(json);
+}
+
+function reqDashboard(cookieValue?: string): NextRequest {
+  const req = new NextRequest(new URL("/dashboard", "http://localhost:3000"));
+  if (cookieValue !== undefined) req.cookies.set("sb-test-auth-token", cookieValue);
   return req;
 }
 
-function esRedirectALogin(res: Response): boolean {
-  const location = res.headers.get("location");
-  return res.status >= 300 && res.status < 400 && !!location && location.includes("/login");
+function redirigeALogin(res: Response): boolean {
+  const loc = res.headers.get("location");
+  return res.status >= 300 && res.status < 400 && !!loc && loc.includes("/login");
 }
 
-describe("proxy", () => {
+// ─── respuestas de Supabase ───
+const RESP = {
+  ok: async () => ({ data: { user: { id: "u1" } }, error: null }),
+  reject401: async () => ({ data: { user: null }, error: { status: 401, message: "invalid JWT" } }),
+  err500: async () => ({ data: { user: null }, error: { status: 500, message: "internal error" } }),
+  err429: async () => ({ data: { user: null }, error: { status: 429, message: "rate limited" } }),
+  netThrow: async () => {
+    throw new TypeError("fetch failed");
+  },
+};
+
+const now = () => Math.floor(Date.now() / 1000);
+const DAY = 86400;
+
+describe("proxy — con SUPABASE_JWT_SECRET configurado", () => {
+  beforeEach(() => {
+    process.env.SUPABASE_JWT_SECRET = SECRET;
+  });
   afterEach(() => {
+    delete process.env.SUPABASE_JWT_SECRET;
     vi.resetAllMocks();
   });
 
-  it("redirige a /login cuando Supabase rechaza explícitamente el JWT (token forjado/expirado)", async () => {
-    getUserImpl = async () => ({
-      data: { user: null },
-      error: { message: "invalid JWT" },
-    });
-
-    const req = requestConCookie("/dashboard", jwtForjadoConExpFuturo());
-    const res = await proxy(req);
-
-    expect(esRedirectALogin(res)).toBe(true);
+  it("autenticado → pasa (aunque no haya cookie parseable)", async () => {
+    getUserImpl = RESP.ok;
+    expect(redirigeALogin(await proxy(reqDashboard()))).toBe(false);
   });
 
-  it("deja pasar con la cookie local ante una falla real de red hacia Supabase (offline)", async () => {
-    getUserImpl = async () => {
-      throw new TypeError("fetch failed");
-    };
-
-    const req = requestConCookie("/dashboard", jwtForjadoConExpFuturo());
-    const res = await proxy(req);
-
-    expect(esRedirectALogin(res)).toBe(false);
+  it("rechazo explícito (401) → /login aunque la cookie tenga firma válida", async () => {
+    getUserImpl = RESP.reject401;
+    const cookie = sessionCookie(await signHS256({ sub: "u1", exp: now() + 3600 }));
+    expect(redirigeALogin(await proxy(reqDashboard(cookie)))).toBe(true);
   });
 
-  it("deja pasar cuando Supabase confirma un usuario autenticado", async () => {
-    getUserImpl = async () => ({
-      data: { user: { id: "user-1" } },
-      error: null,
+  for (const [name, resp] of [
+    ["5xx transitorio", RESP.err500],
+    ["429 rate limit", RESP.err429],
+    ["excepción de red", RESP.netThrow],
+  ] as const) {
+    describe(`indeterminado: ${name}`, () => {
+      it("token firmado fresco → pasa (offline-first)", async () => {
+        getUserImpl = resp;
+        const cookie = sessionCookie(await signHS256({ sub: "u1", exp: now() + 3600 }));
+        expect(redirigeALogin(await proxy(reqDashboard(cookie)))).toBe(false);
+      });
+
+      it("token firmado expirado hace 3 días + refresh token → pasa (gracia)", async () => {
+        getUserImpl = resp;
+        const cookie = sessionCookie(await signHS256({ sub: "u1", exp: now() - 3 * DAY }));
+        expect(redirigeALogin(await proxy(reqDashboard(cookie)))).toBe(false);
+      });
+
+      it("token firmado expirado hace 10 días → /login (fuera de gracia)", async () => {
+        getUserImpl = resp;
+        const cookie = sessionCookie(await signHS256({ sub: "u1", exp: now() - 10 * DAY }));
+        expect(redirigeALogin(await proxy(reqDashboard(cookie)))).toBe(true);
+      });
+
+      it("token firmado pero SIN refresh token → /login", async () => {
+        getUserImpl = resp;
+        const cookie = sessionCookie(await signHS256({ sub: "u1", exp: now() - 3600 }), false);
+        expect(redirigeALogin(await proxy(reqDashboard(cookie)))).toBe(true);
+      });
+
+      it("token forjado alg:none con exp futuro → /login (bug #2 cerrado)", async () => {
+        getUserImpl = resp;
+        const cookie = sessionCookie(forgedAlgNone({ sub: "atacante", exp: now() + 3600 }));
+        expect(redirigeALogin(await proxy(reqDashboard(cookie)))).toBe(true);
+      });
+
+      it("sin cookie de sesión → /login", async () => {
+        getUserImpl = resp;
+        expect(redirigeALogin(await proxy(reqDashboard()))).toBe(true);
+      });
     });
+  }
+});
 
-    const req = requestConCookie("/dashboard", jwtForjadoConExpFuturo());
-    const res = await proxy(req);
+describe("proxy — SIN SUPABASE_JWT_SECRET (barrera blanda + RLS)", () => {
+  afterEach(() => vi.resetAllMocks());
 
-    expect(esRedirectALogin(res)).toBe(false);
+  it("5xx + JWT bien formado y no expirado → pasa (aunque no se verifique firma)", async () => {
+    getUserImpl = RESP.err500;
+    const cookie = sessionCookie(forgedAlgNone({ sub: "x", exp: now() + 3600 }));
+    expect(redirigeALogin(await proxy(reqDashboard(cookie)))).toBe(false);
   });
 
-  it("redirige a /login sin ninguna cookie de sesión", async () => {
-    getUserImpl = async () => ({
-      data: { user: null },
-      error: { message: "no session" },
-    });
+  it("5xx + JWT expirado → /login", async () => {
+    getUserImpl = RESP.err500;
+    const cookie = sessionCookie(forgedAlgNone({ sub: "x", exp: now() - 3600 }));
+    expect(redirigeALogin(await proxy(reqDashboard(cookie)))).toBe(true);
+  });
+});
 
-    const req = new NextRequest(new URL("/dashboard", "http://localhost:3000"));
+describe("proxy — rutas y redirecciones", () => {
+  beforeEach(() => {
+    process.env.SUPABASE_JWT_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.SUPABASE_JWT_SECRET;
+    vi.resetAllMocks();
+  });
+
+  it("/login con usuario autenticado → redirige a /dashboard", async () => {
+    getUserImpl = RESP.ok;
+    const req = new NextRequest(new URL("/login", "http://localhost:3000"));
     const res = await proxy(req);
+    const loc = res.headers.get("location");
+    expect(res.status).toBeGreaterThanOrEqual(300);
+    expect(loc).toContain("/dashboard");
+  });
 
-    expect(esRedirectALogin(res)).toBe(true);
+  it("/login sin sesión → pasa (renderiza el login)", async () => {
+    getUserImpl = RESP.reject401;
+    const req = new NextRequest(new URL("/login", "http://localhost:3000"));
+    expect(redirigeALogin(await proxy(req))).toBe(false);
+  });
+
+  it("ruta pública sin sesión → pasa", async () => {
+    getUserImpl = RESP.reject401;
+    const req = new NextRequest(new URL("/verificar/abc", "http://localhost:3000"));
+    const res = await proxy(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("el redirect a /login preserva el path original en ?redirect", async () => {
+    getUserImpl = RESP.reject401;
+    const req = new NextRequest(new URL("/dashboard/visitas/123", "http://localhost:3000"));
+    const res = await proxy(req);
+    expect(res.headers.get("location")).toContain("redirect=%2Fdashboard%2Fvisitas%2F123");
   });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,67 +1,60 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { clientEnv } from "@/lib/env";
+import {
+  readSupabaseSession,
+  verifyHS256,
+  isAuthRejection,
+  decodeJwtPayload,
+  SESSION_GRACE_MS,
+} from "@/lib/auth/session";
 
 const PROTECTED_PREFIX = "/dashboard";
 const LOGIN_PATH = "/login";
 
-/**
- * Decodifica un JWT sin verificar firma y extrae el payload.
- * Suficiente para leer `exp` — la firma se valida server-side por Supabase.
- */
-function decodeJwtPayload(token: string): { exp?: number; sub?: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf-8"));
-    return payload;
-  } catch {
-    return null;
-  }
-}
+let warnedNoSecret = false;
 
 /**
- * Verifica si alguna cookie de sesión de Supabase contiene un JWT no expirado.
- * Margen de 60s para evitar race conditions con tokens a punto de expirar.
+ * ¿Hay una sesión local aceptable para dejar pasar cuando Supabase no
+ * pudo confirmar (inalcanzable o error transitorio)?
+ *
+ * Con `SUPABASE_JWT_SECRET`: verifica la firma HS256. Un `alg:none` o
+ * firma incorrecta NO pasa (cierra el bug #2). Un token válidamente
+ * firmado que expiró hace menos de SESSION_GRACE_MS y tiene refresh
+ * token → pasa (gracia offline: el cliente no puede refrescar sin red).
+ *
+ * Sin el secreto configurado: cae a la barrera blanda — acepta un JWT
+ * bien formado y no expirado (comportamiento previo), y deja que RLS de
+ * Supabase sea la barrera real de datos. Loguea un warning una vez.
  */
-function hasValidSessionCookie(cookies: { name: string; value: string }[]): boolean {
-  const sessionCookies = cookies.filter(
-    (c) => c.name.startsWith("sb-") && c.name.includes("-auth-token")
-  );
-  if (sessionCookies.length === 0) return false;
+async function hasAcceptableLocalSession(
+  cookies: { name: string; value: string }[],
+  jwtSecret: string | undefined
+): Promise<boolean> {
+  const session = readSupabaseSession(cookies);
+  if (!session) return false;
 
-  // Supabase puede fragmentar el token en múltiples cookies (base, .0, .1, etc.)
-  // Intentar reconstruir: la cookie base o la concatenación de chunks
-  const baseCookie = sessionCookies.find((c) => !c.name.match(/\.\d+$/));
-  let tokenRaw = baseCookie?.value ?? "";
+  const nowSec = Math.floor(Date.now() / 1000);
 
-  if (!tokenRaw) {
-    // Solo chunks numerados — concatenar en orden
-    const chunks = sessionCookies
-      .filter((c) => c.name.match(/\.\d+$/))
-      .sort((a, b) => {
-        const aNum = parseInt(a.name.match(/\.(\d+)$/)?.[1] ?? "0");
-        const bNum = parseInt(b.name.match(/\.(\d+)$/)?.[1] ?? "0");
-        return aNum - bNum;
-      });
-    tokenRaw = chunks.map((c) => c.value).join("");
+  if (jwtSecret) {
+    const payload = await verifyHS256(session.accessToken, jwtSecret);
+    if (!payload?.exp) return false;
+    if (!session.refreshToken) return false;
+    const expiredForMs = (nowSec - payload.exp) * 1000;
+    // No expirado, o expirado dentro de la ventana de gracia.
+    return expiredForMs < SESSION_GRACE_MS;
   }
 
-  // El valor puede ser un JSON con access_token dentro (Supabase SSR format)
-  let jwt = tokenRaw;
-  try {
-    const parsed = JSON.parse(tokenRaw);
-    if (parsed.access_token) jwt = parsed.access_token;
-  } catch {
-    // No es JSON — asumir que es el JWT directamente
+  // Barrera blanda (sin secreto): JWT bien formado + no expirado (margen 60s).
+  if (!warnedNoSecret) {
+    console.warn(
+      "[proxy] SUPABASE_JWT_SECRET no configurado — el fallback offline no verifica " +
+        "la firma del token. Configuralo (Supabase → Settings → API → JWT Secret)."
+    );
+    warnedNoSecret = true;
   }
-
-  const payload = decodeJwtPayload(jwt);
-  if (!payload?.exp) return false;
-
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const MARGIN_SECONDS = 60;
-  return payload.exp > nowSeconds + MARGIN_SECONDS;
+  const payload = decodeJwtPayload(session.accessToken);
+  return !!payload?.exp && payload.exp > nowSec + 60;
 }
 
 export async function proxy(request: NextRequest) {
@@ -69,10 +62,9 @@ export async function proxy(request: NextRequest) {
 
   const supabaseUrl = clientEnv.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey = clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const jwtSecret = process.env.SUPABASE_JWT_SECRET;
 
-  let response = NextResponse.next({
-    request: { headers: request.headers },
-  });
+  let response = NextResponse.next({ request: { headers: request.headers } });
 
   const supabase = createServerClient(supabaseUrl, supabaseKey, {
     cookies: {
@@ -81,9 +73,7 @@ export async function proxy(request: NextRequest) {
       },
       setAll(cookiesToSet) {
         cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
-        response = NextResponse.next({
-          request: { headers: request.headers },
-        });
+        response = NextResponse.next({ request: { headers: request.headers } });
         cookiesToSet.forEach(({ name, value, options }) =>
           response.cookies.set(name, value, options)
         );
@@ -93,22 +83,26 @@ export async function proxy(request: NextRequest) {
 
   const allCookies = request.cookies.getAll();
 
+  // Clasificación en TRES:
+  //  - autenticado   → Supabase confirmó el usuario
+  //  - rechazado     → Supabase respondió "token inválido/expirado/revocado" → /login
+  //  - indeterminado → 5xx/429/timeout o excepción de red → chequeo local
   let user: Awaited<ReturnType<typeof supabase.auth.getUser>>["data"]["user"] = null;
+  let indeterminado = false;
   try {
     const { data, error } = await supabase.auth.getUser();
-    // `error` acá es un rechazo explícito de Supabase (JWT inválido, expirado,
-    // forjado, sesión revocada) — Supabase SÍ respondió, así que NO hay que
-    // confiar en la cookie local sin verificar firma. Solo la excepción real
-    // de red (catch de abajo) representa "Supabase inalcanzable".
     if (!error) {
       user = data.user;
+    } else if (!isAuthRejection(error)) {
+      indeterminado = true; // 5xx/429/desconocido — NO desloguear (bug #16)
     }
+    // isAuthRejection(error) === true → user queda null → redirige
   } catch {
-    // Excepción real de fetch (Supabase inalcanzable) → confiar en cookie
-    // local si el JWT no expiró, para no bloquear el uso offline-first.
-    if (hasValidSessionCookie(allCookies)) {
-      return response;
-    }
+    indeterminado = true; // excepción real de red (Supabase inalcanzable)
+  }
+
+  if (!user && indeterminado && (await hasAcceptableLocalSession(allCookies, jwtSecret))) {
+    return response;
   }
 
   if (pathname.startsWith(PROTECTED_PREFIX) && !user) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,7 +43,8 @@ export default defineConfig({
         "src/lib/supabase/sync-retry.ts": { lines: 94, functions: 100, branches: 86 },
         "src/lib/supabase/sync-lock.ts": { lines: 65, functions: 66, branches: 60 },
         "src/lib/supabase/sync-engine.ts": { lines: 70, functions: 86, branches: 60 },
-        "src/proxy.ts": { lines: 72, functions: 40, branches: 54 },
+        "src/proxy.ts": { lines: 85, functions: 30, branches: 90 },
+        "src/lib/auth/session.ts": { lines: 90, functions: 100, branches: 88 },
         // Tier 1 — Módulo 1 (db). types.ts (motor de permisos) no lo mide v8
         // pero está cubierto de forma exhaustiva por permisos.test.ts +
         // permisos-matriz.test.ts (144 celdas).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,8 +35,8 @@ export default defineConfig({
       // el caso de que alguien borre una suite entera. Los globs por archivo
       // son los que ajustan fino sobre lo que YA está testeado en serio.
       thresholds: {
-        lines: 12,
-        statements: 12,
+        lines: 13,
+        statements: 13,
         functions: 9,
         branches: 12,
         "src/lib/equipos/engine.ts": { lines: 83, functions: 85, branches: 77 },
@@ -44,6 +44,12 @@ export default defineConfig({
         "src/lib/supabase/sync-lock.ts": { lines: 65, functions: 66, branches: 60 },
         "src/lib/supabase/sync-engine.ts": { lines: 70, functions: 86, branches: 60 },
         "src/proxy.ts": { lines: 72, functions: 40, branches: 54 },
+        // Tier 1 — Módulo 1 (db). types.ts (motor de permisos) no lo mide v8
+        // pero está cubierto de forma exhaustiva por permisos.test.ts +
+        // permisos-matriz.test.ts (144 celdas).
+        "src/lib/db/recovery.ts": { lines: 95, functions: 100, branches: 80 },
+        "src/lib/db/seed.ts": { lines: 65, functions: 55, branches: 58 },
+        "src/lib/db/index.ts": { lines: 63 },
       },
     },
   },


### PR DESCRIPTION
**Tier 1 completo** — los tres módulos de fundamentos (identidad + datos).

## Módulo 1 — `src/lib/db/` (esquema y migraciones)

- `docs/modules/01-db.md` + `01-db.scenarios.md` (26 escenarios) + script manual multi-pestaña.
- **v13 confirmado**: la migración a UUID brickea la app en un upgrade con datos (`UpgradeError`, `db.open()` falla). `recovery.ts` + pantalla en `db-provider` → el técnico ve "borrar datos locales y recargar" en vez del mensaje crudo.
- `deleted_at?` tipado en `SyncFields`.
- Tests: `migrations`, `recovery`, `seed`, `deleted-at`, `env`, `db-provider`.
- Issues: #34, #35, #36.

## Módulo 2 — motor de permisos (`src/lib/db/types.ts`)

- `docs/modules/02-permisos.md`.
- `permisos-matriz.test.ts`: pin de las **144 celdas** (4 roles × 9 módulos × 4 acciones).
- JSDoc en `accionesEfectivas` sobre la asimetría de `ver` (por qué `resolverPermiso(undefined)` da `false`).

## Módulo 3 — auth (`proxy.ts`, `src/lib/auth/`)

Cierra 4 bugs del gate de sesión:

| # | Antes | Ahora |
|---|---|---|
| #2 | `alg:none` + `exp` futuro pasaba offline | `verifyHS256` con `SUPABASE_JWT_SECRET` — firma inválida → `/login` |
| #16 | 5xx/429 de Supabase → deslogueo masivo | clasificación en 3: transitorio → chequeo local, no `/login` |
| #3 | >1h offline → `/login` (sin poder loguearse) | gracia de 7 días desde `exp` si hay refresh token |
| #4 | cookie `base64-` no se parseaba | `readSupabaseSession` la entiende + arma chunks |

- `src/lib/auth/session.ts` (helpers puros, Edge) + 17 tests.
- `proxy.test.ts`: matriz de 26 casos.
- Issue de seguimiento: #37 (firma asimétrica).

### ⚠️ Acción del dueño (Módulo 3)

1. **Pegar el `SUPABASE_JWT_SECRET` real** (Supabase → Settings → API → JWT Secret) en `.env.local` **y en Vercel**. Sin el valor, `proxy.ts` degrada a barrera blanda (funciona, pero no verifica firma).
2. **Confirmar que RLS está activo** en todas las tablas de Supabase (defensa en profundidad).

## Verificación

`npm run verify` — exit 0: **314 tests / 30 archivos** · lint 0 errores · formato y tipos limpios · CI verde.

## Pendiente

- Ejecutar manualmente db-S09/S10 (multi-pestaña) en un entorno con la app corriendo.
- Sign-off del dueño en los 3 módulos.