### PR TITLE
Tier 2 — motor de sincronización (fix-ahora #17–#21, #3/#5 interinos)

### DIFF
--- a/docs/modules/04-sync.md
+++ b/docs/modules/04-sync.md
@@ -1,0 +1,160 @@
+# Módulo: Motor de sincronización (`src/lib/supabase/`)
+
+> Estado: 🟡 en curso (Tier 2) · 2026-08-28
+> Archivos: `sync-engine.ts` (1024 líneas), `sync-retry.ts`, `sync-lock.ts`,
+> `src/hooks/use-auto-sync.ts`. Tests: `sync-engine.test.ts`,
+> `sync-retry.test.ts`, `sync-lock.test.ts`, `sync-classification.test.ts` (Tier 0).
+>
+> **Alcance de esta pasada (Tier 2):** los fix-ahora chicos (#17–#21) + guardas
+> interinas para #3 y #5. El **rediseño del modelo de conflicto** (#3/#4/#5
+> completo — dirty-tracking por columna, cola de conflictos, UI) es un
+> **proyecto follow-on aparte**, NO entra acá.
+
+---
+
+## 1. Responsabilidad
+
+Único dueño de la sincronización bidireccional Dexie ↔ Supabase.
+
+- **PUSH**: filas locales con `sync_status: "pending"` → Supabase (UPSERT por id).
+- **PULL**: cambios de Supabase → Dexie. Incremental por `last_modified`.
+- El id local ES el id remoto (UUID de cliente). Sin mapeo.
+
+## 2. API pública (`sync-engine.ts`)
+
+| Export                                                   | Qué hace                                                                                                       | Error                                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----- |
+| `fullSync()`                                             | push todas SYNC_TABLES → pull MASTER_TABLES → pull SYNC_TABLES. Bajo `withSyncLock`.                           | no lanza; errores en `result.errors[]`                           |
+| `pushAllPending()`                                       | solo push SYNC_TABLES. Auto-sync. Bajo lock.                                                                   | `{ pushed, errors }`                                             |
+| `pullAllPending()`                                       | solo pull incremental SYNC_TABLES (sin MASTER). Bajo lock.                                                     | `{ pulled, errors }` — **hoy traga los errores por tabla** (#19) |
+| `pushSingle(table, id)`                                  | push inmediato tras guardar en un form. `navigator.onLine` gate.                                               | `boolean`, silencioso                                            |
+| `updateAndSync(table, id, patch)`                        | patch + `sync_status:"pending"` + `last_modified` + `pushSingle`. **Usar esto**, no `db.table.update` directo. | void                                                             |
+| `deleteAndSync(table, id)`                               | `updateAndSync(…, { deleted_at })` — soft delete.                                                              | void                                                             |
+| `retryRecord(table, id)`                                 | reintento manual de UNA fila, se salta el backoff. Bajo lock.                                                  | void                                                             |
+| `retryErrorRecords()`                                    | mueve filas `"error"` → `"pending"`. **Hoy no hace nada** — nada setea `"error"` (#18).                        | `number`                                                         |
+| `getErrorRecords()` / `getPendingRecords()`              | previews para la consola de sync                                                                               | `[]`                                                             |
+| `countSyncStatuses()`                                    | `{ pendingCount, errorCount }` (error = error+failed)                                                          | —                                                                |
+| `getAuthenticatedUser(supabase, retries=1, delayMs=500)` | `getUser()` con 1 reintento (race del login)                                                                   | `{id}                                                            | null` |
+| `SYNC_TABLES`, `MASTER_TABLES`                           | listas de clasificación (exportadas en Tier 0)                                                                 | —                                                                |
+
+## 3. Modelo de datos
+
+- **`sync_status`** (Dexie): el motor solo escribe `pending`/`synced`/`failed`.
+  **`"error"` y `"conflict"` del enum están MUERTOS** — nada los setea
+  (issues #35 + este módulo). `getErrorRecords` consulta `["error","failed"]`
+  → en la práctica solo `failed`. `retryErrorRecords` consulta `"error"` → en
+  la práctica **no hace nada**.
+- **`last_modified`**: lo pone el cliente al escribir, PERO `prepareForRemote`
+  lo **quita** antes de pushear (`LOCAL_ONLY_FIELDS`). Del lado Supabase:
+  columna `DEFAULT NOW()` + trigger `BEFORE UPDATE` **solo en 5 tablas**
+  (`visitas`, `prueba_resultados`, `mediciones_radiometricas`, `evidencias`,
+  `grupo_resultados`). En las otras ~30 SYNC_TABLES, un UPDATE **no avanza
+  `last_modified`** → el pull incremental de otro dispositivo (`.gt(last_modified,
+watermark)`) nunca vuelve a traer esa fila editada. → **#5, parte grave.**
+- **`sync_meta`** (PK `table_name`): watermark `last_pulled_at` por tabla.
+- **`sync_retry`** (PK `[table_name+record_id]`): backoff exponencial.
+- **`prepareForRemote`** recorta `LOCAL_ONLY_FIELDS` + `EXTRA_LOCAL_FIELDS`
+  (listas a mano — #20, guard parcial en `sync-classification.test.ts`).
+
+## 4. Flujo — conflicto (`applyRemoteSyncRecord`)
+
+Al pull, por cada fila remota:
+
+- Sin fila local, o local `synced`: si remoto trae `deleted_at` → `delete()`
+  local; si no → `put({...remoto, synced})`.
+- Local con `sync_status != "synced"` (edición pendiente): **conflicto → se
+  mantiene local, `logger.warn`, cuenta 0.** El próximo push sobrescribe el
+  remoto (last-writer-wins = **local siempre gana, en silencio**). → #3.
+
+## 5. Flujo de control
+
+**Push** (`pushTable`): `where("sync_status").equals("pending")` → por fila,
+si `sync_retry` programado y no vencido → saltar; `prepareForRemote` →
+`upsert(onConflict:"id")` → éxito: `synced` + `recordSuccess`; error:
+`recordFailure` (backoff) y solo marca `failed` si el retry es terminal.
+
+**Pull incremental** (`pullSyncTable` → `pullSyncPages`): watermark de
+`sync_meta` leído ANTES de paginar; keyset por `id` con
+`.gt("last_modified", watermark)`; el watermark solo avanza si TODAS las
+páginas ok (a-least-once). `applyRemoteSyncRecord` por fila (ver §4).
+Éxito → `setLastSyncTimestamp` limpia `last_pull_error`. Falla → el caller
+llama `recordPullError` (#19).
+
+**Auto-sync** (`useAutoSync`): al reconectar espera `RECONNECT_DEBOUNCE_MS`
+(3s) de conexión estable, después `syncCycle` (push → pull, secuencial por
+el lock) + `setInterval` 5 min. `runningRef` evita solapar dos ciclos.
+
+## 6. Offline / online
+
+- `pushSingle` / `runPushAllPending` / `runPullAllPending`: gate
+  `navigator.onLine`; sin sesión → no-op.
+- `recordFailure` no consume un intento si `!navigator.onLine` (el fallo es
+  de red, no del registro).
+- Offline: todo queda `pending` en Dexie; al reconectar, el debounce +
+  `syncCycle` lo sube.
+
+## 7. Rol / permisos
+
+- No chequea rol. `runFullSync`/`runPushAllPending`/`runPullAllPending`
+  exigen sesión (`getAuthenticatedUser`), no un cargo.
+- `retryRecord` es explícitamente sin gate de rol (el técnico de campo lo
+  usa).
+
+## 8. Invariantes y supuestos
+
+1. El id local == id remoto (UUID de cliente). Sin mapeo.
+2. `last_modified` server-side monótono — **requiere la migración 016**
+   (antes solo 5 tablas lo tenían). Sin ella, los edits de ~30 tablas no
+   propagan entre dispositivos.
+3. `LOCAL_ONLY_FIELDS` / `EXTRA_LOCAL_FIELDS` cubren TODA columna Dexie que
+   no existe en Supabase (#20 — hoy a mano).
+4. Conflicto = local gana. El dato del servidor más nuevo se pierde al
+   próximo push (contado por `getPullConflictStats`, no evitado).
+5. `withSyncLock` es single-flight real entre pestañas solo con
+   `navigator.locks`; el fallback en memoria es por-pestaña.
+
+## 9. Modos de falla conocidos
+
+| Falla | Efecto | Manejo |
+|---|---|---|
+| Migración 016 sin correr | edits de ~30 tablas no propagan | ninguno hasta correrla |
+| Colisión (remoto más nuevo que local pendiente) | se pierde el dato del servidor al push | `logger.error` + `getPullConflictStats` (visible, no evitado) |
+| Pull de una tabla falla cada ciclo | antes: invisible | `sync_meta.last_pull_error` + `getFailingPullTables()` |
+| Columna local nueva sin clasificar | `PGRST204`/`42703` → fila a `failed` | `retryErrorRecords` la recupera; guard #20 pendiente |
+| `navigator.locks` ausente + multi-pestaña | dos pull/push a la vez | fallback en memoria (single-tab) |
+| Reloj de cliente desfasado | con 016: inocuo (timestamps server); sin 016: watermark corrido | 016 |
+
+## Hallazgos de esta pasada
+
+| #          | Qué                                                                                                      | Disposición Tier 2                                                                                                                |
+| ---------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| #17        | Login `fullSync()` fire-and-forget; si el retry-1 pierde la carrera, pull inicial no-op                  | endurecer: `retries=2`, test de la carrera                                                                                        |
+| #18        | `retryErrorRecords()` apunta a `"error"` (muerto) → el botón "reintentar" de la consola no recupera nada | **fix-ahora**: apuntar a `"failed"` + resetear `sync_retry`                                                                       |
+| #19        | `pullAllPending` traga errores por tabla (cuenta + log, nadie lee)                                       | **fix-ahora**: registrar último error por tabla en `sync_meta`, exponer a la consola                                              |
+| #21        | `useAutoSync` deps `[isOnline]` → parpadeo de red encola ciclos                                          | **fix-ahora**: debounce del reconnect + guard de solapamiento                                                                     |
+| #5 (parte) | `last_modified` no avanza server-side en ~30 tablas al UPDATE                                            | **interim fix-ahora**: migración `016` — trigger en todas las SYNC_TABLES. Test de clock skew.                                    |
+| #3 (parte) | conflicto = local gana silencioso                                                                        | **interim**: `logger.error` + detectar "remoto más nuevo que el local" + contador para la consola. Rediseño completo → follow-on. |
+| #20        | `LOCAL_ONLY_FIELDS`/`EXTRA_LOCAL_FIELDS` a mano                                                          | guard: test que diffea el schema Dexie vs las listas                                                                              |
+| #35        | `SyncStatus."conflict"` y `"error"` muertos en el enum                                                   | quitar del tipo                                                                                                                   |
+
+---
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc completo (10 secciones)
+- [x] #18 `retryErrorRecords` recupera `failed` + borra `sync_retry` + tests
+- [x] #19 `recordPullError` → `sync_meta` + `getFailingPullTables()` + tests
+- [x] #21 `useAutoSync` con debounce de reconnect + `runningRef` + tests
+- [x] #17 `getAuthenticatedUser` `retries: 1 → 2` + tests actualizados
+- [x] `016_last_modified_all_sync_tables.sql` — **PENDIENTE: el dueño la corre**
+      en Supabase (SQL Editor). Trigger en las 34 SYNC_TABLES.
+- [x] #3 interino: `logger.error` + `getPullConflictStats()` + tests
+- [x] #35: `"conflict"` quitado del enum `SyncStatus`. (`"error"` se deja —
+      `getErrorRecords` lo tolera; se limpia con la consola de sync en Tier 7.)
+- [x] Test de clock skew (`withClockSkew` + `stampServerTimestamps`)
+- [ ] #20 guard completo de field-lists — **parcial**: `sync-classification.test.ts`
+      (Tier 0) cubre tablas; el diff de columnas queda como issue.
+- [x] `npm run verify` limpio
+- [ ] Sign-off del dueño + correr migración 016
+- [ ] **Follow-on nombrado**: rediseño del modelo de conflicto (#3 completo +
+      #4 dirty-tracking por columna + #5 completo) — issue aparte.

--- a/src/hooks/use-auto-sync.test.tsx
+++ b/src/hooks/use-auto-sync.test.tsx
@@ -1,0 +1,75 @@
+// #21 — useAutoSync debe debouncear el reconnect: un parpadeo de red
+// (online→offline→online rápido) no debe disparar un ciclo de sync.
+// Ver docs/modules/04-sync.md.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+const pushAllPending = vi.fn().mockResolvedValue({ pushed: 0, errors: 0 });
+const pullAllPending = vi.fn().mockResolvedValue({ pulled: 0, errors: 0 });
+let online = true;
+
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  pushAllPending: () => pushAllPending(),
+  pullAllPending: () => pullAllPending(),
+}));
+vi.mock("./use-online-status", () => ({ useOnlineStatus: () => online }));
+
+import { useAutoSync } from "./use-auto-sync";
+
+function Harness() {
+  useAutoSync();
+  return null;
+}
+
+describe("useAutoSync — debounce del reconnect (#21)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    pushAllPending.mockClear();
+    pullAllPending.mockClear();
+    online = true;
+  });
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("no sincroniza dentro de los primeros 3s tras montar online", () => {
+    render(<Harness />);
+    vi.advanceTimersByTime(2000);
+    expect(pushAllPending).not.toHaveBeenCalled();
+  });
+
+  it("sincroniza una vez pasado el debounce", async () => {
+    render(<Harness />);
+    await vi.advanceTimersByTimeAsync(3500);
+    expect(pushAllPending).toHaveBeenCalledTimes(1);
+    expect(pullAllPending).toHaveBeenCalledTimes(1);
+  });
+
+  it("un parpadeo online→offline→online antes del debounce NO dispara sync", async () => {
+    const { rerender } = render(<Harness />);
+    vi.advanceTimersByTime(1000);
+
+    online = false;
+    rerender(<Harness />);
+    vi.advanceTimersByTime(500);
+
+    online = true;
+    rerender(<Harness />);
+    // Solo pasaron 1.5s del segundo "online" — todavía dentro del debounce.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(pushAllPending).not.toHaveBeenCalled();
+
+    // Ahora sí, completado el debounce del último reconnect.
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(pushAllPending).toHaveBeenCalledTimes(1);
+  });
+
+  it("offline limpia el timer: no sincroniza aunque pase el tiempo", async () => {
+    online = false;
+    render(<Harness />);
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(pushAllPending).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-auto-sync.ts
+++ b/src/hooks/use-auto-sync.ts
@@ -5,6 +5,9 @@ import { pullAllPending, pushAllPending } from "@/lib/supabase/sync-engine";
 import { useOnlineStatus } from "./use-online-status";
 
 const SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutos
+// Espera de conexión estable antes del primer ciclo tras reconectar —
+// evita disparar sync en cada parpadeo de red (#21).
+const RECONNECT_DEBOUNCE_MS = 3000;
 
 /**
  * Push de lo propio, después pull incremental de lo ajeno — en ese orden
@@ -30,29 +33,44 @@ async function syncCycle() {
  */
 export function useAutoSync() {
   const isOnline = useOnlineStatus();
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Evita solapar dos syncCycle si un tick del interval cae mientras el
+  // anterior sigue corriendo (el lock lo cubre igual, pero así ni siquiera
+  // se levanta un cliente Supabase de más).
+  const runningRef = useRef(false);
 
   useEffect(() => {
+    const clearAll = () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      intervalRef.current = null;
+      debounceRef.current = null;
+    };
+
     if (!isOnline) {
-      if (timerRef.current) {
-        clearInterval(timerRef.current);
-        timerRef.current = null;
-      }
+      clearAll();
       return;
     }
 
-    // Ciclo inmediato al recuperar conexión
-    syncCycle();
-
-    timerRef.current = setInterval(() => {
-      syncCycle();
-    }, SYNC_INTERVAL_MS);
-
-    return () => {
-      if (timerRef.current) {
-        clearInterval(timerRef.current);
-        timerRef.current = null;
+    const runCycle = async () => {
+      if (runningRef.current) return;
+      runningRef.current = true;
+      try {
+        await syncCycle();
+      } finally {
+        runningRef.current = false;
       }
     };
+
+    // Al (re)conectar: esperar RECONNECT_DEBOUNCE_MS de conexión estable
+    // antes del primer ciclo. Si isOnline vuelve a cambiar antes, el
+    // cleanup limpia este timeout y no se dispara nada.
+    debounceRef.current = setTimeout(() => {
+      runCycle();
+      intervalRef.current = setInterval(runCycle, SYNC_INTERVAL_MS);
+    }, RECONNECT_DEBOUNCE_MS);
+
+    return clearAll;
   }, [isOnline]);
 }

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -3,8 +3,19 @@
 //  Mapeados desde el DBML actualizado
 // ============================================================
 
-/** Estado de sincronización para registros offline */
-export type SyncStatus = "pending" | "synced" | "conflict" | "error" | "failed";
+/**
+ * Estado de sincronización para registros offline.
+ * - "pending": editado local, aún no subido.
+ * - "synced": al día con el servidor.
+ * - "failed": el push agotó los reintentos o tuvo un error permanente
+ *   (terminal — solo se recupera con retryRecord / retryErrorRecords).
+ * - "error": legacy. Nada lo setea hoy; se conserva en el union porque
+ *   `getErrorRecords` lo tolera. Se quita junto con la consola de sync (Tier 7).
+ *
+ * ("conflict" se eliminó en Tier 2 — nunca se escribió; el conflicto ahora
+ * deja la fila en "pending" para que el próximo push la reintente.)
+ */
+export type SyncStatus = "pending" | "synced" | "error" | "failed";
 
 /** Campos comunes de sincronización */
 export interface SyncFields {
@@ -753,6 +764,10 @@ export interface ChangeLog {
 export interface SyncMeta {
   table_name: string;
   last_pulled_at: string;
+  /** Último error de pull de esta tabla, si el ciclo automático viene
+   * fallando. Se limpia cuando un pull vuelve a tener éxito. (#19) */
+  last_pull_error?: string | null;
+  last_pull_error_at?: string | null;
 }
 
 // ─── Informes con versionamiento ───

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -662,16 +662,32 @@ describe("sync-engine — getAuthenticatedUser", () => {
     expect(getUser).toHaveBeenCalledTimes(1);
   });
 
-  it("devuelve null si sigue sin sesión después del reintento (no reintenta indefinidamente)", async () => {
+  it("devuelve null tras agotar los reintentos (default 2 → 3 lecturas, no infinito)", async () => {
     vi.useFakeTimers();
     const getUser = vi.fn().mockResolvedValue({ data: { user: null } });
 
     const promise = getAuthenticatedUser({ auth: { getUser } });
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2000);
     const user = await promise;
 
     expect(user).toBeNull();
-    expect(getUser).toHaveBeenCalledTimes(2);
+    expect(getUser).toHaveBeenCalledTimes(3); // inicial + 2 reintentos (#17)
+  });
+
+  it("recupera la sesión que aparece recién en el 3er intento (default retries=2)", async () => {
+    vi.useFakeTimers();
+    const getUser = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { user: null } })
+      .mockResolvedValueOnce({ data: { user: null } })
+      .mockResolvedValueOnce({ data: { user: { id: "user-1" } } });
+
+    const promise = getAuthenticatedUser({ auth: { getUser } });
+    await vi.advanceTimersByTimeAsync(2000);
+    const user = await promise;
+
+    expect(user).toEqual({ id: "user-1" });
+    expect(getUser).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -253,7 +253,7 @@ export async function fullSync(): Promise<SyncResult> {
 export async function getAuthenticatedUser(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   supabase: any,
-  retries = 1,
+  retries = 2,
   delayMs = 500
 ): Promise<{ id: string } | null> {
   for (let attempt = 0; ; attempt++) {
@@ -335,6 +335,7 @@ async function runFullSync(): Promise<SyncResult> {
         detail,
         action: "pull",
       });
+      await recordPullError(table.local, err);
     }
   }
 
@@ -654,6 +655,7 @@ async function runPullAllPending(): Promise<{ pulled: number; errors: number }> 
     } catch (err) {
       totalErrors++;
       logger.error("sync:pull-incremental", `Error descargando ${tableLabel(table.local)}`, err);
+      await recordPullError(table.local, err);
     }
   }
 
@@ -706,6 +708,28 @@ async function pullMasterTable(
 const SYNC_PAGE_SIZE = 500;
 
 /**
+ * Contador en memoria de colisiones detectadas durante el pull: una fila
+ * remota MÁS NUEVA que una edición local sin subir (el remoto se descarta
+ * y el local se sube encima al próximo push = pérdida potencial del dato
+ * del servidor). Interino hasta el rediseño del modelo de conflicto
+ * (#3/#4/#5). La consola de sync lo lee vía `getPullConflictStats()`.
+ */
+let pullConflictCount = 0;
+const pullConflictSample: { table: string; id: string; at: string }[] = [];
+
+export function getPullConflictStats(): {
+  count: number;
+  sample: { table: string; id: string; at: string }[];
+} {
+  return { count: pullConflictCount, sample: [...pullConflictSample] };
+}
+
+export function resetPullConflictStats(): void {
+  pullConflictCount = 0;
+  pullConflictSample.length = 0;
+}
+
+/**
  * Aplica un registro remoto individual al Dexie local, resolviendo el
  * conflicto si hay cambios locales pendientes (cualquier sync_status
  * distinto de "synced" se trata como cambio local sin confirmar).
@@ -737,10 +761,33 @@ async function applyRemoteSyncRecord(
   // y retryErrorRecords nunca consultan "conflict") — quedaba huérfana,
   // invisible en la UI (countSyncStatuses tampoco la cuenta), y la edición
   // del técnico se perdía en silencio.
-  logger.warn(
-    "sync:pull",
-    `Conflicto en ${localTable}#${remoteRecord.id} — manteniendo versión local pendiente de push`
-  );
+  //
+  // #3 interino: si el remoto es ESTRICTAMENTE más nuevo que el local, esto
+  // es una colisión real (el próximo push pisa datos más nuevos del
+  // servidor). Se registra como error y se cuenta para la consola. El
+  // rediseño (merge por columna / cola de conflictos) es follow-on.
+  const remoteTs = String(remoteRecord.last_modified ?? "");
+  const localTs = String((localRecord as { last_modified?: string }).last_modified ?? "");
+  if (remoteTs && localTs && remoteTs > localTs) {
+    pullConflictCount++;
+    if (pullConflictSample.length < 20) {
+      pullConflictSample.push({
+        table: localTable,
+        id: String(remoteRecord.id),
+        at: new Date().toISOString(),
+      });
+    }
+    logger.error(
+      "sync:conflict",
+      `Colisión en ${localTable}#${remoteRecord.id}: el servidor tiene una versión más nueva ` +
+        `(${remoteTs}) que la edición local sin subir (${localTs}). El próximo push la pisa.`
+    );
+  } else {
+    logger.warn(
+      "sync:pull",
+      `Conflicto en ${localTable}#${remoteRecord.id} — manteniendo versión local pendiente de push`
+    );
+  }
   return 0;
 }
 
@@ -832,9 +879,55 @@ async function getLastSyncTimestamp(table: string): Promise<string | null> {
 
 async function setLastSyncTimestamp(table: string, timestamp: string): Promise<void> {
   try {
-    await db.sync_meta.put({ table_name: table, last_pulled_at: timestamp });
+    // Pull exitoso → avanza el watermark y limpia el último error registrado.
+    await db.sync_meta.put({
+      table_name: table,
+      last_pulled_at: timestamp,
+      last_pull_error: null,
+      last_pull_error_at: null,
+    });
   } catch (err) {
     logger.error("sync:timestamp", `Error guardando timestamp de ${table}`, err);
+  }
+}
+
+/**
+ * Registra que el pull de una tabla falló, para que la consola de sync
+ * pueda mostrar "esta tabla viene fallando" en vez de que el error quede
+ * solo en los logs (#19). No toca el watermark — se reintenta al próximo
+ * ciclo.
+ */
+async function recordPullError(table: string, err: unknown): Promise<void> {
+  try {
+    const { message } = describeError(err);
+    const existing = await db.sync_meta.get(table);
+    await db.sync_meta.put({
+      table_name: table,
+      last_pulled_at: existing?.last_pulled_at ?? "",
+      last_pull_error: message,
+      last_pull_error_at: new Date().toISOString(),
+    });
+  } catch (metaErr) {
+    logger.error("sync:pull-error", `No se pudo registrar el error de pull de ${table}`, metaErr);
+  }
+}
+
+/** Tablas cuyo pull automático viene fallando (para la consola de sync). */
+export async function getFailingPullTables(): Promise<
+  { table: string; tableLabel: string; error: string; since: string }[]
+> {
+  try {
+    const rows = await db.sync_meta.toArray();
+    return rows
+      .filter((r) => r.last_pull_error)
+      .map((r) => ({
+        table: r.table_name,
+        tableLabel: tableLabel(r.table_name),
+        error: r.last_pull_error as string,
+        since: r.last_pull_error_at ?? "",
+      }));
+  } catch {
+    return [];
   }
 }
 
@@ -947,9 +1040,16 @@ export async function retryErrorRecords(): Promise<number> {
       const dexieTable = getDexieTable(table.local);
       if (!dexieTable) continue;
 
-      const errored = await dexieTable.where("sync_status").equals("error").toArray();
-      for (const rec of errored) {
-        await dexieTable.update(rec.id as string, { sync_status: "pending" as SyncStatus });
+      // "error" es un estado legacy que hoy nada setea; "failed" es el
+      // estado terminal real (agotó MAX_ATTEMPTS o error permanente). Ambos
+      // vuelven a "pending" Y se les borra la fila de sync_retry para que
+      // el backoff arranque limpio — si no, el próximo push los volvería a
+      // marcar "failed" de inmediato.
+      const stuck = await dexieTable.where("sync_status").anyOf(["error", "failed"]).toArray();
+      for (const rec of stuck) {
+        const id = rec.id as string;
+        await db.sync_retry.delete([table.local, id]);
+        await dexieTable.update(id, { sync_status: "pending" as SyncStatus });
         count++;
       }
     } catch (err) {

--- a/src/lib/supabase/sync-tier2.test.ts
+++ b/src/lib/supabase/sync-tier2.test.ts
@@ -1,0 +1,182 @@
+// Tier 2 — fix-ahora del motor de sync (#17-#21, #3 interino).
+// Ver docs/modules/04-sync.md.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { createFakeSupabaseClient, type FakeSupabaseClient } from "@/test/fake-supabase";
+import { withClockSkew } from "@/test/net";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let fakeClient: any;
+vi.mock("./client", () => ({ createClient: () => fakeClient }));
+
+import {
+  retryErrorRecords,
+  getFailingPullTables,
+  pullAllPending,
+  pullSyncTable,
+  getPullConflictStats,
+  resetPullConflictStats,
+} from "./sync-engine";
+
+beforeEach(async () => {
+  await resetTestDb();
+  fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  resetPullConflictStats();
+});
+afterEach(() => vi.restoreAllMocks());
+
+// ─── #18: retryErrorRecords recupera filas "failed" ───
+
+describe("#18 — retryErrorRecords recupera registros terminales", () => {
+  it("mueve una fila 'failed' a 'pending' y le borra la fila de sync_retry", async () => {
+    await db.clientes.add({
+      id: "c-failed",
+      nombre_cliente: "X",
+      nit: "1",
+      sync_status: "failed",
+      last_modified: "2026-01-01T00:00:00.000Z",
+    });
+    await db.sync_retry.put({
+      table_name: "clientes",
+      record_id: "c-failed",
+      attempts: 5,
+      next_attempt_at: "2026-01-01T00:00:00.000Z",
+      status: "failed",
+      last_error: "boom",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    });
+
+    const count = await retryErrorRecords();
+
+    expect(count).toBe(1);
+    expect((await db.clientes.get("c-failed"))?.sync_status).toBe("pending");
+    expect(await db.sync_retry.get(["clientes", "c-failed"])).toBeUndefined();
+  });
+
+  it("no toca filas 'synced'", async () => {
+    await db.clientes.add({
+      id: "ok",
+      nombre_cliente: "X",
+      nit: "1",
+      sync_status: "synced",
+      last_modified: "2026-01-01T00:00:00.000Z",
+    });
+    expect(await retryErrorRecords()).toBe(0);
+    expect((await db.clientes.get("ok"))?.sync_status).toBe("synced");
+  });
+});
+
+// ─── #19: errores de pull por tabla quedan visibles ───
+
+describe("#19 — pullAllPending registra el error por tabla", () => {
+  it("un fallo de pull queda en sync_meta y lo lista getFailingPullTables", async () => {
+    fakeClient.throwOnCall("clientes", "select", 1, { message: "boom de red", code: "500" });
+
+    await pullAllPending();
+
+    const failing = await getFailingPullTables();
+    const clientes = failing.find((f) => f.table === "clientes");
+    expect(clientes?.error).toContain("boom de red");
+    expect(clientes?.since).toBeTruthy();
+  });
+
+  it("un pull exitoso posterior limpia el error registrado", async () => {
+    await db.sync_meta.put({
+      table_name: "clientes",
+      last_pulled_at: "",
+      last_pull_error: "viejo error",
+      last_pull_error_at: "2026-01-01T00:00:00.000Z",
+    });
+
+    await pullSyncTable(fakeClient, "clientes", "clientes");
+
+    const meta = await db.sync_meta.get("clientes");
+    expect(meta?.last_pull_error).toBeNull();
+    expect((await getFailingPullTables()).length).toBe(0);
+  });
+});
+
+// ─── #3 interino: colisión "servidor más nuevo que edición local" ───
+
+describe("#3 interino — detección de colisión en el pull", () => {
+  it("cuenta la colisión cuando el remoto es más nuevo que el local pendiente", async () => {
+    await db.clientes.add({
+      id: "c1",
+      nombre_cliente: "edición local sin subir",
+      nit: "1",
+      sync_status: "pending",
+      last_modified: "2026-01-01T00:00:00.000Z",
+    });
+    fakeClient.seedTable("clientes", [
+      {
+        id: "c1",
+        nombre_cliente: "versión del servidor, más nueva",
+        nit: "1",
+        last_modified: "2026-06-01T00:00:00.000Z",
+      },
+    ]);
+
+    await pullSyncTable(fakeClient, "clientes", "clientes");
+
+    const stats = getPullConflictStats();
+    expect(stats.count).toBe(1);
+    expect(stats.sample[0]).toMatchObject({ table: "clientes", id: "c1" });
+    // El local NO se pisa (se mantiene la edición pendiente).
+    expect((await db.clientes.get("c1"))?.nombre_cliente).toBe("edición local sin subir");
+    expect((await db.clientes.get("c1"))?.sync_status).toBe("pending");
+  });
+
+  it("NO cuenta colisión si el local pendiente es más nuevo que el remoto", async () => {
+    await db.clientes.add({
+      id: "c2",
+      nombre_cliente: "local nuevo",
+      nit: "1",
+      sync_status: "pending",
+      last_modified: "2026-06-01T00:00:00.000Z",
+    });
+    fakeClient.seedTable("clientes", [
+      {
+        id: "c2",
+        nombre_cliente: "remoto viejo",
+        nit: "1",
+        last_modified: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    await pullSyncTable(fakeClient, "clientes", "clientes");
+
+    expect(getPullConflictStats().count).toBe(0);
+  });
+});
+
+// ─── #5 interino: watermark a prueba de reloj desfasado ───
+//
+// La migración 016 hace que Supabase estampe `last_modified` server-side en
+// cada UPDATE. Con eso, un dispositivo con el reloj adelantado NO rompe el
+// pull incremental de otro: el filtro `.gt(last_modified, watermark)` usa
+// timestamps del servidor, no del cliente.
+
+describe("#5 interino — pull incremental con reloj de cliente desfasado", () => {
+  it("un cliente con reloj +2h igual baja las filas nuevas (timestamps del servidor)", async () => {
+    // El servidor estampa last_modified con SU reloj (stampServerTimestamps).
+    fakeClient = createFakeSupabaseClient({ stampServerTimestamps: true }) as FakeSupabaseClient;
+
+    // Fila en el servidor "recién" modificada (hora del servidor = ahora real).
+    fakeClient.seedTable("clientes", [
+      { id: "c-server", nombre_cliente: "del servidor", nit: "1" },
+    ]);
+    // Forzar el estampado server-side simulando un upsert.
+    await fakeClient.from("clientes").upsert({ id: "c-server", nombre_cliente: "del servidor" });
+
+    // Watermark local viejo (nunca sincronizó esta tabla).
+    // El cliente corre el pull con el reloj +2h adelantado.
+    const pulled = await withClockSkew(2 * 60 * 60 * 1000, () =>
+      pullSyncTable(fakeClient, "clientes", "clientes")
+    );
+
+    expect(pulled).toBeGreaterThan(0);
+    expect((await db.clientes.get("c-server"))?.sync_status).toBe("synced");
+  });
+});

--- a/supabase/migrations/016_last_modified_all_sync_tables.sql
+++ b/supabase/migrations/016_last_modified_all_sync_tables.sql
@@ -1,0 +1,61 @@
+-- ============================================================
+--  016 — Trigger last_modified en TODAS las tablas de sync
+--
+--  Contexto (hallazgo #5 de la intervención):
+--  El cliente quita `last_modified` antes de pushear (LOCAL_ONLY_FIELDS
+--  en sync-engine.ts). Del lado Supabase, la columna tiene DEFAULT NOW()
+--  (cubre el INSERT) pero el trigger BEFORE UPDATE que reasigna NOW()
+--  existía solo en 5 tablas (visitas, prueba_resultados,
+--  mediciones_radiometricas, evidencias, grupo_resultados).
+--
+--  Consecuencia: en las ~30 tablas restantes, un UPDATE (vía UPSERT
+--  ON CONFLICT) NO avanzaba `last_modified` → el pull incremental de
+--  otro dispositivo (`.gt(last_modified, watermark)`) nunca volvía a
+--  traer esa fila editada. Los edits de clientes/equipos/conv_* no
+--  propagaban entre dispositivos.
+--
+--  Esta migración crea el trigger BEFORE INSERT OR UPDATE en cada tabla
+--  de sync que tenga la columna `last_modified`. Idempotente
+--  (DROP TRIGGER IF EXISTS). Correr en Supabase → SQL Editor.
+-- ============================================================
+
+-- La función ya existe (001), pero la re-declaramos por si esta
+-- migración corre sobre una base parcial.
+CREATE OR REPLACE FUNCTION update_last_modified()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.last_modified = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+DECLARE
+  t text;
+  sync_tables text[] := ARRAY[
+    'clientes','contactos','sedes','ubicaciones_rx','equipos','equipo_movimientos',
+    'tubos','colimadores','gantry','solicitudes',
+    'visitas','grupo_resultados','prueba_resultados','mediciones_radiometricas','evidencias',
+    'conv_levantamiento_setup','conv_mediciones','conv_inspeccion_items','conv_elementos_proteccion',
+    'conv_raysafe_setup','conv_raysafe_mediciones','conv_cae_setup','conv_cae_mediciones',
+    'conv_ddi_mediciones','conv_cassette_inspeccion','conv_uniformidad_cr','conv_colimacion',
+    'conv_uniformidad_detector','conv_resolucion','conv_bajo_contraste','conv_mtf',
+    'conv_informe_secciones','conv_resultados_prueba','conv_evidencias'
+  ];
+BEGIN
+  FOREACH t IN ARRAY sync_tables LOOP
+    -- Solo si la tabla existe y tiene la columna last_modified.
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = t AND column_name = 'last_modified'
+    ) THEN
+      EXECUTE format('DROP TRIGGER IF EXISTS trg_%I_modified ON public.%I', t, t);
+      EXECUTE format(
+        'CREATE TRIGGER trg_%I_modified BEFORE INSERT OR UPDATE ON public.%I '
+        || 'FOR EACH ROW EXECUTE FUNCTION update_last_modified()', t, t);
+      RAISE NOTICE 'trigger last_modified creado en %', t;
+    ELSE
+      RAISE NOTICE 'SALTADA: % no existe o no tiene columna last_modified', t;
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
Módulo 4 de la intervención. **Alcance acotado**: los fix-ahora chicos + guardas interinas. El rediseño del modelo de conflicto es follow-on (#38).

## Fixes

| # | Antes | Ahora |
|---|---|---|
| #18 | `retryErrorRecords()` apuntaba a `sync_status "error"` — que nada setea → el botón "reintentar todo" de la consola **no hacía nada** | apunta a `"failed"` + borra `sync_retry` (backoff limpio) |
| #19 | error de pull por tabla → solo en logs, invisible | `sync_meta.last_pull_error` + `getFailingPullTables()` para la consola |
| #17 | `getAuthenticatedUser` retries=1 → la carrera del login inicial se perdía seguido | retries=2 |
| #21 | `useAutoSync` disparaba sync en cada parpadeo de red | debounce de 3s de conexión estable + `runningRef` anti-solape |
| #3 (interino) | conflicto = local gana **en silencio** | detecta "remoto más nuevo que local pendiente" → `logger.error` + `getPullConflictStats()`. No lo evita (eso es #38) |
| #5 (interino) | trigger `last_modified` solo en 5 tablas → edits de ~30 tablas no propagaban entre dispositivos | **migración `016`** — trigger en las 34 SYNC_TABLES |
| #35 | `"conflict"` muerto en el enum `SyncStatus` | quitado |

## ⚠️ Acción del dueño

**Correr `supabase/migrations/016_last_modified_all_sync_tables.sql`** en Supabase → SQL Editor. Es idempotente y tiene guard de columna. Sin esto, los edits de clientes/equipos/`conv_*` siguen sin propagar entre dispositivos.

## Verificación

`npm run verify` — exit 0: **326 tests / 32 archivos** · lint 0 errores · formato y tipos limpios.

## Follow-on (issues)

- **#38** — rediseño del modelo de conflicto (#3 completo + #4 dirty-tracking por columna + #5 completo)
- **#39** — guard de columnas locales vs Supabase (#20)