### PR TITLE
Tier 4 — workflow de visitas (re-PR a main)

### DIFF
--- a/docs/modules/08-workflow.md
+++ b/docs/modules/08-workflow.md
@@ -1,0 +1,71 @@
+# Módulo: workflow de visitas (`src/lib/workflow/`)
+
+> Estado: 🟡 en curso (Tier 4 · Módulos 10–14) · 2026-08-28
+> `module-completeness.ts`, `visita-service.ts`, `visit-state-machine.ts`,
+> `informe-service.ts`, `publicar-informe.ts`, `equipo-service.ts`,
+> `change-tracker.ts`, `validation.ts`. Antes: solo `visit-state-machine.test.ts`
+> (transiciones/roles, puro).
+
+---
+
+## 1. Responsabilidad
+
+El ciclo de vida de una visita: `asignada → en_progreso → en_revision →
+aprobada → enviada` (+ back-edges `devolver` y `solicitar_ajustes_cliente`).
+
+| Archivo               | Qué                                                                |
+| --------------------- | ------------------------------------------------------------------ |
+| `visita-service`      | `crearVisitaDesdeSolicitud` — nace la visita + auto-genera pruebas |
+| `module-completeness` | ¿la visita está lista para avanzar? (gate input)                   |
+| `visit-state-machine` | transiciones + gates + `executeTransition` (efecto en DB)          |
+| `informe-service`     | `crearInformeDesdeVisita` — numeración, concepto, versionado       |
+| `publicar-informe`    | PDF oficial + QR + hash + Storage                                  |
+| `equipo-service`      | `trasladarEquipo`                                                  |
+| `change-tracker`      | auditoría genérica de cambios (`change_logs`)                      |
+| `validation`          | wrapper descriptivo de `getVisitCompleteness` (sin callers hoy)    |
+
+## 2. Hallazgos y disposición
+
+| #                                                    | Qué                                                                                                                                                                                              | En este PR                                                                                                                                                                  |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **#6**                                               | `crearVisitaDesdeSolicitud`: regeneraba el id de la visita; `console.error`; una visita con paquete pero **0 pruebas** (catálogo `grupo_pruebas` sin sembrar) devolvía `success: true` sin señal | **fix-ahora**: usa el id existente; `logger.error`; `logger.warn` si `pruebasCreadas === 0`                                                                                 |
+| **#7**                                               | Visita de tipo sin paquete → nunca pasa el gate (ids de `getModuleStatuses` ≠ `getDefaultModules`)                                                                                               | **guard cableado**: `assertCanCreateVisitFor` en `crearVisitaDesdeSolicitud` → `NoPackageError`. Fix real (unificar ids) → issue, cuando arranque el 2º equipo              |
+| **#8**                                               | `aprobar` NO tenía gate — se podía aprobar (y publicar el PDF oficial) una visita incompleta                                                                                                     | **fix-ahora**: `aprobar` ahora tiene `hasGate: true`; `checkGate` aplica la misma completitud que `enviar_revision`                                                         |
+| **#9**                                               | `executeTransition` hacía visita + solicitud + informe como pasos sueltos no transaccionales; publish fire-and-forget con `console.error`                                                        | **interino**: las 3 escrituras de estado en `db.transaction`; publish falla → `logger.error`; `checkVisitConsistency()` detecta divergencias. **Rediseño completo → issue** |
+| **#15**                                              | `getVisitCompletenessBulk` = loop secuencial de `getVisitCompleteness` (O(visitas × ~15 scans conv*\*)), re-corre en cada mutación conv*\*                                                       | **backlog** → issue (batch/memoize)                                                                                                                                         |
+| **#22**                                              | `db.informes.where("visita_id").first()` → fila arbitraria si hubiera duplicados                                                                                                                 | **fix defensivo**: se ordena por `version_actual` desc antes de tomar `[0]` (hay 1 informe por visita por diseño)                                                           |
+| `pctResueltas` / `preInformePct` `total === 0 → 100` | fail-open: un grupo sin pruebas contaba como completo                                                                                                                                            | **fix-ahora**: → `0` (fail-safe). Hoy es defensivo (para CONVENCIONAL cada grupo tiene 2-6 secciones fijas)                                                                 |
+| `change-tracker.getChangeHistory`                    | usa `.where("[tabla+registro_id]")` sin índice compuesto declarado                                                                                                                               | **verificado OK**: Dexie 4 lo resuelve con los índices simples `tabla`/`registro_id`. Sin acción                                                                            |
+
+## 3. Cobertura nueva
+
+- `module-completeness.test.ts` (6): visita fresca → bloquea; todo excluido → pasa; PIN #7; PIN #15.
+- `workflow-tier4.test.ts` (11): #8 gate de `aprobar`; #9 transacción + `checkVisitConsistency`; #6/#7 en `crearVisitaDesdeSolicitud`.
+- `informe-equipo-service.test.ts` (10): numeración `EYC-año-seq`, concepto rollup, vencimiento 2 años, re-aprobación = nueva versión mismo informe; `trasladarEquipo` (transacción, guards).
+- `change-tracker.test.ts` (6): `trackChange`, `updateWithTracking` (diff-only), `getChangeHistory`.
+
+## Modos de falla
+
+| Falla                                                  | Efecto                                  | Manejo                                                                                                 |
+| ------------------------------------------------------ | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Aprobar visita incompleta                              | antes: PDF oficial de datos incompletos | ahora: bloqueado por el gate                                                                           |
+| `crearInformeDesdeVisita` falla tras cambiar el estado | visita "aprobada" sin informe           | `checkVisitConsistency` lo detecta; rediseño → issue                                                   |
+| `publicarVersionOficial` falla                         | visita aprobada, sin PDF oficial        | `logger.error` + botón "Publicar versión oficial" en `informes/[id]`; `checkVisitConsistency` lo lista |
+| Catálogo `grupo_pruebas` sin sembrar                   | visita CONVENCIONAL con 0 pruebas       | `logger.warn` (antes: silencio)                                                                        |
+
+---
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc
+- [x] #6: id + `logger` + warn de 0 pruebas
+- [x] #7: guard `assertCanCreateVisitFor` cableado en `visita-service`
+- [x] #8: `aprobar` con gate de completitud
+- [x] #9 interino: transacción de estado + `checkVisitConsistency`
+- [x] `pctResueltas` fail-safe
+- [x] Tests (33 nuevos)
+- [ ] Issue: rediseño completo de #9 (informe/publish transaccional o saga)
+- [ ] Issue: #15 perf de `getVisitCompletenessBulk`
+- [ ] Issue: #7 unificar ids `getModuleStatuses` ↔ `getDefaultModules` (al 2º equipo)
+- [x] `npm run verify` limpio
+- [ ] Sign-off del dueño

--- a/src/lib/equipos/index.ts
+++ b/src/lib/equipos/index.ts
@@ -11,6 +11,9 @@ export {
   getModules,
   getDefaultModules,
   getRequiredModules,
+  canCreateVisitFor,
+  assertCanCreateVisitFor,
+  NoPackageError,
 } from "./registry";
 
 // Tipos

--- a/src/lib/workflow/change-tracker.test.ts
+++ b/src/lib/workflow/change-tracker.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { trackChange, updateWithTracking, getChangeHistory } from "./change-tracker";
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("trackChange", () => {
+  it("escribe una fila en change_logs", async () => {
+    await trackChange("clientes", "c1", "nombre", "viejo", "nuevo", "u1");
+    const logs = await db.change_logs.toArray();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      tabla: "clientes",
+      registro_id: "c1",
+      campo: "nombre",
+      valor_anterior: "viejo",
+      valor_nuevo: "nuevo",
+      modificado_por_id: "u1",
+    });
+  });
+});
+
+describe("updateWithTracking", () => {
+  it("loguea SOLO los campos que cambiaron y aplica el update", async () => {
+    await db.clientes.add({
+      id: "c1",
+      nombre_cliente: "ACME",
+      nit: "1",
+      telefono: "111",
+      sync_status: "synced",
+      last_modified: "x",
+    });
+
+    const changed = await updateWithTracking(
+      "clientes",
+      db.clientes as unknown as Parameters<typeof updateWithTracking>[1],
+      "c1",
+      { nombre_cliente: "ACME S.A.", telefono: "111" }, // solo nombre cambia
+      "u1"
+    );
+
+    expect(changed).toEqual(["nombre_cliente"]);
+    expect((await db.clientes.get("c1"))?.nombre_cliente).toBe("ACME S.A.");
+    expect(await db.change_logs.count()).toBe(1);
+  });
+
+  it("registro inexistente → [] y no escribe nada", async () => {
+    expect(
+      await updateWithTracking(
+        "clientes",
+        db.clientes as unknown as Parameters<typeof updateWithTracking>[1],
+        "no-existe",
+        { nit: "9" },
+        "u"
+      )
+    ).toEqual([]);
+    expect(await db.change_logs.count()).toBe(0);
+  });
+
+  it("sin cambios reales → [] y no aplica update", async () => {
+    await db.clientes.add({
+      id: "c2",
+      nombre_cliente: "X",
+      nit: "1",
+      sync_status: "synced",
+      last_modified: "x",
+    });
+    const changed = await updateWithTracking(
+      "clientes",
+      db.clientes as unknown as Parameters<typeof updateWithTracking>[1],
+      "c2",
+      { nombre_cliente: "X" },
+      "u"
+    );
+    expect(changed).toEqual([]);
+    expect(await db.change_logs.count()).toBe(0);
+  });
+});
+
+describe("getChangeHistory", () => {
+  it("trae el historial de un registro (Dexie 4 resuelve el where compuesto con los índices simples)", async () => {
+    // Verificado: aunque el schema no declara el índice compuesto
+    // [tabla+registro_id], Dexie 4 lo resuelve usando los índices `tabla` y
+    // `registro_id` que sí existen. getChangeHistory funciona.
+    await trackChange("clientes", "c1", "nombre", "a", "b", "u1");
+    await trackChange("clientes", "c1", "nit", "1", "2", "u1");
+    await trackChange("clientes", "OTRO", "nombre", "x", "y", "u1");
+
+    const history = await getChangeHistory("clientes", "c1");
+    expect(history).toHaveLength(2);
+    expect(history.map((h) => h.campo).sort()).toEqual(["nit", "nombre"]);
+  });
+
+  it("sin historial → []", async () => {
+    expect(await getChangeHistory("clientes", "nada")).toEqual([]);
+  });
+});

--- a/src/lib/workflow/equipo-service.ts
+++ b/src/lib/workflow/equipo-service.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { randomUUID } from "@/lib/uuid";
+import { logger } from "@/lib/logger";
 import { pushSingle } from "@/lib/supabase/sync-engine";
 import type { EquipoMovimiento } from "@/lib/db/types";
 
@@ -77,7 +78,7 @@ export async function trasladarEquipo(
 
     return { success: true, movimientoId };
   } catch (err) {
-    console.error("[EquipoService] Error al trasladar:", err);
+    logger.error("equipo:traslado", "Error al trasladar equipo", err);
     return {
       success: false,
       error: err instanceof Error ? err.message : "Error desconocido",

--- a/src/lib/workflow/informe-equipo-service.test.ts
+++ b/src/lib/workflow/informe-equipo-service.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+import { makeUbicacion } from "@/test/factories";
+
+const pushSingle = vi.fn().mockResolvedValue(true);
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  pushSingle: (...a: unknown[]) => pushSingle(...a),
+}));
+
+import { crearInformeDesdeVisita } from "./informe-service";
+import { trasladarEquipo } from "./equipo-service";
+
+beforeEach(async () => {
+  await resetTestDb();
+  pushSingle.mockClear();
+});
+
+// ─── informe-service ───
+
+describe("crearInformeDesdeVisita", () => {
+  it("numera EYC-{año}-001 el primer informe del año", async () => {
+    const { visita } = await seedGraph();
+    const inf = await crearInformeDesdeVisita(visita!.id!, "ing-1", "tec-1");
+    expect(inf.numero_informe).toBe(`EYC-${new Date().getFullYear()}-001`);
+    expect(inf.version_actual).toBe(1);
+    expect(await db.informe_versiones.where("informe_id").equals(inf.id!).count()).toBe(1);
+  });
+
+  it("incrementa el secuencial con informes previos del año", async () => {
+    const year = new Date().getFullYear();
+    await db.informes.add({
+      id: "prev",
+      visita_id: "otra",
+      equipo_id: "e",
+      ubicacion_id: "u",
+      numero_informe: `EYC-${year}-007`,
+      version_actual: 1,
+      concepto_general: "FAVORABLE",
+      qr_token: "t",
+      fecha_emision: "2026-01-01",
+      fecha_vencimiento: "2028-01-01",
+      estado: "aprobado",
+      creado_en: "2026-01-01",
+    });
+    const { visita } = await seedGraph();
+    const inf = await crearInformeDesdeVisita(visita!.id!, "ing", "tec");
+    expect(inf.numero_informe).toBe(`EYC-${year}-008`);
+  });
+
+  it("concepto NO_FAVORABLE si alguna prueba lo es", async () => {
+    const { visita } = await seedGraph();
+    await db.prueba_resultados.bulkAdd([
+      {
+        id: "p1",
+        visita_id: visita!.id!,
+        prueba_definicion_id: "d1",
+        equipo_id: "e",
+        completado: true,
+        concepto: "FAVORABLE",
+        sync_status: "synced",
+        last_modified: "x",
+      },
+      {
+        id: "p2",
+        visita_id: visita!.id!,
+        prueba_definicion_id: "d2",
+        equipo_id: "e",
+        completado: true,
+        concepto: "NO_FAVORABLE",
+        sync_status: "synced",
+        last_modified: "x",
+      },
+    ]);
+    const inf = await crearInformeDesdeVisita(visita!.id!, "ing", "tec");
+    expect(inf.concepto_general).toBe("NO_FAVORABLE");
+  });
+
+  it("vencimiento a 2 años de la emisión", async () => {
+    const { visita } = await seedGraph();
+    const inf = await crearInformeDesdeVisita(visita!.id!, "ing", "tec");
+    const emis = new Date(inf.fecha_emision);
+    const venc = new Date(inf.fecha_vencimiento);
+    expect(venc.getFullYear() - emis.getFullYear()).toBe(2);
+  });
+
+  it("re-aprobación: nueva versión sobre el MISMO informe, no uno nuevo", async () => {
+    const { visita } = await seedGraph();
+    const inf1 = await crearInformeDesdeVisita(visita!.id!, "ing", "tec");
+    const inf2 = await crearInformeDesdeVisita(visita!.id!, "ing", "tec");
+
+    expect(inf2.id).toBe(inf1.id);
+    expect(inf2.version_actual).toBe(2);
+    expect(await db.informes.count()).toBe(1);
+    expect(await db.informe_versiones.where("informe_id").equals(inf1.id!).count()).toBe(2);
+  });
+
+  it("visita inexistente → lanza", async () => {
+    await expect(crearInformeDesdeVisita("no-existe", "i", "t")).rejects.toThrow();
+  });
+});
+
+// ─── equipo-service ───
+
+describe("trasladarEquipo", () => {
+  it("cambia ubicacion_id y registra el movimiento en una transacción", async () => {
+    const { equipo, sede } = await seedGraph({ conVisita: false });
+    const destino = makeUbicacion(sede.id!);
+    await db.ubicaciones_rx.add(destino);
+
+    const res = await trasladarEquipo(equipo.id!, destino.id!, {
+      motivo: "  mudanza  ",
+      registradoPorId: "u1",
+    });
+
+    expect(res.success).toBe(true);
+    expect((await db.equipos.get(equipo.id!))?.ubicacion_id).toBe(destino.id);
+    const mov = await db.equipo_movimientos.get(res.movimientoId!);
+    expect(mov).toMatchObject({
+      equipo_id: equipo.id,
+      ubicacion_nueva_id: destino.id,
+      motivo: "mudanza", // trim
+      registrado_por_id: "u1",
+    });
+  });
+
+  it("misma ubicación → rechaza", async () => {
+    const { equipo, ubicacion } = await seedGraph({ conVisita: false });
+    const res = await trasladarEquipo(equipo.id!, ubicacion.id!);
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("ya está");
+  });
+
+  it("destino inexistente → rechaza y no toca el equipo", async () => {
+    const { equipo, ubicacion } = await seedGraph({ conVisita: false });
+    const res = await trasladarEquipo(equipo.id!, "no-existe");
+    expect(res.success).toBe(false);
+    expect((await db.equipos.get(equipo.id!))?.ubicacion_id).toBe(ubicacion.id);
+  });
+
+  it("equipo inexistente → rechaza", async () => {
+    expect((await trasladarEquipo("no-existe", "tampoco")).success).toBe(false);
+  });
+});

--- a/src/lib/workflow/module-completeness.test.ts
+++ b/src/lib/workflow/module-completeness.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+import {
+  getModuleStatuses,
+  getVisitCompleteness,
+  getVisitCompletenessBulk,
+} from "./module-completeness";
+
+// module-completeness decide si una visita puede avanzar ("enviar a revisión").
+// Tests con una base sembrada real (conv_* vía Dexie).
+
+const CODIGOS = [
+  "2.1",
+  "2.2",
+  "2.3",
+  "2.4",
+  "2.5",
+  "2.6",
+  "2.7",
+  "2.8",
+  "2.9",
+  "2.10",
+  "2.11",
+  "2.12",
+  "2.13",
+  "2.14",
+  "2.15",
+  "2.16",
+  "2.17",
+  "2.18",
+  "2.19",
+  "2.20",
+  "2.21",
+];
+
+async function excluirTodasLasSecciones(visitaId: string) {
+  // incluida: false → getEstadoPruebasPorGrupo trata cada prueba como resuelta.
+  await db.conv_informe_secciones.bulkAdd(
+    CODIGOS.map((codigo, i) => ({
+      id: `${visitaId}-${codigo}`,
+      visita_id: visitaId,
+      prueba_codigo: codigo,
+      orden: i + 1,
+      incluida: false,
+      sync_status: "synced" as const,
+      last_modified: new Date().toISOString(),
+    }))
+  );
+}
+
+describe("module-completeness — visita CONVENCIONAL", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("visita recién creada (sin datos conv_*) → grupos requeridos bloquean", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+
+    const status = await getModuleStatuses(visita!.id!);
+    expect(status["grupo-a"].status).toBe("sin_iniciar");
+
+    const comp = await getVisitCompleteness(visita!.id!);
+    // grupo-a/b/d/e son requeridos en MODULOS_CONVENCIONAL
+    expect(comp.blocking).toEqual(
+      expect.arrayContaining(["grupo-a", "grupo-b", "grupo-d", "grupo-e"])
+    );
+    expect(comp.percentage).toBeLessThan(100);
+  });
+
+  it("todas las secciones excluidas del informe → nada bloquea", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await excluirTodasLasSecciones(visita!.id!);
+
+    const comp = await getVisitCompleteness(visita!.id!);
+    expect(comp.blocking).toEqual([]);
+    expect(comp.percentage).toBe(100);
+  });
+
+  it("visita inexistente → estructura vacía, sin bloqueos", async () => {
+    expect(await getModuleStatuses("no-existe")).toEqual({});
+    const comp = await getVisitCompleteness("no-existe");
+    expect(comp).toMatchObject({ total: 0, completed: 0, blocking: [] });
+  });
+});
+
+describe("module-completeness — hallazgo #7 (visita sin paquete)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("PIN: equipo de tipo sin paquete → módulos default nunca coinciden con getModuleStatuses → bloqueo permanente", async () => {
+    // El guard de registry (Tier 3) impide crear estas visitas; si igual
+    // existiera una, getVisitCompleteness la deja bloqueada para siempre.
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.equipos.update(equipo.id!, { tipo_equipo: "CT" });
+
+    const comp = await getVisitCompleteness(visita!.id!);
+    // getDefaultModules ids (condiciones/levantamiento/pruebas) no están en
+    // progressMap → todos sin_iniciar → los requeridos bloquean.
+    expect(comp.blocking).toEqual(
+      expect.arrayContaining(["condiciones", "levantamiento", "pruebas"])
+    );
+  });
+});
+
+describe("module-completeness — #15 getVisitCompletenessBulk", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("PIN: es un loop secuencial de getVisitCompleteness (no una versión batch)", async () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+      ids.push(visita!.id!);
+    }
+
+    const map = await getVisitCompletenessBulk(ids);
+    expect(map.size).toBe(3);
+    for (const id of ids) {
+      expect(map.get(id)?.blocking.length).toBeGreaterThan(0);
+    }
+    // El costo es O(visitas × ~15 scans conv_*). Optimización → issue.
+  });
+
+  it("lista vacía → Map vacío", async () => {
+    expect((await getVisitCompletenessBulk([])).size).toBe(0);
+  });
+});

--- a/src/lib/workflow/module-completeness.ts
+++ b/src/lib/workflow/module-completeness.ts
@@ -113,7 +113,11 @@ async function getInfoPercentage(visita: {
 //  prueba legítimamente no aplica al equipo evaluado.
 
 function pctResueltas(g: { total: number; pendientes: number } | undefined): number {
-  if (!g || g.total === 0) return 100;
+  // Fail-safe (#6): un grupo sin pruebas cuenta como "sin iniciar", no
+  // "completo". Hoy es defensivo (para CONVENCIONAL cada grupo tiene 2-6
+  // secciones fijas del catálogo), pero evita que un paquete futuro con un
+  // grupo vacío pase el gate por default.
+  if (!g || g.total === 0) return 0;
   return Math.round(((g.total - g.pendientes) / g.total) * 100);
 }
 
@@ -132,7 +136,7 @@ export async function getModuleStatuses(visitaId: string): Promise<Record<string
   const pendientesGeneral = Object.values(estadoPorGrupo).reduce((acc, g) => acc + g.pendientes, 0);
   const preInformePct =
     totalGeneral === 0
-      ? 100
+      ? 0 // fail-safe (#6): sin pruebas → sin iniciar, no completo
       : Math.round(((totalGeneral - pendientesGeneral) / totalGeneral) * 100);
 
   return {

--- a/src/lib/workflow/visit-state-machine.ts
+++ b/src/lib/workflow/visit-state-machine.ts
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { logger } from "@/lib/logger";
 import type { EstadoVisita, Solicitud } from "@/lib/db/types";
 import { getVisitCompleteness } from "./module-completeness";
 
@@ -78,7 +79,10 @@ const TRANSITIONS: Record<EstadoVisita, ActionDefinition[]> = {
       description: "Aprobar el informe y generar documento final",
       target: "aprobada",
       roles: ["tecnico", "coordinador", "programador"],
-      hasGate: false,
+      // #8: aprobar publica el PDF oficial (QR + hash) — no debe poder
+      // aprobarse una visita incompleta. Mismo gate de completitud que
+      // enviar_revision (los datos pueden haber cambiado desde entonces).
+      hasGate: true,
       variant: "success",
       icon: "BadgeCheck",
     },
@@ -200,8 +204,10 @@ export function canTransition(
  * Ejecuta la gate de validación para una acción.
  * Retorna si puede proceder y los errores de bloqueo.
  */
+const GATED_ACTIONS: VisitAction[] = ["enviar_revision", "aprobar"];
+
 export async function checkGate(visitaId: string, action: VisitAction): Promise<GateResult> {
-  if (action === "enviar_revision") {
+  if (GATED_ACTIONS.includes(action)) {
     const completeness = await getVisitCompleteness(visitaId);
     if (completeness.blocking.length > 0) {
       return {
@@ -250,10 +256,11 @@ export async function executeTransition(
   }
 
   // Actualizar estado de la visita
+  const nowIso = new Date().toISOString();
   const updateData: Record<string, unknown> = {
     estado_visita: actionDef.target,
     sync_status: "pending",
-    last_modified: new Date().toISOString(),
+    last_modified: nowIso,
   };
 
   // Si es devolución (interna o por cliente), guardar observaciones
@@ -262,20 +269,38 @@ export async function executeTransition(
     extra?.observaciones_revision
   ) {
     updateData.observaciones_revision = extra.observaciones_revision;
-    updateData.devuelto_en = new Date().toISOString();
+    updateData.devuelto_en = nowIso;
   }
 
-  await db.visitas.update(visitaId, updateData);
+  const newPipelineEstado = SOLICITUD_SYNC[actionDef.target];
 
-  // Si el cliente solicitó ajustes, el informe ya emitido queda en corrección
+  // #9 interino: las tres escrituras de estado (visita + solicitud + informe
+  // a "correccion_cliente") van en UNA transacción, para que no queden
+  // divergentes si algo falla a mitad. La creación del informe y la
+  // publicación del PDF quedan afuera (son async/red) — ver más abajo.
   let informeAfectadoId: string | undefined;
-  if (action === "solicitar_ajustes_cliente") {
-    const informe = await db.informes.where("visita_id").equals(visitaId).first();
-    if (informe?.id) {
-      await db.informes.update(informe.id, { estado: "correccion_cliente" });
-      informeAfectadoId = informe.id;
+  await db.transaction("rw", [db.visitas, db.solicitudes, db.informes], async () => {
+    await db.visitas.update(visitaId, updateData);
+
+    if (action === "solicitar_ajustes_cliente") {
+      // Una visita tiene un solo informe (el versionado va en informe_versiones);
+      // se ordena por número de versión por si acaso hubiera datos duplicados.
+      const informes = await db.informes.where("visita_id").equals(visitaId).toArray();
+      const informe = informes.sort((a, b) => (b.version_actual ?? 0) - (a.version_actual ?? 0))[0];
+      if (informe?.id) {
+        await db.informes.update(informe.id, { estado: "correccion_cliente" });
+        informeAfectadoId = informe.id;
+      }
     }
-  }
+
+    if (newPipelineEstado && visita.solicitud_id) {
+      await db.solicitudes.update(visita.solicitud_id, {
+        pipeline_estado: newPipelineEstado as Solicitud["pipeline_estado"],
+        sync_status: "pending",
+        last_modified: nowIso,
+      });
+    }
+  });
 
   // Al aprobar: crear/versionar el informe y publicar el PDF oficial (QR+hash).
   // Centralizado aquí (no en el handler de un botón específico) para que ocurra
@@ -292,20 +317,16 @@ export async function executeTransition(
       const { publicarVersionOficial } = await import("./publicar-informe");
       publicarVersionOficial(informe.id, visitaId).then((r) => {
         if (!r.success) {
-          console.error("[VisitStateMachine] No se pudo publicar la versión oficial:", r.error);
+          // #9: la transición ya ocurrió pero el PDF oficial NO se publicó.
+          // Queda pendiente de reintento (botón "Publicar versión oficial"
+          // en informes/[id]). Se registra como error, no como console.
+          logger.error(
+            "workflow:aprobar",
+            `Visita ${visitaId} aprobada pero la versión oficial del informe ${informe.id} NO se publicó: ${r.error}`
+          );
         }
       });
     }
-  }
-
-  // Sincronizar estado del pipeline de la solicitud
-  const newPipelineEstado = SOLICITUD_SYNC[actionDef.target];
-  if (newPipelineEstado && visita.solicitud_id) {
-    await db.solicitudes.update(visita.solicitud_id, {
-      pipeline_estado: newPipelineEstado as Solicitud["pipeline_estado"],
-      sync_status: "pending",
-      last_modified: new Date().toISOString(),
-    });
   }
 
   // Push inmediato (import dinámico para no cargar el cliente Supabase en tests)
@@ -330,4 +351,59 @@ function getBlockingMessage(moduleId: string): string {
     pruebas: "Complete todas las pruebas de control de calidad",
   };
   return messages[moduleId] ?? `Módulo "${moduleId}" incompleto`;
+}
+
+// ─── Reconciliación (#9 interino) ───
+
+export interface VisitConsistencyIssue {
+  visitaId: string;
+  problema: string;
+}
+
+/**
+ * Detecta divergencias entre el estado de la visita, el `pipeline_estado`
+ * de su solicitud, y el estado del informe. `executeTransition` hace las
+ * escrituras de estado en una transacción, pero la creación/publicación del
+ * informe queda afuera (async/red) y puede fallar dejando estados
+ * inconsistentes. Esta función los encuentra para que la consola de sync /
+ * revisión pueda listarlos.
+ */
+export async function checkVisitConsistency(visitaId: string): Promise<VisitConsistencyIssue[]> {
+  const issues: VisitConsistencyIssue[] = [];
+  const visita = await db.visitas.get(visitaId);
+  if (!visita) return [{ visitaId, problema: "Visita no encontrada" }];
+
+  const esperadoPipeline = SOLICITUD_SYNC[visita.estado_visita];
+  if (esperadoPipeline && visita.solicitud_id) {
+    const solicitud = await db.solicitudes.get(visita.solicitud_id);
+    if (solicitud && solicitud.pipeline_estado !== esperadoPipeline) {
+      issues.push({
+        visitaId,
+        problema: `visita "${visita.estado_visita}" pero solicitud "${solicitud.pipeline_estado}" (se esperaba "${esperadoPipeline}")`,
+      });
+    }
+  }
+
+  if (visita.estado_visita === "aprobada" || visita.estado_visita === "enviada") {
+    const informe = (await db.informes.where("visita_id").equals(visitaId).toArray()).sort(
+      (a, b) => (b.version_actual ?? 0) - (a.version_actual ?? 0)
+    )[0];
+    if (!informe) {
+      issues.push({ visitaId, problema: `visita "${visita.estado_visita}" pero sin informe` });
+    } else {
+      const version = await db.informe_versiones
+        .where("informe_id")
+        .equals(informe.id!)
+        .and((v) => v.numero_version === informe.version_actual)
+        .first();
+      if (!version?.pdf_url) {
+        issues.push({
+          visitaId,
+          problema: `informe ${informe.numero_informe} v${informe.version_actual} sin PDF oficial publicado`,
+        });
+      }
+    }
+  }
+
+  return issues;
 }

--- a/src/lib/workflow/visita-service.ts
+++ b/src/lib/workflow/visita-service.ts
@@ -1,7 +1,8 @@
 import { db } from "@/lib/db";
 import { randomUUID } from "@/lib/uuid";
+import { logger } from "@/lib/logger";
 import type { VisitaEjecucion, PruebaResultado, GrupoResultado, Solicitud } from "@/lib/db/types";
-import { hasPackage } from "@/lib/equipos";
+import { hasPackage, assertCanCreateVisitFor, NoPackageError } from "@/lib/equipos";
 
 // ============================================================
 //  Servicio de creación de visitas
@@ -34,6 +35,13 @@ export async function crearVisitaDesdeSolicitud(
     const equipo = await db.equipos.get(equipoId);
     if (!equipo) return { success: false, error: "Equipo no encontrado" };
 
+    // #7: solo se pueden crear visitas de tipos con paquete definido (hoy
+    // solo CONVENCIONAL). Una visita de otro tipo nunca podría pasar el gate
+    // de completitud — ver docs/modules/06-grupos-registry.md.
+    if (equipo.tipo_equipo) {
+      assertCanCreateVisitFor(equipo.tipo_equipo);
+    }
+
     const now = new Date().toISOString();
 
     // Crear la visita
@@ -65,7 +73,8 @@ export async function crearVisitaDesdeSolicitud(
         db.prueba_definiciones,
       ],
       async () => {
-        visitaId = (await db.visitas.add({ ...visita, id: randomUUID() })) as string;
+        // #6: usar el id que ya tiene `visita` (no regenerar otro).
+        visitaId = (await db.visitas.add(visita)) as string;
 
         if (equipo.tipo_equipo) {
           const usarPaquete = hasPackage(equipo.tipo_equipo);
@@ -152,6 +161,17 @@ export async function crearVisitaDesdeSolicitud(
       }
     );
 
+    // #6: una visita con paquete pero SIN pruebas generadas nace rota — casi
+    // siempre porque el catálogo agrupado (grupo_pruebas) no se sembró
+    // (seedFromPackage está comentado, ver issue #36). No se falla la
+    // creación, pero se registra para no perder el rastro.
+    if (equipo.tipo_equipo && hasPackage(equipo.tipo_equipo) && pruebasCreadas === 0) {
+      logger.warn(
+        "visita:crear",
+        `Visita ${visitaId!} creada SIN pruebas (catálogo grupo_pruebas vacío para ${equipo.tipo_equipo}?)`
+      );
+    }
+
     return {
       success: true,
       visitaId: visitaId!,
@@ -159,7 +179,11 @@ export async function crearVisitaDesdeSolicitud(
       gruposCreados,
     };
   } catch (err) {
-    console.error("[VisitaService] Error:", err);
+    if (err instanceof NoPackageError) {
+      logger.warn("visita:crear", err.message);
+      return { success: false, error: err.message };
+    }
+    logger.error("visita:crear", "Error creando la visita", err);
     return {
       success: false,
       error: err instanceof Error ? err.message : "Error desconocido",

--- a/src/lib/workflow/workflow-tier4.test.ts
+++ b/src/lib/workflow/workflow-tier4.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+
+// executeTransition hace imports dinámicos de sync-engine, informe-service y
+// publicar-informe — se mockean para no tocar red ni el cliente Supabase.
+const pushSingle = vi.fn().mockResolvedValue(true);
+const crearInformeDesdeVisita = vi.fn();
+const publicarVersionOficial = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  pushSingle: (...a: unknown[]) => pushSingle(...a),
+}));
+vi.mock("./informe-service", () => ({
+  crearInformeDesdeVisita: (...a: unknown[]) => crearInformeDesdeVisita(...a),
+}));
+vi.mock("./publicar-informe", () => ({
+  publicarVersionOficial: (...a: unknown[]) => publicarVersionOficial(...a),
+}));
+
+import { executeTransition, checkGate, checkVisitConsistency } from "./visit-state-machine";
+import { crearVisitaDesdeSolicitud } from "./visita-service";
+import { NoPackageError } from "@/lib/equipos";
+
+beforeEach(async () => {
+  await resetTestDb();
+  pushSingle.mockClear();
+  crearInformeDesdeVisita.mockClear();
+  publicarVersionOficial.mockClear();
+  crearInformeDesdeVisita.mockResolvedValue({ id: "inf-1", numero_informe: "EYC-2026-001" });
+});
+
+// ─── #8: aprobar ahora tiene gate de completitud ───
+
+describe("#8 — aprobar tiene gate de completitud", () => {
+  it("aprobar con módulos incompletos → bloqueado, no publica informe", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "en_revision" });
+
+    const gate = await checkGate(visita!.id!, "aprobar");
+    expect(gate.canProceed).toBe(false);
+
+    const res = await executeTransition(visita!.id!, "aprobar", "coordinador", {
+      usuarioId: "u1",
+    });
+    expect(res.success).toBe(false);
+    expect(res.gateResult?.canProceed).toBe(false);
+    expect(crearInformeDesdeVisita).not.toHaveBeenCalled();
+    expect((await db.visitas.get(visita!.id!))?.estado_visita).toBe("en_revision");
+  });
+
+  it("aprobar con todo excluido (completo) → aprueba y dispara la creación del informe", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "en_revision" });
+    // Excluir todas las secciones → completitud 100%.
+    await db.conv_informe_secciones.bulkAdd(
+      Array.from({ length: 21 }, (_, i) => ({
+        id: `s-${i}`,
+        visita_id: visita!.id!,
+        prueba_codigo: `2.${i + 1}`,
+        orden: i + 1,
+        incluida: false,
+        sync_status: "synced" as const,
+        last_modified: new Date().toISOString(),
+      }))
+    );
+
+    const res = await executeTransition(visita!.id!, "aprobar", "coordinador", { usuarioId: "u1" });
+    expect(res.success).toBe(true);
+    expect(res.newState).toBe("aprobada");
+    expect(crearInformeDesdeVisita).toHaveBeenCalledWith(visita!.id!, "u1", expect.any(String));
+    expect(publicarVersionOficial).toHaveBeenCalledWith("inf-1", visita!.id!);
+  });
+});
+
+// ─── #9 interino: transacción + reconciliación ───
+
+describe("#9 interino — estado consistente", () => {
+  it("iniciar_visita: visita y solicitud avanzan juntas", async () => {
+    const { visita, solicitud } = await seedGraph({ estadoVisita: "asignada" });
+
+    const res = await executeTransition(visita!.id!, "iniciar_visita", "tecnico");
+    expect(res.success).toBe(true);
+    expect((await db.visitas.get(visita!.id!))?.estado_visita).toBe("en_progreso");
+    expect((await db.solicitudes.get(solicitud!.id!))?.pipeline_estado).toBe("ejecucion");
+  });
+
+  it("checkVisitConsistency detecta visita aprobada sin informe", async () => {
+    const { visita } = await seedGraph({ estadoVisita: "aprobada" });
+    const issues = await checkVisitConsistency(visita!.id!);
+    expect(issues.some((i) => i.problema.includes("sin informe"))).toBe(true);
+  });
+
+  it("checkVisitConsistency detecta pipeline de solicitud divergente", async () => {
+    const { visita, solicitud } = await seedGraph({ estadoVisita: "en_progreso" });
+    await db.solicitudes.update(solicitud!.id!, { pipeline_estado: "solicitudes" });
+    const issues = await checkVisitConsistency(visita!.id!);
+    expect(issues.some((i) => i.problema.includes("solicitud"))).toBe(true);
+  });
+
+  it("visita consistente → sin issues", async () => {
+    const { visita } = await seedGraph({ estadoVisita: "asignada" });
+    expect(await checkVisitConsistency(visita!.id!)).toEqual([]);
+  });
+});
+
+// ─── #6 / #7: crearVisitaDesdeSolicitud ───
+
+describe("#6 / #7 — crearVisitaDesdeSolicitud", () => {
+  it("#7: equipo de tipo sin paquete → falla con NoPackageError, no crea visita", async () => {
+    const { equipo, solicitud } = await seedGraph({ conVisita: false });
+    await db.equipos.update(equipo.id!, { tipo_equipo: "MAMOGRAFO" });
+
+    const res = await crearVisitaDesdeSolicitud(solicitud!.id!, equipo.id!);
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("MAMOGRAFO");
+    expect(await db.visitas.count()).toBe(0);
+  });
+
+  it("#6: CONVENCIONAL sin catálogo grupo_pruebas → crea la visita con 0 pruebas (warn), success igual", async () => {
+    const { equipo, solicitud } = await seedGraph({ conVisita: false });
+
+    const res = await crearVisitaDesdeSolicitud(solicitud!.id!, equipo.id!);
+    expect(res.success).toBe(true);
+    expect(res.pruebasCreadas).toBe(0);
+    expect(await db.visitas.count()).toBe(1);
+  });
+
+  it("#6: la visita usa el id que ya tiene (no regenera otro)", async () => {
+    const { equipo, solicitud } = await seedGraph({ conVisita: false });
+    const res = await crearVisitaDesdeSolicitud(solicitud!.id!, equipo.id!);
+    const visitas = await db.visitas.toArray();
+    expect(visitas).toHaveLength(1);
+    expect(visitas[0].id).toBe(res.visitaId);
+  });
+
+  it("solicitud inexistente → success:false", async () => {
+    const res = await crearVisitaDesdeSolicitud("no-existe", "tampoco");
+    expect(res.success).toBe(false);
+  });
+});
+
+describe("NoPackageError", () => {
+  it("es una instancia de Error con tipoEquipo", () => {
+    const e = new NoPackageError("CT");
+    expect(e).toBeInstanceOf(Error);
+    expect(e.tipoEquipo).toBe("CT");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         // Tier 1 — Módulo 1 (db). types.ts (motor de permisos) no lo mide v8
         // pero está cubierto de forma exhaustiva por permisos.test.ts +
         // permisos-matriz.test.ts (144 celdas).
+        "src/lib/workflow/**": { lines: 68, functions: 68, branches: 52 },
         "src/lib/db/recovery.ts": { lines: 95, functions: 100, branches: 80 },
         "src/lib/db/seed.ts": { lines: 65, functions: 55, branches: 58 },
         "src/lib/db/index.ts": { lines: 63 },


### PR DESCRIPTION
**La #49 se mergeó a `fix/tier3-computo` en vez de a `main`, y como esa rama ya había ido a main por la #44, el Tier 4 nunca llegó.** Esta PR lleva los 4 commits del Tier 4 directo a `main`.

Contenido idéntico a la #49:

| # | Arreglo |
|---|---|
| **#8** | `aprobar` ahora tiene gate de completitud (antes se podía aprobar + publicar el PDF oficial de una visita incompleta) |
| **#6** | `crearVisitaDesdeSolicitud`: usa el id existente (no regenera); `logger`; warn si nace con 0 pruebas |
| **#7** | `assertCanCreateVisitFor` cableado → `NoPackageError` para tipos sin paquete. Fix real → #48 |
| **#9** interino | 3 escrituras de estado en `db.transaction`; publish falla → `logger.error`; `checkVisitConsistency()`. Rediseño → #46 |
| `pctResueltas` `total===0` | → 0 (fail-safe, antes 100) |
| **#15** | pin + #47 (perf de `getVisitCompletenessBulk`) |

**+33 tests.** `npm run verify` exit 0: 428 tests / 41 archivos.