### PR TITLE
Tier 5 — generación del PDF (tests de contrato)

### DIFF
--- a/docs/modules/09-pdf.md
+++ b/docs/modules/09-pdf.md
@@ -1,0 +1,74 @@
+# Módulo: generación del PDF (`src/lib/pdf/`)
+
+> Estado: 🟡 en curso (Tier 5) · 2026-08-28
+> `generar-pre-informe.ts` (1814 líneas) + `secciones-convencional.ts` (3229).
+> Antes: **cero tests**. ~5000 líneas — el artefacto de mayor valor.
+
+---
+
+## 1. Responsabilidad
+
+`generarPreInforme(visitaId, opts?) → Blob | null`: arma el PDF completo del
+informe desde Dexie — portada, datos de cliente/equipo/ubicación, una sección
+por prueba TECDOC, fotos, diagrama radiométrico. `opts.qrDataUrl` para la
+versión oficial (con QR de verificación).
+
+Consumido por: `informes/[id]` (descarga), `pre-informe-modulo` (preview),
+`publicar-informe` (versión oficial).
+
+## 2. Estructura
+
+| Función                                                   | Qué                                                                                                                                                           |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `recopilarDatos(visitaId)` (privada)                      | junta cliente/equipo/ubicación/sede/tubo/sala/técnico/contactos + `prueba_resultados` + `mediciones_radiometricas` + `elementos_proteccion` + `partes_equipo` |
+| `recopilarDatosConv(visitaId)` (exportada)                | junta las 19 tablas `conv_*` — el contrato de datos del PDF convencional                                                                                      |
+| `generarPreInforme`                                       | orquesta: importa jsPDF+autotable dinámicamente, `recopilarDatos`, `recopilarDatosConv` si `hasPackage`, y dibuja                                             |
+| `render*(ctx, conv)` (~30 en `secciones-convencional.ts`) | dibujan cada sección/foto/tabla                                                                                                                               |
+
+- **Marca de agua**: se omite si la visita está `aprobada` o `enviada` (versión final).
+- **Logo**: `fetch("/logo-informe.png")` cacheado en módulo — **sin manejo de
+  error si el fetch falla** (finding menor).
+
+## 3. Hallazgos
+
+| #                                                              | Qué                                                                                                                                                                                                                                                                                                                                                 | Disposición                                                        |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **deleted_at inconsistente en `recopilarDatosConv`**           | `conv_mediciones`, `conv_elementos_proteccion`, `conv_evidencias`, `conv_uniformidad_detector`, `conv_cassette_inspeccion`, `conv_uniformidad_cr` **filtran** `deleted_at`. `conv_raysafe_mediciones`, `conv_ddi_mediciones`, `conv_cae_mediciones` y las tablas de setup **NO** → una medición RaySafe/CAE/DDI borrada sigue apareciendo en el PDF | **issue** (extiende #34) — pin en `secciones-convencional.test.ts` |
+| `recopilarDatos` lee `db.elementos_proteccion`                 | la tabla legacy sin sync (issue #34 / #36) — el camino convencional usa `conv_elementos_proteccion`                                                                                                                                                                                                                                                 | ya trackeado (#34)                                                 |
+| `getLogoBase64` sin try/catch                                  | si `/logo-informe.png` falla, `generarPreInforme` lanza entero                                                                                                                                                                                                                                                                                      | **issue menor**                                                    |
+| `secciones-convencional.ts` ~30 `renderFotosXX` casi idénticas | mucho copy-paste                                                                                                                                                                                                                                                                                                                                    | fuera de alcance (no es bug)                                       |
+
+## 4. Cobertura nueva
+
+- `generar-pre-informe.test.ts` (5): visita inexistente → `null`; genera `Blob`
+  `application/pdf` para CONVENCIONAL; **el nombre del cliente y la serie del
+  equipo llegan al PDF** (se extrae texto del buffer crudo — jsPDF no comprime
+  por defecto); ruta no-CONVENCIONAL (legacy); acepta `qrDataUrl`.
+- `secciones-convencional.test.ts` (6): `recopilarDatosConv` — visita vacía →
+  catálogo por defecto; respeta `conv_informe_secciones.incluida`; dedupe de
+  `conv_inspeccion_items`; **PIN del `deleted_at` inconsistente**.
+
+**Estrategia:** contrato, no píxeles. Se corre jsPDF de verdad (funciona en
+happy-dom con `fetch` mockeado) y se verifica que los datos correctos entran
+al documento, extrayendo el texto del PDF crudo.
+
+## Modos de falla
+
+| Falla                                       | Efecto                                        | Manejo                |
+| ------------------------------------------- | --------------------------------------------- | --------------------- |
+| Medición conv\_\* borrada (raysafe/cae/ddi) | aparece en el PDF                             | ninguno — issue       |
+| `/logo-informe.png` 404                     | `generarPreInforme` lanza                     | ninguno — issue menor |
+| Visita sin equipo / sin datos               | genera un PDF con secciones vacías (no lanza) | ok                    |
+
+---
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc
+- [x] Tests de contrato: `generarPreInforme` end-to-end + `recopilarDatosConv`
+- [x] PIN del `deleted_at` inconsistente
+- [x] Umbrales de cobertura (`generar-pre-informe.ts` 65%, `secciones` 43%)
+- [x] Issue #51: `deleted_at` inconsistente en `recopilarDatosConv`
+- [x] Issue #52: `getLogoBase64` sin try/catch
+- [x] `npm run verify` limpio
+- [ ] Sign-off del dueño

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// getLogoBase64 hace fetch("/logo-informe.png") — se mockea con un PNG mínimo.
+vi.stubGlobal(
+  "fetch",
+  vi.fn().mockResolvedValue({
+    blob: async () =>
+      new Blob([new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])], { type: "image/png" }),
+  })
+);
+
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+import { generarPreInforme } from "./generar-pre-informe";
+
+// jsPDF no comprime por defecto → el texto dibujado queda legible en el
+// buffer crudo del PDF (operadores `(str) Tj`). Alcanza para tests de
+// contrato: "¿el dato X llegó al documento?", sin snapshots de píxeles.
+async function pdfText(blob: Blob): Promise<string> {
+  const buf = new Uint8Array(await blob.arrayBuffer());
+  let s = "";
+  for (const b of buf) s += String.fromCharCode(b);
+  return s;
+}
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("generarPreInforme — contrato de datos", () => {
+  it("visita inexistente → null", async () => {
+    expect(await generarPreInforme("no-existe")).toBeNull();
+  });
+
+  it("genera un Blob application/pdf para una visita CONVENCIONAL", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const blob = await generarPreInforme(visita!.id!);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob!.type).toBe("application/pdf");
+    expect(blob!.size).toBeGreaterThan(1000);
+  });
+
+  it("el nombre del cliente, la sede y la serie del equipo llegan al PDF", async () => {
+    const { visita, cliente, sede, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.clientes.update(cliente.id!, { nombre_cliente: "CLINICA-MARCADOR-CLI" });
+    await db.sedes.update(sede.id!, { nombre_sede: "SEDE-MARCADOR" });
+    await db.equipos.update(equipo.id!, { numero_serie: "SERIE-MARCADOR-999" });
+
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("CLINICA-MARCADOR-CLI");
+    expect(text).toContain("SERIE-MARCADOR-999");
+  });
+
+  it("equipo sin paquete (no-CONVENCIONAL) también genera el PDF (ruta legacy)", async () => {
+    const { visita, equipo } = await seedGraph();
+    await db.equipos.update(equipo.id!, { tipo_equipo: "CT" });
+    const blob = await generarPreInforme(visita!.id!);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob!.type).toBe("application/pdf");
+  });
+
+  it("versión oficial: acepta un qrDataUrl sin romper", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "aprobada" });
+    const qr =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+    const blob = await generarPreInforme(visita!.id!, { qrDataUrl: qr });
+    expect(blob).toBeInstanceOf(Blob);
+  });
+});

--- a/src/lib/pdf/secciones-convencional.test.ts
+++ b/src/lib/pdf/secciones-convencional.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { recopilarDatosConv } from "./secciones-convencional";
+
+// Las filas conv_* tienen muchos campos obligatorios que no importan acá;
+// `row()` afloja el tipado para armar fixtures mínimos.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const row = <T>(o: Partial<T> & Record<string, unknown>) => o as any;
+
+// recopilarDatosConv es el CONTRATO DE DATOS del PDF convencional: qué
+// tablas conv_* lee y cómo. Los render*() dibujan sobre eso.
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+const V = "visita-test";
+const del = { deleted_at: "2026-01-01T00:00:00Z", sync_status: "synced", last_modified: "x" };
+const ok = { sync_status: "synced", last_modified: "x" };
+
+describe("recopilarDatosConv — carga de tablas", () => {
+  it("visita vacía → estructura con arrays vacíos y catálogo de secciones por defecto", async () => {
+    const d = await recopilarDatosConv(V);
+    expect(d.mediciones).toEqual([]);
+    expect(d.raysafeMediciones).toEqual([]);
+    expect(d.caeMediciones).toEqual([]);
+    expect(d.secciones).toHaveLength(21);
+    expect(d.secciones.every((s) => s.incluida)).toBe(true);
+  });
+
+  it("usa conv_informe_secciones cuando existen (respeta el toggle 'incluida')", async () => {
+    await db.conv_informe_secciones.bulkAdd([
+      row({ id: "s1", visita_id: V, prueba_codigo: "2.1", orden: 1, incluida: true }),
+      row({ id: "s2", visita_id: V, prueba_codigo: "2.2", orden: 2, incluida: false }),
+    ]);
+    const d = await recopilarDatosConv(V);
+    expect(d.secciones).toHaveLength(2);
+    expect(d.secciones.find((s) => s.prueba_codigo === "2.2")?.incluida).toBe(false);
+  });
+
+  it("dedupe de conv_inspeccion_items por (seccion, item_numero) — gana la que tiene concepto", async () => {
+    await db.conv_inspeccion_items.bulkAdd([
+      row({ id: "i1", visita_id: V, seccion: "equipo", item_numero: 1 }),
+      row({ id: "i2", visita_id: V, seccion: "equipo", item_numero: 1, concepto: "Conforme" }),
+    ]);
+    const d = await recopilarDatosConv(V);
+    expect(d.inspeccion).toHaveLength(1);
+    expect(d.inspeccion[0].concepto).toBe("Conforme");
+  });
+});
+
+describe("recopilarDatosConv — filtrado de deleted_at (INCONSISTENTE — finding)", () => {
+  it("conv_mediciones SÍ filtra deleted_at", async () => {
+    await db.conv_mediciones.bulkAdd([
+      row({ id: "m1", visita_id: V, punto_numero: 1, ...ok }),
+      row({ id: "m2", visita_id: V, punto_numero: 2, ...del }),
+    ]);
+    const d = await recopilarDatosConv(V);
+    expect(d.mediciones.map((m) => m.id)).toEqual(["m1"]);
+  });
+
+  it("PIN: conv_raysafe_mediciones NO filtra deleted_at (fila borrada aparece en el PDF)", async () => {
+    await db.conv_raysafe_mediciones.bulkAdd([
+      row({ id: "r1", visita_id: V, toma_numero: 1, ...ok }),
+      row({ id: "r2", visita_id: V, toma_numero: 2, ...del }),
+    ]);
+    const d = await recopilarDatosConv(V);
+    // Comportamiento ACTUAL (bug latente): devuelve las 2. → issue #51.
+    expect(d.raysafeMediciones.map((r) => r.id)).toEqual(["r1", "r2"]);
+  });
+
+  it("PIN: conv_cae_mediciones y conv_ddi_mediciones tampoco filtran deleted_at", async () => {
+    await db.conv_cae_mediciones.add(row({ id: "c1", visita_id: V, toma_numero: 1, ...del }));
+    await db.conv_ddi_mediciones.add(
+      row({ id: "dd1", visita_id: V, grupo: 1, toma_numero: 1, ...del })
+    );
+    const d = await recopilarDatosConv(V);
+    expect(d.caeMediciones).toHaveLength(1);
+    expect(d.ddiMediciones).toHaveLength(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,6 +55,11 @@ export default defineConfig({
         "src/lib/db/recovery.ts": { lines: 95, functions: 100, branches: 80 },
         "src/lib/db/seed.ts": { lines: 65, functions: 55, branches: 58 },
         "src/lib/db/index.ts": { lines: 63 },
+        // Tier 5 — PDF. Tests de contrato (smoke end-to-end + recopilarDatosConv);
+        // no snapshots de píxeles. Cobertura alta para un smoke porque
+        // generarPreInforme recorre casi toda la tubería de render.
+        "src/lib/pdf/generar-pre-informe.ts": { lines: 65, functions: 40, branches: 58 },
+        "src/lib/pdf/secciones-convencional.ts": { lines: 43, functions: 28, branches: 20 },
       },
     },
   },


### PR DESCRIPTION
Módulo 15. ~5000 líneas (`generar-pre-informe.ts` 1814 + `secciones-convencional.ts` 3229). **Cero tests** hasta ahora — el artefacto de mayor valor.

## Estrategia: contrato, no píxeles

jsPDF corre de verdad en el entorno de test (happy-dom + `fetch` mockeado). Como jsPDF **no comprime por defecto**, el texto dibujado queda legible en el buffer crudo del PDF → se puede verificar "¿el dato X llegó al documento?" sin snapshots de imagen.

## Cobertura nueva (11 tests)

| Archivo | Qué verifica |
|---|---|
| `generar-pre-informe.test.ts` (5) | visita inexistente → `null`; genera `Blob application/pdf` para CONVENCIONAL; **el nombre del cliente y la serie del equipo llegan al PDF**; ruta no-CONVENCIONAL (legacy); acepta `qrDataUrl` |
| `secciones-convencional.test.ts` (6) | `recopilarDatosConv` — catálogo de secciones por defecto, respeta `incluida`, dedupe de `inspeccion_items`, **PIN del `deleted_at` inconsistente** |

Coverage sorprendentemente alta para un smoke: `generar-pre-informe.ts` **68% líneas** (el smoke recorre casi toda la tubería de render), `secciones-convencional.ts` 46%.

## Hallazgos (issues)

- **#51** — `recopilarDatosConv` filtra `deleted_at` solo en 6 de 19 tablas `conv_*`. Una medición RaySafe/CAE/DDI **borrada sigue apareciendo en el PDF oficial**. Mismo patrón inconsistente en `evaluacion.ts` (`cargarTablasConv`).
- **#52** — `getLogoBase64` sin `try/catch`: un 404 de `/logo-informe.png` rompe todo el informe.

## Verificación

`npm run verify` — exit 0: **406 tests / 39 archivos**.