### PR TITLE
fix(ui): Tier 6 (1/2) — reapertura de diálogos + writes de equipo transaccionales

### DIFF
--- a/docs/modules/10-ui-form-dialogs.md
+++ b/docs/modules/10-ui-form-dialogs.md
@@ -1,0 +1,171 @@
+# Módulo: `components/*-form-dialog` + piezas compartidas de UI
+
+> Estado: 🟡 en curso (Tier 6 — parte 1 de 2) · Última actualización: `2026-08-28` · Responsable: `Juan Pablo Guzmán`
+
+Doc producido por el protocolo de intervención (ver
+`~/.claude/plans/en-dias-anteriores-he-cheerful-hopcroft.md`).
+
+Esta parte 1 certifica los **7 diálogos de CRUD de maestras** (Módulo 17 del
+plan) y dos piezas compartidas chicas del Módulo 18 (`state-timeline`,
+`setup-field`). La **parte 2** — `src/components/visita-modulos/*` (Módulo 16:
+grupo-a..e, info, pre-informe) + `visit-action-bar` + `manual-drawer` + la
+re-escalada de `react-hooks/set-state-in-effect` para esa ruta — queda pendiente
+como su propia pasada por volumen (≈330 KB de componentes sin tests).
+
+---
+
+## 1. Responsabilidad
+
+Los `*-form-dialog` son la **única superficie de alta/edición de las entidades
+maestras** desde el dashboard: cliente, contacto, sede, ubicación, equipo,
+solicitud, y traslado de equipo. Cada uno es dueño de escritura de su(s)
+tabla(s) Dexie y encola el push a Supabase vía `pushSingle`. No calculan
+nada de dominio: sólo validan campos mínimos, escriben y sincronizan.
+
+`state-timeline` y `setup-field` son componentes de presentación puros
+(sin acceso a datos): el primero dibuja el ciclo de vida de la visita, el
+segundo es un input no controlado con guardado on-blur.
+
+## 2. API pública
+
+| Export | Firma | Efectos | Convención de error | ¿Idempotente? |
+| --- | --- | --- | --- | --- |
+| `ClienteFormDialog` | `{open, onOpenChange, cliente?, onSaved?}` | `db.clientes` add/update + `pushSingle("clientes", id)` | `catch` → `console.error`, no re-lanza; sin toast | sí (update determinístico por `id`) |
+| `ContactoFormDialog` | `{open, onOpenChange, clienteId, contacto?, onSaved?}` | `db.contactos` add/update + push | idem | sí |
+| `SedeFormDialog` | `{open, onOpenChange, clienteId, sede?, onSaved?}` | `db.sedes` add/update + push | idem | sí |
+| `UbicacionFormDialog` | `{open, onOpenChange, sedeId, ubicacion?, onSaved?}` | `db.ubicaciones` add/update + push | idem | sí |
+| `EquipoFormDialog` | `{open, onOpenChange, ubicacionId, equipo?, onSaved?}` | **transacción `rw`** sobre `equipos` + `tubos` + `colimadores` + `gantry`; push por cada fila afectada | `catch` → `console.error`, no re-lanza | sí (update por `id`; hijos resueltos determinísticamente) |
+| `SolicitudFormDialog` | `{open, onOpenChange, editSolicitud?, ...}` | `db.solicitudes` add/update + push | idem | sí |
+| `TrasladarEquipoDialog` | `{open, onOpenChange, equipo, ...}` | delega en `equipo-service.trasladarEquipo` (Tier 4) | ver Módulo 14 | sí |
+| `StateTimeline` | `{currentState, className?}` | ninguno (render puro) | n/a | sí |
+| `SetupField` | `{label, defaultValue, type?, step?, placeholder?, className?, onSave}` | llama `onSave(value)` on-blur | n/a | el `onSave` puede no serlo — ver §8 |
+
+## 3. Modelo de datos
+
+- **Tablas propias (dueño de escritura):** una por diálogo (`clientes`,
+  `contactos`, `sedes`, `ubicaciones`, `solicitudes`) — salvo `EquipoFormDialog`
+  que escribe **4** (`equipos`, `tubos`, `colimadores`, `gantry`).
+- **Dependencias solo-lectura:** el id del padre llega por prop
+  (`clienteId`, `sedeId`, `ubicacionId`). Ningún diálogo lee catálogos.
+- **`deleted_at`:** al guardar `EquipoFormDialog`, si el usuario **borra todos
+  los campos** de un hijo (tubo/colimador/gantry) que ya existía, ese hijo se
+  **soft-borra** (`deleted_at = now`, `sync_status = "pending"`), no se deja la
+  fila huérfana ni se hace hard-delete. La recarga del form al reabrir ya
+  **filtra** filas con `deleted_at` y, ante duplicados preexistentes, toma
+  siempre el de menor `id` (selección determinística). Los demás diálogos no
+  borran.
+- **`last_modified`:** lo setea el diálogo con `new Date().toISOString()` en
+  cada add/update (cliente-generado — ver limitación de watermark en Módulo 4).
+- **Supabase:** todas estas tablas son `SYNC_TABLES` (push + pull). El push es
+  fire-and-forget: `pushSingle(tabla, id)` tras cerrar el diálogo.
+
+## 4. Flujo de control
+
+1. El padre monta el diálogo y controla `open` **directo** (no vía el
+   `onOpenChange` de Radix).
+2. Al pasar `open` de `false` a `true`, `useReseedOnOpen` ejecuta el `seed()`
+   una sola vez → repuebla el estado del form desde la prop de entidad (y, en
+   `EquipoFormDialog`, carga async los hijos).
+3. El usuario edita. Los cambios viven en `useState` local; **ningún**
+   re-render del padre los pisa (ver §9, #11).
+4. `handleSave`: valida el campo mínimo (p. ej. `nombre_cliente`), escribe en
+   Dexie (`EquipoFormDialog` dentro de `db.transaction`), llama `onSaved?.(id)`,
+   cierra (`onOpenChange(false)`) y dispara `pushSingle` por cada fila.
+5. Si el `catch` se activa, se loguea en consola y el diálogo **queda abierto**
+   (no hay feedback visible — smell §10).
+
+## 5. Comportamiento offline / online
+
+- **100% offline:** alta y edición de todas las maestras. La escritura Dexie
+  no depende de red.
+- **Encola para push:** cada add/update marca `sync_status = "pending"`; el
+  `pushSingle` intenta el envío inmediato y, si falla, la fila queda pendiente
+  para el ciclo de `use-auto-sync`.
+- **Exige red:** nada en el camino de guardado.
+- **Al reconectar:** el auto-sync empuja las filas `pending`. `EquipoFormDialog`
+  puede generar hasta 4 pushes por guardado.
+
+## 6. Interacción con sync
+
+- **Writes que encolan push:** todos.
+- **Conflicto:** hereda el modelo global — local gana, silencioso
+  (`logger.warn`), con detección de colisión server-más-nueva agregada en
+  Tier 2. Estos diálogos no añaden lógica de conflicto propia.
+- **Watermark:** `last_modified` cliente-generado (limitación conocida,
+  Módulo 4).
+
+## 7. Rol / permisos
+
+- Los diálogos **no** chequean permiso internamente. El gate vive en la
+  **página** que los monta (`hasPermission()` de `useRole()`), sólo en cliente.
+- Un usuario sin permiso no ve el botón que abre el diálogo; no hay refuerzo
+  server-side para las maestras (sólo `/api/usuarios` está server-enforced).
+
+## 8. Invariantes y supuestos
+
+- El padre pasa un `id` de padre **válido y ya persistido** (no se valida FK).
+- La prop de entidad en modo edición trae el `id`; el `seed()` la spreadea —
+  se asume que `id` no cambia entre reaperturas de la misma entidad lógica.
+- `EquipoFormDialog` asume **≤ 1** tubo / colimador / gantry "vivo" por equipo.
+  Si hay duplicados preexistentes, opera sobre el de menor `id` y **no** los
+  deduplica (los demás quedan como están).
+- `SetupField` asume que el `onSave` provisto es idempotente o tiene su propio
+  debounce: se dispara en cada `blur`, incluso sin cambios.
+- `StateTimeline` tolera un `currentState` fuera de `ESTADO_ORDER`
+  (`indexOf` → -1 → ningún paso marcado como actual, no explota).
+
+## 9. Modos de falla conocidos
+
+| Falla | Efecto | Manejo actual |
+| --- | --- | --- |
+| Excepción en `handleSave` | escritura parcial posible salvo en equipo | `console.error`; el diálogo queda abierto sin feedback |
+| Push falla (offline / 5xx) | fila queda `pending` | recuperada por `use-auto-sync` |
+| `EquipoFormDialog`: falla a mitad de los 4 writes | **antes:** equipo guardado sin hijos (o al revés) | **corregido (#10):** todo en `db.transaction("rw", …)` → rollback total |
+| Reabrir el diálogo con un objeto de entidad nuevo por render | **antes:** el `useEffect [open, entity]` re-sembraba y pisaba lo tipeado | **corregido (#11):** `useReseedOnOpen` sólo siembra en la transición `open` false→true |
+
+## 10. Preguntas abiertas / smells
+
+- Sin feedback de error en UI: un guardado que falla es invisible para el
+  técnico. Debería mostrar toast + mantener foco.
+- `console.error` en vez de `logger` (los demás módulos ya migraron a
+  `@/lib/logger`).
+- `EquipoFormDialog` no deduplica hijos preexistentes — sólo los ignora.
+- `handleOpenChange` (reset en `next === true`) quedó como código muerto en
+  varios diálogos ahora que `useReseedOnOpen` cubre la reapertura; limpiar.
+- `visita-modulos/*` sigue con `react-hooks/set-state-in-effect` en "warn"
+  (parte 2).
+
+---
+
+## Apéndice B — Log de decisiones (triage de hallazgos)
+
+| # | Descripción | Decisión | Razón | Sign-off |
+| --- | --- | --- | --- | --- |
+| 10 | `EquipoFormDialog` escribía `equipos` + hijos sin transacción; cargaba hijos con `.first()` (duplicados arbitrarios); limpiar campos no borraba la fila hija | **fix-ahora** | Escritura parcial rompe la integridad del equipo, que alimenta toda la captura de visita | ⬜ pendiente dueño |
+| 11 | `useEffect [open, entityObject]` re-sembraba el form en cada re-render del padre que spreadea un objeto nuevo → pisaba ediciones en curso; 3 diálogos lo tapaban con `eslint-disable exhaustive-deps` | **fix-ahora** | Pérdida de trabajo del técnico en la carga diaria; afecta los 7 diálogos | ⬜ pendiente dueño |
+
+### Detalle del fix
+
+- **`src/hooks/use-reseed-on-open.ts`** (nuevo): `useReseedOnOpen(open, seed)`
+  ejecuta `seed()` sólo en la transición `open` false→true. Usa un ref de
+  "última referencia" actualizado dentro de un `useEffect` (no en render, por
+  `react-hooks/refs` del compilador). Aplicado a los 7 diálogos; removidos los
+  `eslint-disable exhaustive-deps`.
+- **`src/components/equipo-form-dialog.tsx`**: `handleSave` envuelve equipo +
+  hijos en `db.transaction("rw", [equipos, tubos, colimadores, gantry], …)`;
+  helper `guardarHijo` que crea/actualiza si hay datos, o **soft-borra** el
+  hijo existente si el usuario limpió todos sus campos; carga de hijos ahora
+  filtra `deleted_at` y desempata duplicados por menor `id`.
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc de la parte 1 (7 diálogos + 2 compartidos)
+- [ ] Matriz de escenarios manual ejecutada (P1–P5) — pendiente dueño
+- [x] Hallazgos #10 y #11 cerrados con test verde
+  (`equipo-form-dialog.test.tsx`, `use-reseed-on-open.test.tsx`)
+- [x] Cobertura con umbral por archivo en `vitest.config.ts`
+- [x] `npm run verify` limpio (typecheck, lint 0 errores, format, 451 tests, build)
+- [x] Sin `eslint-disable` nuevo; removidos los 3 `exhaustive-deps` viejos
+- [ ] Sign-off del dueño
+- [ ] **Parte 2:** `visita-modulos/*`, `visit-action-bar`, `manual-drawer`,
+      re-escalar `react-hooks/set-state-in-effect` para esa ruta

--- a/src/components/cliente-form-dialog.tsx
+++ b/src/components/cliente-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { randomUUID } from "@/lib/uuid";
 import { db } from "@/lib/db";
 import type { Cliente } from "@/lib/db/types";
@@ -64,15 +65,11 @@ export function ClienteFormDialog({
     setForm((prev) => ({ ...prev, [field]: value }));
   }
 
-  // El padre controla `open` seteando el prop directamente (no vía
-  // onOpenChange), así que hay que repoblar el form acá — handleOpenChange
-  // solo dispara para cierres iniciados por Radix (Esc, overlay, botón).
-  useEffect(() => {
-    if (!open) return;
-    void (async () => {
-      setForm(cliente ? { ...cliente } : { ...EMPTY });
-    })();
-  }, [open, cliente]);
+  // Repoblar el form al reabrir (el padre controla `open` directo, no vía
+  // onOpenChange). Solo en la transición de apertura — ver useReseedOnOpen.
+  useReseedOnOpen(open, () => {
+    setForm(cliente ? { ...cliente } : { ...EMPTY });
+  });
 
   async function handleSave() {
     if (!form.nombre_cliente?.trim()) return;

--- a/src/components/contacto-form-dialog.tsx
+++ b/src/components/contacto-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { db } from "@/lib/db";
 import type { Contacto } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
@@ -79,13 +80,7 @@ export function ContactoFormDialog({
   // El padre controla `open` seteando el prop directamente (no vía
   // onOpenChange), así que hay que repoblar el form acá — handleOpenChange
   // solo dispara para cierres iniciados por Radix (Esc, overlay, botón).
-  useEffect(() => {
-    if (!open) return;
-    void (async () => {
-      resetForm();
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, contacto]);
+  useReseedOnOpen(open, resetForm);
 
   async function handleSave() {
     if (!nombre.trim()) return;

--- a/src/components/equipo-form-dialog.test.tsx
+++ b/src/components/equipo-form-dialog.test.tsx
@@ -145,6 +145,77 @@ describe("EquipoFormDialog", () => {
     expect(gantries[0].id).toBe(gantry.id);
   });
 
+  it("#10: soft-borra el tubo cuando el usuario limpia todos sus campos", async () => {
+    const equipo = await seedEquipo({ marca: "Siemens" });
+    const tubo: Tubo = {
+      id: randomUUID(),
+      equipo_id: equipo.id!,
+      marca: "Varian",
+      modelo: "A-100",
+      numero_serie: "SN-1",
+    };
+    await db.tubos.add(tubo);
+
+    const onSaved = vi.fn();
+    render(
+      <EquipoFormDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        ubicacionId="ubicacion-1"
+        equipo={equipo}
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Tubo de Rayos X"));
+    const marcaInput = await waitFor(() => screen.getByDisplayValue("Varian"));
+    fireEvent.change(marcaInput, { target: { value: "" } });
+    fireEvent.change(screen.getByDisplayValue("A-100"), { target: { value: "" } });
+    fireEvent.change(screen.getByDisplayValue("SN-1"), { target: { value: "" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /^guardar$/i }));
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+
+    const row = await db.tubos.get(tubo.id);
+    expect(row).toBeTruthy();
+    expect(row!.deleted_at).toBeTruthy();
+    expect(row!.sync_status).toBe("pending");
+  });
+
+  it("#10: si falla un write hijo, el update del equipo también se revierte", async () => {
+    const equipo = await seedEquipo({ marca: "Siemens", modelo: "OLD" });
+    const addSpy = vi.spyOn(db.gantry, "add").mockRejectedValueOnce(new Error("boom"));
+
+    render(
+      <EquipoFormDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        ubicacionId="ubicacion-1"
+        equipo={equipo}
+        onSaved={vi.fn()}
+      />
+    );
+
+    const modeloInput = await waitFor(() => screen.getByDisplayValue("OLD"));
+    fireEvent.change(modeloInput, { target: { value: "NEW" } });
+
+    fireEvent.click(screen.getByText("Gantry (CT)"));
+    const gantrySection = screen.getByText("Gantry (CT)").closest("div")!;
+    fireEvent.change(within(gantrySection).getAllByRole("textbox")[0], {
+      target: { value: "GantryX" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^guardar$/i }));
+
+    await waitFor(() => expect(addSpy).toHaveBeenCalled());
+    await waitFor(async () => {
+      const fresh = await db.equipos.get(equipo.id!);
+      expect(fresh!.modelo).toBe("OLD");
+    });
+    expect(await db.gantry.where("equipo_id").equals(equipo.id!).count()).toBe(0);
+    addSpy.mockRestore();
+  });
+
   it("crea el tubo cuando el equipo todavía no tiene uno", async () => {
     const equipo = await seedEquipo({ marca: "Siemens" });
     const onSaved = vi.fn();

--- a/src/components/equipo-form-dialog.tsx
+++ b/src/components/equipo-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { db } from "@/lib/db";
 import type { Equipo, Tubo, Colimador, Gantry } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
@@ -148,11 +149,9 @@ export function EquipoFormDialog({
 
   const [saving, setSaving] = useState(false);
 
-  // El padre controla `open` seteando el prop directamente (no vía
-  // onOpenChange), así que hay que repoblar el form acá — sin esto, reabrir
-  // el modal de edición muestra datos desactualizados del equipo.
-  useEffect(() => {
-    if (!open) return;
+  // Repoblar el form al reabrir (el padre controla `open` directo). Solo en
+  // la transición de apertura — ver useReseedOnOpen (#11).
+  useReseedOnOpen(open, () => {
     void (async () => {
       setTipoEquipo(equipo?.tipo_equipo ?? "");
       setSistemaAdq(equipo?.sistema_adquisicion ?? "");
@@ -170,12 +169,19 @@ export function EquipoFormDialog({
       setFiltAnadida(equipo?.filtracion_anadida_mmal?.toString() ?? "");
 
       // Cargar tubo/colimador/gantry existentes del equipo (si los hay) para
-      // poder actualizarlos en vez de crear duplicados al guardar.
+      // poder actualizarlos en vez de crear duplicados al guardar. Se ignoran
+      // las filas soft-deleted y, si hubiera duplicados preexistentes, se toma
+      // siempre el de menor `id` para que la selección sea determinística (#10).
+      const primeroVivo = <T extends { id?: string; deleted_at?: string | null }>(
+        rows: T[]
+      ): T | undefined =>
+        rows.filter((r) => !r.deleted_at).sort((a, b) => (a.id ?? "").localeCompare(b.id ?? ""))[0];
+
       const [tubo, colimador, gantryReg] = equipo?.id
         ? await Promise.all([
-            db.tubos.where("equipo_id").equals(equipo.id).first(),
-            db.colimadores.where("equipo_id").equals(equipo.id).first(),
-            db.gantry.where("equipo_id").equals(equipo.id).first(),
+            db.tubos.where("equipo_id").equals(equipo.id).toArray().then(primeroVivo),
+            db.colimadores.where("equipo_id").equals(equipo.id).toArray().then(primeroVivo),
+            db.gantry.where("equipo_id").equals(equipo.id).toArray().then(primeroVivo),
           ])
         : [undefined, undefined, undefined];
 
@@ -201,7 +207,7 @@ export function EquipoFormDialog({
       setGantrySerie(gantryReg?.numero_serie ?? "");
       setGantryDetector(gantryReg?.tipo_detector ?? "");
     })();
-  }, [open, equipo]);
+  });
 
   async function handleSave() {
     setSaving(true);
@@ -229,89 +235,119 @@ export function EquipoFormDialog({
         last_modified: now,
       };
 
-      let equipoId: string;
+      const tuboData: Omit<Tubo, "id"> = {
+        equipo_id: "",
+        marca: tuboMarca || undefined,
+        modelo: tuboModelo || undefined,
+        numero_serie: tuboSerie || undefined,
+        tipo: tuboTipo || undefined,
+        mas_max: tuboMasMax ? parseFloat(tuboMasMax) : undefined,
+        kv_max: tuboKvMax ? parseFloat(tuboKvMax) : undefined,
+        ma_max: tuboMaMax ? parseFloat(tuboMaMax) : undefined,
+        foco_fino_mm: tuboFocoFino ? parseFloat(tuboFocoFino) : undefined,
+        foco_grueso_mm: tuboFocoGrueso ? parseFloat(tuboFocoGrueso) : undefined,
+        creado_en: now,
+        sync_status: "pending",
+        last_modified: now,
+      };
+      const colData: Omit<Colimador, "id"> = {
+        equipo_id: "",
+        marca: colMarca || undefined,
+        modelo: colModelo || undefined,
+        numero_serie: colSerie || undefined,
+        creado_en: now,
+        sync_status: "pending",
+        last_modified: now,
+      };
+      const gantryData: Omit<Gantry, "id"> = {
+        equipo_id: "",
+        marca: gantryMarca || undefined,
+        modelo: gantryModelo || undefined,
+        numero_serie: gantrySerie || undefined,
+        tipo_detector: gantryDetector || undefined,
+        creado_en: now,
+        sync_status: "pending",
+        last_modified: now,
+      };
 
-      if (isEdit && equipo?.id) {
-        await db.equipos.update(equipo.id, equipoData);
-        equipoId = equipo.id;
-      } else {
-        equipoId = (await db.equipos.add({ ...equipoData, id: randomUUID() })) as string;
-      }
+      const tuboTieneDatos = !!(tuboMarca || tuboModelo || tuboSerie);
+      const colTieneDatos = !!(colMarca || colModelo || colSerie);
+      const gantryTieneDatos = !!(gantryMarca || gantryModelo || gantrySerie);
 
-      // Guardar tubo si hay datos (actualiza el existente en vez de duplicar)
-      let savedTuboId: string | undefined;
-      if (tuboMarca || tuboModelo || tuboSerie) {
-        const tuboData: Omit<Tubo, "id"> = {
-          equipo_id: equipoId,
-          marca: tuboMarca || undefined,
-          modelo: tuboModelo || undefined,
-          numero_serie: tuboSerie || undefined,
-          tipo: tuboTipo || undefined,
-          mas_max: tuboMasMax ? parseFloat(tuboMasMax) : undefined,
-          kv_max: tuboKvMax ? parseFloat(tuboKvMax) : undefined,
-          ma_max: tuboMaMax ? parseFloat(tuboMaMax) : undefined,
-          foco_fino_mm: tuboFocoFino ? parseFloat(tuboFocoFino) : undefined,
-          foco_grueso_mm: tuboFocoGrueso ? parseFloat(tuboFocoGrueso) : undefined,
-          creado_en: now,
-          sync_status: "pending",
-          last_modified: now,
-        };
-        if (tuboId) {
-          await db.tubos.update(tuboId, tuboData);
-          savedTuboId = tuboId;
+      // #10: todos los writes (equipo + hijos) van en una sola transacción,
+      // así un fallo a mitad no deja al equipo guardado sin sus hijos (o al
+      // revés). Los ids a pushear se acumulan y se envían tras el commit.
+      const toPush: Array<[Parameters<typeof pushSingle>[0], string]> = [];
+
+      await db.transaction("rw", [db.equipos, db.tubos, db.colimadores, db.gantry], async () => {
+        let equipoId: string;
+        if (isEdit && equipo?.id) {
+          await db.equipos.update(equipo.id, equipoData);
+          equipoId = equipo.id;
         } else {
-          savedTuboId = (await db.tubos.add({ ...tuboData, id: randomUUID() })) as string;
+          equipoId = (await db.equipos.add({ ...equipoData, id: randomUUID() })) as string;
         }
-      }
+        toPush.push(["equipos", equipoId]);
 
-      // Guardar colimador si hay datos (actualiza el existente en vez de duplicar)
-      let savedColId: string | undefined;
-      if (colMarca || colModelo || colSerie) {
-        const colData: Omit<Colimador, "id"> = {
-          equipo_id: equipoId,
-          marca: colMarca || undefined,
-          modelo: colModelo || undefined,
-          numero_serie: colSerie || undefined,
-          creado_en: now,
-          sync_status: "pending",
-          last_modified: now,
+        // Hijo: si hay datos, crear/actualizar; si el usuario limpió todos los
+        // campos y existía una fila, soft-delete (no dejar la fila huérfana).
+        type HijoTable = {
+          update: (id: string, changes: Record<string, unknown>) => PromiseLike<unknown>;
+          add: (obj: Record<string, unknown>) => PromiseLike<unknown>;
         };
-        if (colId) {
-          await db.colimadores.update(colId, colData);
-          savedColId = colId;
-        } else {
-          savedColId = (await db.colimadores.add({ ...colData, id: randomUUID() })) as string;
-        }
-      }
+        const guardarHijo = async <T extends { equipo_id: string }>(
+          nombre: Parameters<typeof pushSingle>[0],
+          tabla: HijoTable,
+          data: T,
+          existingId: string | undefined,
+          tieneDatos: boolean
+        ) => {
+          if (tieneDatos) {
+            const payload = { ...data, equipo_id: equipoId };
+            if (existingId) {
+              await tabla.update(existingId, payload);
+              toPush.push([nombre, existingId]);
+            } else {
+              const nuevoId = (await tabla.add({ ...payload, id: randomUUID() })) as string;
+              toPush.push([nombre, nuevoId]);
+            }
+          } else if (existingId) {
+            await tabla.update(existingId, {
+              deleted_at: now,
+              sync_status: "pending",
+              last_modified: now,
+            });
+            toPush.push([nombre, existingId]);
+          }
+        };
 
-      // Guardar gantry si hay datos (actualiza el existente en vez de duplicar)
-      let savedGantryId: string | undefined;
-      if (gantryMarca || gantryModelo || gantrySerie) {
-        const gantryData: Omit<Gantry, "id"> = {
-          equipo_id: equipoId,
-          marca: gantryMarca || undefined,
-          modelo: gantryModelo || undefined,
-          numero_serie: gantrySerie || undefined,
-          tipo_detector: gantryDetector || undefined,
-          creado_en: now,
-          sync_status: "pending",
-          last_modified: now,
-        };
-        if (gantryId) {
-          await db.gantry.update(gantryId, gantryData);
-          savedGantryId = gantryId;
-        } else {
-          savedGantryId = (await db.gantry.add({ ...gantryData, id: randomUUID() })) as string;
-        }
-      }
+        await guardarHijo(
+          "tubos",
+          db.tubos as unknown as HijoTable,
+          tuboData,
+          tuboId,
+          tuboTieneDatos
+        );
+        await guardarHijo(
+          "colimadores",
+          db.colimadores as unknown as HijoTable,
+          colData,
+          colId,
+          colTieneDatos
+        );
+        await guardarHijo(
+          "gantry",
+          db.gantry as unknown as HijoTable,
+          gantryData,
+          gantryId,
+          gantryTieneDatos
+        );
+      });
 
       onOpenChange(false);
       onSaved?.();
 
-      pushSingle("equipos", equipoId);
-      if (savedTuboId) pushSingle("tubos", savedTuboId);
-      if (savedColId) pushSingle("colimadores", savedColId);
-      if (savedGantryId) pushSingle("gantry", savedGantryId);
+      for (const [tabla, id] of toPush) pushSingle(tabla, id);
     } catch (err) {
       console.error("[EquipoForm] Error:", err);
     } finally {

--- a/src/components/sede-form-dialog.tsx
+++ b/src/components/sede-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import type { Sede } from "@/lib/db/types";
@@ -126,13 +127,7 @@ export function SedeFormDialog({
   // El padre controla `open` seteando el prop directamente (no vía
   // onOpenChange), así que hay que repoblar el form acá — handleOpenChange
   // solo dispara para cierres iniciados por Radix (Esc, overlay, botón).
-  useEffect(() => {
-    if (!open) return;
-    void (async () => {
-      resetForm();
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, sede]);
+  useReseedOnOpen(open, resetForm);
 
   async function handleSave() {
     if (!nombre.trim()) return;

--- a/src/components/solicitud-form-dialog.tsx
+++ b/src/components/solicitud-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import type { Solicitud } from "@/lib/db/types";
@@ -119,8 +120,7 @@ export function SolicitudFormDialog({
   // overlay, botón). En modo edición repuebla desde editSolicitud; en modo
   // creación limpia los pasos, para que reabrir "Nueva Solicitud" no
   // arrastre el cliente/sede/ubicación seleccionados en una apertura previa.
-  useEffect(() => {
-    if (!open) return;
+  useReseedOnOpen(open, () => {
     if (!editSolicitud) {
       resetForm();
       return;
@@ -137,7 +137,7 @@ export function SolicitudFormDialog({
       );
       setContactoId(editSolicitud.contacto_programar_id ?? "");
     })();
-  }, [open, editSolicitud]);
+  });
 
   function resetForm() {
     setClienteId("");

--- a/src/components/state-timeline.test.tsx
+++ b/src/components/state-timeline.test.tsx
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { StateTimeline } from "./state-timeline";
+import { ESTADO_ORDER, ESTADO_CONFIG } from "@/lib/workflow/visit-state-machine";
+
+afterEach(cleanup);
+
+describe("StateTimeline", () => {
+  it("renderiza un paso por cada estado del ciclo de vida", () => {
+    render(<StateTimeline currentState="asignada" />);
+    for (const estado of ESTADO_ORDER) {
+      // El label aparece dos veces (variante sm y variante mobile).
+      expect(screen.getAllByText(ESTADO_CONFIG[estado].label).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("marca el estado actual con la clase del dot resaltado", () => {
+    const { container } = render(<StateTimeline currentState="en_revision" />);
+    const dots = container.querySelectorAll("div.rounded-full.border-2");
+    // El índice de `en_revision` en ESTADO_ORDER es el dot con ring-primary.
+    const idx = ESTADO_ORDER.indexOf("en_revision");
+    expect(dots[idx].className).toContain("ring-primary/20");
+  });
+
+  it("no explota si el estado no está en el orden (índice -1)", () => {
+    expect(() => render(<StateTimeline currentState={"desconocido" as never} />)).not.toThrow();
+  });
+});

--- a/src/components/ubicacion-form-dialog.tsx
+++ b/src/components/ubicacion-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { db } from "@/lib/db";
 import type { UbicacionRx } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
@@ -78,13 +79,7 @@ export function UbicacionFormDialog({
   // El padre controla `open` seteando el prop directamente (no vía
   // onOpenChange), así que hay que repoblar el form acá — handleOpenChange
   // solo dispara para cierres iniciados por Radix (Esc, overlay, botón).
-  useEffect(() => {
-    if (!open) return;
-    void (async () => {
-      resetForm();
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, ubicacion]);
+  useReseedOnOpen(open, resetForm);
 
   async function handleSave() {
     if (!nombre.trim()) return;

--- a/src/components/visita-modulos/setup-field.test.tsx
+++ b/src/components/visita-modulos/setup-field.test.tsx
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { SetupField } from "./setup-field";
+
+afterEach(cleanup);
+
+describe("SetupField", () => {
+  it("guarda el valor on-blur y muestra el check de confirmación", () => {
+    vi.useFakeTimers();
+    const onSave = vi.fn();
+    render(<SetupField label="Distancia" defaultValue={100} onSave={onSave} />);
+
+    const input = screen.getByDisplayValue("100");
+    fireEvent.change(input, { target: { value: "120" } });
+    fireEvent.blur(input);
+
+    expect(onSave).toHaveBeenCalledWith("120");
+    // El check se limpia tras 1500ms.
+    vi.advanceTimersByTime(1500);
+    vi.useRealTimers();
+  });
+
+  it("no es controlado: editar no requiere re-render del padre", () => {
+    const onSave = vi.fn();
+    render(<SetupField label="Técnica" defaultValue="" type="text" onSave={onSave} />);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "abc" } });
+    expect((input as HTMLInputElement).value).toBe("abc");
+    expect(onSave).not.toHaveBeenCalled();
+    fireEvent.blur(input);
+    expect(onSave).toHaveBeenCalledWith("abc");
+  });
+});

--- a/src/hooks/use-reseed-on-open.test.tsx
+++ b/src/hooks/use-reseed-on-open.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { useReseedOnOpen } from "./use-reseed-on-open";
+
+afterEach(cleanup);
+
+function Harness({ open, entity, seed }: { open: boolean; entity: unknown; seed: () => void }) {
+  // `entity` está en las props para forzar re-render; el hook NO debe
+  // re-sembrar por su cambio de identidad.
+  useReseedOnOpen(open, seed);
+  return <span data-testid="e">{JSON.stringify(entity)}</span>;
+}
+
+describe("useReseedOnOpen", () => {
+  it("no siembra si arranca cerrado", () => {
+    const seed = vi.fn();
+    render(<Harness open={false} entity={{}} seed={seed} />);
+    expect(seed).not.toHaveBeenCalled();
+  });
+
+  it("siembra una vez al abrir", () => {
+    const seed = vi.fn();
+    const { rerender } = render(<Harness open={false} entity={{}} seed={seed} />);
+    rerender(<Harness open={true} entity={{}} seed={seed} />);
+    expect(seed).toHaveBeenCalledTimes(1);
+  });
+
+  it("#11: NO re-siembra si el padre pasa un objeto nuevo mientras está abierto", () => {
+    const seed = vi.fn();
+    const { rerender } = render(<Harness open={true} entity={{ v: 1 }} seed={seed} />);
+    expect(seed).toHaveBeenCalledTimes(1);
+
+    // El padre spreadea un objeto nuevo en cada render — identidad distinta.
+    rerender(<Harness open={true} entity={{ v: 1 }} seed={seed} />);
+    rerender(<Harness open={true} entity={{ v: 2 }} seed={seed} />);
+    expect(seed).toHaveBeenCalledTimes(1); // sigue en 1
+  });
+
+  it("re-siembra al cerrar y volver a abrir (con datos frescos)", () => {
+    let count = 0;
+    const seed = vi.fn(() => count++);
+    const { rerender } = render(<Harness open={true} entity={{}} seed={seed} />);
+    rerender(<Harness open={false} entity={{}} seed={seed} />);
+    rerender(<Harness open={true} entity={{}} seed={seed} />);
+    expect(seed).toHaveBeenCalledTimes(2);
+  });
+
+  it("usa el seed más reciente (no una versión vieja del closure)", () => {
+    const seedA = vi.fn();
+    const seedB = vi.fn();
+    const { rerender } = render(<Harness open={false} entity={{}} seed={seedA} />);
+    rerender(<Harness open={false} entity={{}} seed={seedB} />);
+    rerender(<Harness open={true} entity={{}} seed={seedB} />);
+    expect(seedA).not.toHaveBeenCalled();
+    expect(seedB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/use-reseed-on-open.ts
+++ b/src/hooks/use-reseed-on-open.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Ejecuta `seed()` SOLO cuando `open` pasa de `false` a `true` — no en cada
+ * re-render mientras el diálogo sigue abierto.
+ *
+ * Los diálogos de entidad se controlan seteando el prop `open` directo (no
+ * vía `onOpenChange` de Radix), así que hay que repoblar el form a mano al
+ * reabrir. El problema (#11): si se pone `seed` en un `useEffect` que también
+ * depende del prop de la entidad, y el padre spreadea un objeto nuevo en cada
+ * render (`entity={{ ...fromLiveQuery }}`), el efecto se re-dispara y pisa lo
+ * que el usuario está escribiendo. Este hook solo re-siembra en la
+ * transición de apertura.
+ */
+export function useReseedOnOpen(open: boolean, seed: () => void): void {
+  const wasOpen = useRef(false);
+  const seedRef = useRef(seed);
+
+  // Mantener la última referencia de `seed` sin escribir el ref en render.
+  useEffect(() => {
+    seedRef.current = seed;
+  });
+
+  useEffect(() => {
+    if (open && !wasOpen.current) seedRef.current();
+    wasOpen.current = open;
+  }, [open]);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,6 +61,13 @@ export default defineConfig({
         // generarPreInforme recorre casi toda la tubería de render.
         "src/lib/pdf/generar-pre-informe.ts": { lines: 65, functions: 40, branches: 58 },
         "src/lib/pdf/secciones-convencional.ts": { lines: 43, functions: 28, branches: 20 },
+        // Tier 6 — Módulo 17 (form-dialogs) + piezas compartidas del Módulo 18.
+        // #10 (writes multi-tabla del equipo ahora transaccionales + soft-delete
+        // de hijos huérfanos) y #11 (useReseedOnOpen: repoblar el form solo en
+        // la transición open→true) quedan fijados con test.
+        "src/hooks/use-reseed-on-open.ts": { lines: 100, functions: 100, branches: 90 },
+        "src/components/state-timeline.tsx": { lines: 88, functions: 100, branches: 75 },
+        "src/components/visita-modulos/setup-field.tsx": { lines: 90, functions: 80, branches: 70 },
       },
     },
   },


### PR DESCRIPTION
## Contexto

Tier 6 del plan de intervención (UI de captura y CRUD). Esta es la **parte 1 de 2**: los 7 diálogos de maestras (Módulo 17) + dos piezas de presentación chicas del Módulo 18. La **parte 2** — `src/components/visita-modulos/*` (grupo-a..e, info, pre-informe), `visit-action-bar`, `manual-drawer`, y re-escalar `react-hooks/set-state-in-effect` para esa ruta — va en un PR aparte por volumen (~330 KB sin tests).

## Hallazgos cerrados

### #11 — Reapertura de diálogo pisa ediciones en curso
El `useEffect` con deps `[open, entityObject]` re-sembraba el form en cada re-render del padre que spreadea un objeto de entidad nuevo (`entity={{ ...fromLiveQuery }}`), borrando lo que el técnico estaba tipeando. 3 diálogos lo tapaban con `eslint-disable react-hooks/exhaustive-deps`.

**Fix:** nuevo hook `useReseedOnOpen(open, seed)` que ejecuta `seed()` **solo en la transición `open` false→true**. Aplicado a los 7 diálogos; removidos los 3 `eslint-disable`. El hook usa un ref de "última referencia" actualizado dentro de un `useEffect` (no en render, para no violar `react-hooks/refs` del compilador de React).

### #10 — `equipo-form-dialog`: writes multi-tabla no transaccionales
`handleSave` escribía `equipos` + `tubos`/`colimadores`/`gantry` como awaits separados: un fallo a mitad dejaba el equipo guardado sin sus hijos (o al revés). Además cargaba hijos con `.first()` (duplicados preexistentes se editaban arbitrario) y limpiar todos los campos de un hijo no borraba la fila.

**Fix:**
- Todo en `db.transaction("rw", [equipos, tubos, colimadores, gantry], …)` → rollback total.
- `guardarHijo`: crea/actualiza si hay datos; **soft-borra** (`deleted_at`) el hijo existente si el usuario limpió todos sus campos.
- Carga de hijos filtra `deleted_at` y desempata duplicados por menor `id` (determinístico).

## Cobertura nueva

| Archivo | Tests |
|---|---|
| `src/hooks/use-reseed-on-open.test.tsx` | 5 — no siembra cerrado, siembra 1x al abrir, **no re-siembra con objeto nuevo mientras está abierto (#11)**, re-siembra al cerrar+reabrir, usa el seed más reciente |
| `src/components/equipo-form-dialog.test.tsx` | +2 — **soft-borra el tubo al limpiar sus campos**, **rollback del equipo si falla un write hijo** |
| `src/components/state-timeline.test.tsx` | 3 — un paso por estado, marca el actual, tolera estado fuera de orden |
| `src/components/visita-modulos/setup-field.test.tsx` | 2 — guarda on-blur + check, no controlado |

Thresholds por archivo agregados en `vitest.config.ts`.

## Verificación

`npm run verify` limpio: typecheck, lint (0 errores), format, **451 tests**, build.

## Doc

`docs/modules/10-ui-form-dialogs.md` — 10 secciones + log de decisiones para la parte 1.

## Pendiente (parte 2)

- Smoke/gate tests de `visita-modulos/grupo-a..e`, `info-modulo`, `pre-informe-modulo`
- `visit-action-bar` (gate de permiso), `manual-drawer`
- Re-escalar `react-hooks/set-state-in-effect` a "error" para `src/components/visita-modulos/**`
