### PR TITLE
test(ui): Tier 6 (2/2) — smoke net de visita-modulos + set-state-in-effect a error

### DIFF
--- a/docs/modules/10-ui-form-dialogs.md
+++ b/docs/modules/10-ui-form-dialogs.md
@@ -167,5 +167,5 @@ segundo es un input no controlado con guardado on-blur.
 - [x] `npm run verify` limpio (typecheck, lint 0 errores, format, 451 tests, build)
 - [x] Sin `eslint-disable` nuevo; removidos los 3 `exhaustive-deps` viejos
 - [ ] Sign-off del dueño
-- [ ] **Parte 2:** `visita-modulos/*`, `visit-action-bar`, `manual-drawer`,
-      re-escalar `react-hooks/set-state-in-effect` para esa ruta
+- [x] **Parte 2:** `visita-modulos/*`, `visit-action-bar`, `manual-drawer`,
+      re-escalar `react-hooks/set-state-in-effect` → ver `10-ui-visita-modulos.md`

--- a/docs/modules/10-ui-visita-modulos.md
+++ b/docs/modules/10-ui-visita-modulos.md
@@ -1,0 +1,173 @@
+# Módulo: `components/visita-modulos/*` + barra de acciones + manual-drawer
+
+> Estado: 🟡 en curso (Tier 6 — parte 2 de 2) · Última actualización: `2026-08-28` · Responsable: `Juan Pablo Guzmán`
+
+Doc producido por el protocolo de intervención (ver
+`~/.claude/plans/en-dias-anteriores-he-cheerful-hopcroft.md`).
+
+Parte 2 de Tier 6. Cubre los **7 módulos de captura de visita** (Módulo 16 del
+plan) y las piezas de UI compartidas restantes del Módulo 18
+(`visit-action-bar`, `manual-drawer`, hook `useBlobPreviewUrl`). La parte 1
+(form-dialogs de maestras) está en `10-ui-form-dialogs.md`.
+
+Alcance de esta pasada: **red de smoke tests + corrección de deuda de
+`react-hooks/set-state-in-effect`**. La cobertura profunda tabla-por-tabla de
+cada módulo de grupo se hace en Tier 3/4 cuando se recree el flujo completo
+desde la app.
+
+---
+
+## 1. Responsabilidad
+
+`visita-modulos/*` son las **superficies de captura de campo** de una visita
+CONVENCIONAL. Cada módulo es dueño de escritura de un subconjunto de las
+tablas `conv_*` (o de campos de `visitas`/`equipos`/`ubicaciones_rx` en el
+caso de `info-modulo`) y encola push a Supabase.
+
+- `info-modulo` — precarga: cliente, sede, ubicación, equipo, tubo, contactos.
+- `grupo-a` … `grupo-e` — las 5 baterías de pruebas convencionales (mediciones,
+  inspección visual, elementos de protección, evidencias fotográficas).
+- `pre-informe-modulo` — resumen de conceptos por prueba + generación del PDF
+  de pre-informe (borrador).
+
+`visit-action-bar` es la **única superficie que dispara transiciones de estado
+de la visita**: lee `getAvailableActions(estado, cargo)` y ejecuta
+`checkGate` + `executeTransition` (Tier 4).
+
+`manual-drawer` es un panel lateral de solo lectura con el manual de cada
+prueba; sin acceso a datos.
+
+## 2. API pública
+
+| Export | Firma | Efectos | Convención de error | ¿Idempotente? |
+| --- | --- | --- | --- | --- |
+| `InfoModulo` / `GrupoAModulo` … `GrupoEModulo` / `PreInformeModulo` | `{ visitaId: string }` | `useLiveQuery` sobre la visita + sus `conv_*`; auto-inicializan filas de setup/inspección si faltan; escrituras vía `updateAndSync` / `db.*.add` + `pushSingle` | `catch` → `console.error`, no re-lanza; sin toast | los guards con `useRef` evitan doble auto-init en el mismo montaje |
+| `VisitActionBar` | `{ visitaId, estadoVisita, onTransition?, progressText? }` | `checkGate` + `executeTransition` (Tier 4); `onTransition(newState)` al terminar | `catch` → `console.error` | sí (la state-machine valida estado actual) |
+| `ManualDrawer` | `{ open, onClose, pruebas, pruebaCodigo? }` | ninguno (render puro + animación) | n/a | sí |
+| `useBlobPreviewUrl` (hook) | `(blob) => string \| null` | `URL.createObjectURL` en render (`useMemo`), `revokeObjectURL` en cleanup | n/a | sí |
+
+## 3. Modelo de datos
+
+- **Tablas propias:** `conv_levantamiento_setup`, `conv_mediciones`,
+  `conv_inspeccion_items`, `conv_elementos_proteccion`, `conv_evidencias`,
+  `conv_ddi_mediciones`, `conv_cassettes`, `conv_raysafe_mediciones`,
+  `conv_cae_mediciones`, `conv_informe_secciones`, … (según el módulo). Además
+  `info-modulo` escribe campos de `visitas`, `clientes`, `sedes`,
+  `ubicaciones_rx`, `equipos`, `tubos`, `contactos`.
+- **`deleted_at`:** los `useLiveQuery` de los módulos de grupo **sí** filtran
+  `deleted_at` en `conv_mediciones`, `conv_elementos_proteccion`,
+  `conv_evidencias`. `conv_inspeccion_items` se carga **sin filtrar** — es el
+  hallazgo #14 (fix-ahora ya aplicado en Tier 1/3 para el camino de
+  conformidad; el render del módulo todavía lo lista sin filtro, ver §10).
+- **`last_modified`:** cliente-generado en cada write (limitación Módulo 4).
+- **Supabase:** todas las `conv_*` son `SYNC_TABLES`.
+
+## 4. Flujo de control
+
+1. La página `dashboard/visitas/[id]` monta el módulo con `visitaId`.
+2. `useDb()` indica si Dexie está lista; hasta entonces → "Cargando…".
+3. `useLiveQuery` resuelve la visita + sus `conv_*`. Si la visita no existe →
+   "Visita no encontrada". `undefined` (aún cargando) → "Cargando…".
+4. Al montar, si faltan filas base (`conv_levantamiento_setup`,
+   `conv_inspeccion_items`), un `useEffect` con guard de `useRef` las crea una
+   sola vez.
+5. El usuario edita celdas; cada cambio hace `updateAndSync` (debounce por
+   campo en varios módulos) + `pushSingle`.
+6. `pre-informe-modulo` deriva el concepto de cada prueba con `evaluacion.ts`
+   (Tier 3) y arma el PDF con `generar-pre-informe.ts` (Tier 5).
+
+## 5. Comportamiento offline / online
+
+- **100% offline:** toda la captura. `useLiveQuery` lee de IndexedDB.
+- **Encola para push:** cada write marca `sync_status = "pending"`.
+- **Exige red:** nada de la captura. El PDF de pre-informe se genera local.
+- **Al reconectar:** el auto-sync empuja las filas `pending`.
+
+## 6. Interacción con sync
+
+- Writes vía `updateAndSync` / `deleteAndSync` (soft-delete) encolan push.
+- Conflicto: modelo global (local gana, `logger.warn` + detección de colisión
+  de Tier 2).
+- `visit-action-bar` → `executeTransition` hace varios writes no
+  transaccionales (hallazgo #9, backlog Tier 4).
+
+## 7. Rol / permisos
+
+- Los módulos de captura **no** chequean permiso: el gate está en la página
+  (`hasPermission`), solo cliente.
+- `visit-action-bar` **sí** filtra por `role.cargo` vía
+  `getAvailableActions` — un rol sin transiciones no ve ningún botón. El
+  refuerzo real de la transición vive en `executeTransition` (valida cargo +
+  estado). Sigue siendo lógica cliente; no hay RLS que lo imponga.
+
+## 8. Invariantes y supuestos
+
+- Asume que las filas `conv_*` base se auto-crean al primer montaje del módulo
+  (los guards de `useRef` no sobreviven a un remount con datos aún sin
+  reflejar — de ahí el guard adicional por `visitaId`).
+- Asume exactamente una visita por `visitaId` y que su `equipo` es
+  CONVENCIONAL (los módulos de grupo no tienen camino no-CONV — hallazgo #7,
+  guard en `registry.ts`).
+- `ManualDrawer`: `visible` sobrevive a `open=false` durante 250 ms (animación
+  de salida) — no se puede derivar en render.
+
+## 9. Modos de falla conocidos
+
+| Falla | Efecto | Manejo actual |
+| --- | --- | --- |
+| Excepción en un save de celda | write parcial posible | `console.error`, sin feedback UI |
+| `executeTransition` falla a mitad | estados visita/informe/solicitud divergentes | detección de reconciliación (Tier 4, #9) |
+| `conv_inspeccion_items` con filas `deleted_at` | aparecen en la lista del módulo | filtro pendiente (§10) |
+
+## 10. Preguntas abiertas / smells
+
+- `conv_inspeccion_items` se lista sin filtrar `deleted_at` en los módulos de
+  grupo (el camino de conformidad ya lo filtra; la UI de captura no).
+- `console.error` en vez de `logger` en toda la carpeta.
+- Sin feedback de error de guardado en la UI.
+- Cobertura de los módulos de grupo es **smoke-only** (33–62 % líneas): la
+  matriz de escenarios completa (celda por celda, cada `conv_*`) queda para
+  Tier 3/4 al recrear el flujo desde la app.
+
+---
+
+## Apéndice B — Log de decisiones (triage de hallazgos)
+
+| # | Descripción | Decisión | Razón | Sign-off |
+| --- | --- | --- | --- | --- |
+| 23 (parcial) | `react-hooks/set-state-in-effect` en "warn" para `visita-modulos/**` + `manual-drawer` sin red de tests | **fix-ahora** | Deuda rastreada con fecha de salida en Tier 6; ya hay smoke tests que respaldan el cambio | ⬜ pendiente dueño |
+
+### Detalle del fix de `set-state-in-effect`
+
+- **`src/hooks/use-blob-preview-url.ts`** (nuevo): reemplaza el patrón
+  `useState + useEffect(setPreview(...))` que se repetía **6 veces** en los
+  5 módulos de grupo (previsualización de evidencias fotográficas). El URL se
+  deriva en render con `useMemo`; el efecto solo revoca en cleanup. — 0
+  violaciones.
+- **`info-modulo.tsx`** — `EditableField` / `EditableTextArea`: el
+  `useEffect(() => setLocal(value), [value])` pasa a **ajuste de estado en
+  render** con un `prevValue` de control (patrón sancionado por React docs).
+- **`grupo-d-modulo.tsx`** — la inicialización de los valores base 2.9 desde
+  DB pasa a ajuste en render guardado por un flag `baseInit`; se elimina el
+  `eslint-disable react-hooks/exhaustive-deps` que la acompañaba.
+- **`manual-drawer.tsx`** — la sincronización de índice por `pruebaCodigo`
+  pasa a ajuste en render (una vez por combinación `codigo × pruebas
+  cargadas`). La orquestación de animación de entrada mantiene **un
+  `eslint-disable` inline justificado**: `visible` controla el montaje y debe
+  sobrevivir a `open=false` durante la animación de salida, así que no puede
+  derivarse.
+- **`eslint.config.mjs`** — `react-hooks/set-state-in-effect` vuelve a
+  `"error"` para `src/components/visita-modulos/**` y
+  `src/components/manual-drawer.tsx`.
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc de la parte 2
+- [ ] Matriz de escenarios completa (celda por celda) — **diferida a Tier 3/4**
+- [x] Smoke tests: 21 (`modulos-smoke.test.tsx`, 3 estados × 7 módulos) +
+  7 (`manual-drawer.test.tsx`) + 8 (`visit-action-bar.test.tsx`)
+- [x] `react-hooks/set-state-in-effect` = "error" en la ruta, 0 violaciones
+  (1 disable inline justificado en `manual-drawer`)
+- [x] Thresholds de cobertura (piso actual) por archivo + glob en `vitest.config.ts`
+- [x] `npm run verify` limpio (typecheck, lint 0 errores, format, 487 tests, build)
+- [ ] Sign-off del dueño

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,10 +21,22 @@ const eslintConfig = defineConfig([
     // módulo afectado re-escala la regla a "error" en su ruta (o corrige la
     // violación con test) como criterio de salida de su tier:
     //   - src/hooks/**            -> Tier 1
-    //   - src/components/visita-modulos/**, manual-drawer -> Tier 6
+    //   - src/components/visita-modulos/**, manual-drawer -> Tier 6 ✅ (abajo)
     //   - src/app/dashboard/**    -> Tier 7
     rules: {
       "react-hooks/set-state-in-effect": "warn",
+    },
+  },
+  {
+    // Tier 6 — ruta certificada. Las violaciones de `set-state-in-effect` en
+    // los módulos de captura de visita y en el manual-drawer se corrigieron
+    // (useBlobPreviewUrl para las previsualizaciones; ajuste de estado en
+    // render para la sincronización de props) y quedan cubiertas por
+    // smoke-tests. La única excepción justificada inline es la orquestación
+    // de animación de `manual-drawer`. La regla vuelve a "error" acá.
+    files: ["src/components/visita-modulos/**/*.{ts,tsx}", "src/components/manual-drawer.tsx"],
+    rules: {
+      "react-hooks/set-state-in-effect": "error",
     },
   },
   {

--- a/src/components/manual-drawer.test.tsx
+++ b/src/components/manual-drawer.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ManualDrawer } from "./manual-drawer";
+import { getManualGrupo } from "@/lib/equipos/convencional/manual";
+
+const PRUEBAS = getManualGrupo("A");
+
+afterEach(cleanup);
+
+describe("ManualDrawer", () => {
+  it("no monta nada si open=false", () => {
+    const { container } = render(<ManualDrawer open={false} onClose={vi.fn()} pruebas={PRUEBAS} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("no monta nada si no hay pruebas, aunque open=true", () => {
+    const { container } = render(<ManualDrawer open onClose={vi.fn()} pruebas={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("monta el panel y muestra la primera prueba cuando open=true", async () => {
+    render(<ManualDrawer open onClose={vi.fn()} pruebas={PRUEBAS} />);
+    expect(await screen.findByText("Manual")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: PRUEBAS[0].nombre })).toBeInTheDocument();
+  });
+
+  it("abre en la prueba indicada por pruebaCodigo", async () => {
+    const target = PRUEBAS[1] ?? PRUEBAS[0];
+    render(<ManualDrawer open onClose={vi.fn()} pruebas={PRUEBAS} pruebaCodigo={target.codigo} />);
+    expect(await screen.findByRole("heading", { name: target.nombre })).toBeInTheDocument();
+  });
+
+  it("cambia de prueba al clickear un tab", async () => {
+    const otra = PRUEBAS[2] ?? PRUEBAS[PRUEBAS.length - 1];
+    render(<ManualDrawer open onClose={vi.fn()} pruebas={PRUEBAS} />);
+    await screen.findByText("Manual");
+    const tabs = screen.getAllByRole("button", { name: otra.codigo });
+    fireEvent.click(tabs[0]);
+    expect(await screen.findByRole("heading", { name: otra.nombre })).toBeInTheDocument();
+  });
+
+  it("llama onClose al presionar Escape", async () => {
+    const onClose = vi.fn();
+    render(<ManualDrawer open onClose={onClose} pruebas={PRUEBAS} />);
+    await screen.findByText("Manual");
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("llama onClose al clickear el botón X", async () => {
+    const onClose = vi.fn();
+    render(<ManualDrawer open onClose={onClose} pruebas={PRUEBAS} />);
+    await screen.findByText("Manual");
+    // El botón X no tiene texto accesible; es el primer botón sin código de prueba.
+    const closeBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.querySelector("svg") && !b.textContent?.trim());
+    fireEvent.click(closeBtn!);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/manual-drawer.tsx
+++ b/src/components/manual-drawer.tsx
@@ -25,9 +25,14 @@ export function ManualDrawer({ open, onClose, pruebas, pruebaCodigo }: ManualDra
   const [animating, setAnimating] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // Animate in
+  // Animación de entrada/salida. `visible` controla el montaje y DEBE
+  // sobrevivir a `open === false` durante los 250 ms de la animación de
+  // salida, así que no puede derivarse en render. El setState síncrono acá
+  // es intencional (transición puntual de `open`, sin cascada), no el
+  // patrón que `react-hooks/set-state-in-effect` busca prevenir.
   useEffect(() => {
     if (open) {
+      /* eslint-disable-next-line react-hooks/set-state-in-effect */
       setVisible(true);
       requestAnimationFrame(() => requestAnimationFrame(() => setAnimating(true)));
     } else {
@@ -37,13 +42,20 @@ export function ManualDrawer({ open, onClose, pruebas, pruebaCodigo }: ManualDra
     }
   }, [open]);
 
-  // Sync initial prueba
-  useEffect(() => {
-    if (pruebaCodigo && pruebas.length > 0) {
+  // Posicionar el índice en la prueba pedida por `pruebaCodigo`. Se hace una
+  // vez por cada combinación distinta de (pruebaCodigo, pruebas ya cargadas)
+  // — ajuste de estado en render, no en efecto. No se re-dispara por un
+  // simple cambio de identidad del array `pruebas` (eso reiniciaría la
+  // navegación manual del usuario).
+  const syncKey = pruebas.length > 0 ? (pruebaCodigo ?? "") : null;
+  const [syncedFor, setSyncedFor] = useState<string | null>(null);
+  if (syncKey !== null && syncKey !== syncedFor) {
+    setSyncedFor(syncKey);
+    if (pruebaCodigo) {
       const idx = pruebas.findIndex((p) => p.codigo === pruebaCodigo);
       if (idx >= 0) setCurrentIdx(idx);
     }
-  }, [pruebaCodigo, pruebas]);
+  }
 
   // Scroll to top on prueba change
   useEffect(() => {

--- a/src/components/visit-action-bar.test.tsx
+++ b/src/components/visit-action-bar.test.tsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+// ============================================================
+//  VisitActionBar — gating del ciclo de vida de la visita.
+//
+//  Se mockean SOLO los efectos de la state-machine (checkGate,
+//  executeTransition); getAvailableActions y el mapa de transiciones son
+//  reales, así se verifica que la barra ofrece exactamente las acciones que
+//  el (estado, rol) permite.
+// ============================================================
+
+const useRole = vi.fn();
+vi.mock("@/components/role-provider", () => ({ useRole: () => useRole() }));
+
+const checkGate = vi.fn();
+const executeTransition = vi.fn();
+vi.mock("@/lib/workflow/visit-state-machine", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/workflow/visit-state-machine")>();
+  return {
+    ...actual,
+    checkGate: (...args: unknown[]) => checkGate(...args),
+    executeTransition: (...args: unknown[]) => executeTransition(...args),
+  };
+});
+
+import { VisitActionBar } from "./visit-action-bar";
+
+const asRole = (cargo: string) => useRole.mockReturnValue({ role: { cargo, usuarioId: "u1" } });
+
+describe("VisitActionBar", () => {
+  beforeEach(() => {
+    checkGate.mockResolvedValue({ canProceed: true, errors: [] });
+    executeTransition.mockResolvedValue({ success: true, newState: "en_revision" });
+  });
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("no renderiza nada si no hay rol resuelto", () => {
+    useRole.mockReturnValue({ role: null });
+    const { container } = render(<VisitActionBar visitaId="v1" estadoVisita="asignada" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("ofrece 'Iniciar Visita' a un técnico en estado asignada", () => {
+    asRole("tecnico");
+    render(<VisitActionBar visitaId="v1" estadoVisita="asignada" />);
+    expect(screen.getByRole("button", { name: /Iniciar Visita/i })).toBeInTheDocument();
+  });
+
+  it("no ofrece acciones a un comercial (rol sin transiciones)", () => {
+    asRole("comercial");
+    const { container } = render(<VisitActionBar visitaId="v1" estadoVisita="asignada" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("bloquea 'Enviar a Revisión' si el gate de completitud falla", async () => {
+    asRole("tecnico");
+    checkGate.mockResolvedValue({
+      canProceed: false,
+      errors: [{ moduleId: "grupo-a", message: "Grupo A incompleto" }],
+    });
+    render(<VisitActionBar visitaId="v1" estadoVisita="en_progreso" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Enviar a Revisión/i }));
+
+    expect(await screen.findByText("Módulos incompletos")).toBeInTheDocument();
+    expect(screen.getByText("Grupo A incompleto")).toBeInTheDocument();
+    expect(executeTransition).not.toHaveBeenCalled();
+  });
+
+  it("ejecuta la transición y notifica onTransition cuando el gate pasa", async () => {
+    asRole("tecnico");
+    const onTransition = vi.fn();
+    render(<VisitActionBar visitaId="v1" estadoVisita="en_progreso" onTransition={onTransition} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Enviar a Revisión/i }));
+
+    await waitFor(() => expect(onTransition).toHaveBeenCalledWith("en_revision"));
+    expect(executeTransition).toHaveBeenCalledWith(
+      "v1",
+      "enviar_revision",
+      "tecnico",
+      expect.objectContaining({ usuarioId: "u1" })
+    );
+  });
+
+  it("una acción con requiereRazon pide el motivo antes de ejecutar", async () => {
+    asRole("coordinador");
+    render(<VisitActionBar visitaId="v1" estadoVisita="en_revision" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Devolver con Observaciones/i }));
+
+    const textarea = await screen.findByPlaceholderText(/Describe el motivo/i);
+    const confirmar = screen.getByRole("button", { name: /Confirmar/i });
+    expect(confirmar).toBeDisabled();
+    expect(executeTransition).not.toHaveBeenCalled();
+
+    fireEvent.change(textarea, { target: { value: "Falta calibrar el tubo" } });
+    expect(confirmar).toBeEnabled();
+
+    fireEvent.click(confirmar);
+    await waitFor(() =>
+      expect(executeTransition).toHaveBeenCalledWith(
+        "v1",
+        "devolver",
+        "coordinador",
+        expect.objectContaining({ observaciones_revision: "Falta calibrar el tubo" })
+      )
+    );
+  });
+
+  it("muestra el estado terminal cuando no hay acciones (aprobada)", () => {
+    asRole("tecnico");
+    render(<VisitActionBar visitaId="v1" estadoVisita="aprobada" />);
+    expect(screen.getByText(/Visita aprobada/i)).toBeInTheDocument();
+  });
+
+  it("muestra el estado terminal 'enviada' sin acciones para un técnico", () => {
+    asRole("tecnico");
+    render(<VisitActionBar visitaId="v1" estadoVisita="enviada" />);
+    expect(screen.getByText(/Informe enviado al cliente/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/visita-modulos/grupo-a-modulo.tsx
+++ b/src/components/visita-modulos/grupo-a-modulo.tsx
@@ -32,6 +32,7 @@ import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
 import { SetupField } from "@/components/visita-modulos/setup-field";
 import { useRowSavedFlash } from "@/hooks/use-row-saved";
+import { useBlobPreviewUrl } from "@/hooks/use-blob-preview-url";
 import type { ConvInspeccionItem } from "@/lib/equipos/convencional/db/types";
 
 // ─── Constants ───
@@ -199,16 +200,7 @@ function ImageSlot({
   onRemove: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (evidencia?.blob_local) {
-      const url = URL.createObjectURL(evidencia.blob_local);
-      setPreview(url);
-      return () => URL.revokeObjectURL(url);
-    }
-    setPreview(null);
-  }, [evidencia?.blob_local]);
+  const preview = useBlobPreviewUrl(evidencia?.blob_local);
 
   return (
     <div className="space-y-2">
@@ -261,16 +253,7 @@ function ElementoFotoCell({
   onRemove: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (evidencia?.blob_local) {
-      const url = URL.createObjectURL(evidencia.blob_local);
-      setPreview(url);
-      return () => URL.revokeObjectURL(url);
-    }
-    setPreview(null);
-  }, [evidencia?.blob_local]);
+  const preview = useBlobPreviewUrl(evidencia?.blob_local);
 
   return (
     <>

--- a/src/components/visita-modulos/grupo-b-modulo.tsx
+++ b/src/components/visita-modulos/grupo-b-modulo.tsx
@@ -34,6 +34,7 @@ import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
 import { SetupField } from "@/components/visita-modulos/setup-field";
 import { useRowSavedFlash } from "@/hooks/use-row-saved";
+import { useBlobPreviewUrl } from "@/hooks/use-blob-preview-url";
 
 // ─── Constants ───
 
@@ -264,16 +265,7 @@ function ImageSlot({
   onRemove: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (evidencia?.blob_local) {
-      const url = URL.createObjectURL(evidencia.blob_local);
-      setPreview(url);
-      return () => URL.revokeObjectURL(url);
-    }
-    setPreview(null);
-  }, [evidencia?.blob_local]);
+  const preview = useBlobPreviewUrl(evidencia?.blob_local);
 
   return (
     <div className="space-y-2">

--- a/src/components/visita-modulos/grupo-c-modulo.tsx
+++ b/src/components/visita-modulos/grupo-c-modulo.tsx
@@ -29,6 +29,7 @@ import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
 import { SetupField } from "@/components/visita-modulos/setup-field";
 import { useRowSavedFlash } from "@/hooks/use-row-saved";
+import { useBlobPreviewUrl } from "@/hooks/use-blob-preview-url";
 
 // ─── Constants ───
 
@@ -186,16 +187,7 @@ function ImageSlot({
   onRemove: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (evidencia?.blob_local) {
-      const url = URL.createObjectURL(evidencia.blob_local);
-      setPreview(url);
-      return () => URL.revokeObjectURL(url);
-    }
-    setPreview(null);
-  }, [evidencia?.blob_local]);
+  const preview = useBlobPreviewUrl(evidencia?.blob_local);
 
   return (
     <div className="space-y-2">

--- a/src/components/visita-modulos/grupo-d-modulo.tsx
+++ b/src/components/visita-modulos/grupo-d-modulo.tsx
@@ -29,6 +29,7 @@ import { irAModulo } from "@/lib/modulo-nav";
 import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
 import { useRowSavedFlash } from "@/hooks/use-row-saved";
+import { useBlobPreviewUrl } from "@/hooks/use-blob-preview-url";
 
 // ─── Helpers ───
 
@@ -142,16 +143,7 @@ function ImageSlot({
   onRemove: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (evidencia?.blob_local) {
-      const url = URL.createObjectURL(evidencia.blob_local);
-      setPreview(url);
-      return () => URL.revokeObjectURL(url);
-    }
-    setPreview(null);
-  }, [evidencia?.blob_local]);
+  const preview = useBlobPreviewUrl(evidencia?.blob_local);
 
   return (
     <div className="space-y-2">
@@ -340,13 +332,15 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
   const [savedEiBase, setSavedEiBase] = useState(false);
   const [savedDiBase, setSavedDiBase] = useState(false);
 
-  // Initialize base values from DB record once data loads
-  useEffect(() => {
-    const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
+  // Inicializar los valores base desde el registro de DB una sola vez, cuando
+  // `data` ya cargó: ajuste de estado en render (guardado, no en efecto).
+  const [baseInit, setBaseInit] = useState(false);
+  if (!baseInit && data?.ddiMediciones.length) {
+    const t1 = data.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
+    setBaseInit(true);
     if (t1?.ei_base != null) setBaseEi29(String(t1.ei_base));
     if (t1?.di_base != null) setBaseDi29(String(t1.di_base));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [(data?.ddiMediciones.length ?? 0) > 0]);
+  }
 
   // ─── Save helpers ───
   async function updateDdi(id: string, fields: Record<string, unknown>) {

--- a/src/components/visita-modulos/grupo-e-modulo.tsx
+++ b/src/components/visita-modulos/grupo-e-modulo.tsx
@@ -30,6 +30,7 @@ import { ManualDrawer } from "@/components/manual-drawer";
 import { getManualGrupo } from "@/lib/equipos/convencional/manual";
 import { SetupField } from "@/components/visita-modulos/setup-field";
 import { useRowSavedFlash } from "@/hooks/use-row-saved";
+import { useBlobPreviewUrl } from "@/hooks/use-blob-preview-url";
 
 // ─── Helpers ───
 
@@ -125,16 +126,7 @@ function ImageSlot({
   onRemove: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (evidencia?.blob_local) {
-      const url = URL.createObjectURL(evidencia.blob_local);
-      setPreview(url);
-      return () => URL.revokeObjectURL(url);
-    }
-    setPreview(null);
-  }, [evidencia?.blob_local]);
+  const preview = useBlobPreviewUrl(evidencia?.blob_local);
 
   return (
     <div className="space-y-2">

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef } from "react";
 import { randomUUID } from "@/lib/uuid";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
@@ -66,12 +66,16 @@ function EditableField({
   type?: "text" | "number" | "date";
 }) {
   const [local, setLocal] = useState(value);
+  const [prevValue, setPrevValue] = useState(value);
   const [saved, setSaved] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  useEffect(() => {
+  // Sincronizar `local` cuando el valor externo cambia (guardado remoto,
+  // sync entre dispositivos): ajuste de estado en render, no en efecto.
+  if (value !== prevValue) {
+    setPrevValue(value);
     setLocal(value);
-  }, [value]);
+  }
 
   const handleChange = useCallback(
     (v: string) => {
@@ -161,12 +165,16 @@ function EditableTextArea({
   placeholder?: string;
 }) {
   const [local, setLocal] = useState(value);
+  const [prevValue, setPrevValue] = useState(value);
   const [saved, setSaved] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  useEffect(() => {
+  // Sincronizar `local` cuando el valor externo cambia (guardado remoto,
+  // sync entre dispositivos): ajuste de estado en render, no en efecto.
+  if (value !== prevValue) {
+    setPrevValue(value);
     setLocal(value);
-  }, [value]);
+  }
 
   const handleChange = useCallback(
     (v: string) => {

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+
+// ============================================================
+//  Smoke tests de los 7 módulos de captura de visita.
+//
+//  No verifican el detalle de cada tabla — eso es Tier 3/4. Verifican el
+//  CONTRATO común de los 3 estados de render:
+//    - useDb no listo / data indefinida -> "Cargando…"
+//    - data === null (visita inexistente) -> "Visita no encontrada"
+//    - visita sembrada -> render completo sin throw ("Volver al workspace")
+//
+//  Con esta red, la re-escalada de `react-hooks/set-state-in-effect` a
+//  "error" para src/components/visita-modulos/** deja de ser riesgosa.
+// ============================================================
+
+const useDb = vi.fn();
+vi.mock("@/components/db-provider", () => ({ useDb: () => useDb() }));
+vi.mock("@/components/role-provider", () => ({
+  useRole: () => ({ role: "tecnico", cargo: "tecnico", usuarioId: "u1", nombre: "Tec" }),
+}));
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  pushSingle: vi.fn(),
+  updateAndSync: vi.fn().mockResolvedValue(undefined),
+  deleteAndSync: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { GrupoAModulo } from "./grupo-a-modulo";
+import { GrupoBModulo } from "./grupo-b-modulo";
+import { GrupoCModulo } from "./grupo-c-modulo";
+import { GrupoDModulo } from "./grupo-d-modulo";
+import { GrupoEModulo } from "./grupo-e-modulo";
+import { InfoModulo } from "./info-modulo";
+import { PreInformeModulo } from "./pre-informe-modulo";
+
+const MODULOS: Array<[string, ComponentType<{ visitaId: string }>]> = [
+  ["InfoModulo", InfoModulo],
+  ["GrupoAModulo", GrupoAModulo],
+  ["GrupoBModulo", GrupoBModulo],
+  ["GrupoCModulo", GrupoCModulo],
+  ["GrupoDModulo", GrupoDModulo],
+  ["GrupoEModulo", GrupoEModulo],
+  ["PreInformeModulo", PreInformeModulo],
+];
+
+describe("visita-modulos — smoke", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+  });
+
+  afterEach(() => cleanup());
+
+  describe.each(MODULOS)("%s", (_name, Modulo) => {
+    it("muestra 'Cargando' mientras la DB no está lista", () => {
+      useDb.mockReturnValue({ isReady: false });
+      render(<Modulo visitaId="v-cualquiera" />);
+      expect(screen.getByText(/Cargando/i)).toBeInTheDocument();
+    });
+
+    it("muestra 'Visita no encontrada' si el id no existe", async () => {
+      render(<Modulo visitaId="v-inexistente" />);
+      expect(await screen.findByText(/Visita no encontrada/i)).toBeInTheDocument();
+    });
+
+    it("renderiza el módulo completo con una visita sembrada, sin throw", async () => {
+      const { visita } = await seedGraph();
+      render(<Modulo visitaId={visita!.id!} />);
+      expect(await screen.findByText(/Volver al workspace/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/hooks/use-blob-preview-url.ts
+++ b/src/hooks/use-blob-preview-url.ts
@@ -1,0 +1,22 @@
+import { useEffect, useMemo } from "react";
+
+/**
+ * Deriva un object-URL de un `Blob` para previsualizar evidencias
+ * fotográficas, y lo revoca cuando el blob cambia o el componente se
+ * desmonta.
+ *
+ * Reemplaza el patrón `useState + useEffect(setPreview(...))` que se
+ * repetía en los 5 módulos de grupo (A–E): ese patrón dispara
+ * `react-hooks/set-state-in-effect`. Acá el URL se calcula en render con
+ * `useMemo` (sin `setState`) y el efecto solo hace la limpieza.
+ */
+export function useBlobPreviewUrl(blob: Blob | null | undefined): string | null {
+  const url = useMemo(() => (blob ? URL.createObjectURL(blob) : null), [blob]);
+
+  useEffect(() => {
+    if (!url) return;
+    return () => URL.revokeObjectURL(url);
+  }, [url]);
+
+  return url;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,6 +68,15 @@ export default defineConfig({
         "src/hooks/use-reseed-on-open.ts": { lines: 100, functions: 100, branches: 90 },
         "src/components/state-timeline.tsx": { lines: 88, functions: 100, branches: 75 },
         "src/components/visita-modulos/setup-field.tsx": { lines: 90, functions: 80, branches: 70 },
+        // Tier 6 parte 2 — Módulo 16 (visita-modulos) + Módulo 18 restante.
+        // Los módulos de captura tienen SMOKE tests (3 estados de render por
+        // módulo): red suficiente para re-escalar `set-state-in-effect` a
+        // "error" en esa ruta. La cobertura profunda de cada tabla queda para
+        // Tier 3/4 cuando se recree el flujo completo. Floors = piso actual.
+        "src/hooks/use-blob-preview-url.ts": { lines: 78, functions: 70, branches: 45 },
+        "src/components/manual-drawer.tsx": { lines: 92, functions: 75, branches: 88 },
+        "src/components/visit-action-bar.tsx": { lines: 85, functions: 85, branches: 72 },
+        "src/components/visita-modulos/**": { lines: 33, functions: 15, branches: 16 },
       },
     },
   },


### PR DESCRIPTION
## Contexto

Tier 6, **parte 2 de 2** (la parte 1, form-dialogs, es #54 ya mergeado). Cubre el Módulo 16 (`src/components/visita-modulos/*`) y las piezas restantes del Módulo 18 (`visit-action-bar`, `manual-drawer`).

Alcance: **red de smoke tests + saldar la deuda de `react-hooks/set-state-in-effect`** en esa ruta. La cobertura profunda celda-por-celda de cada módulo de grupo se difiere a Tier 3/4 (cuando se recree el flujo completo desde la app) — son 7 archivos de 900–1250 líneas cada uno.

## Red de tests (36 nuevos)

| Archivo | Tests |
|---|---|
| `visita-modulos/modulos-smoke.test.tsx` | 21 — para los 7 módulos (`Info`, `GrupoA`–`GrupoE`, `PreInforme`): estado "Cargando", "Visita no encontrada", y render completo con visita sembrada sin throw. DB real (`fake-indexeddb`) + `seedGraph`. |
| `manual-drawer.test.tsx` | 7 — no monta con `open=false`/sin pruebas, muestra la primera prueba, abre en `pruebaCodigo`, cambia de tab, cierra con Escape y con la X. |
| `visit-action-bar.test.tsx` | 8 — sin rol → nada; acciones correctas por `(estado, cargo)`; rol sin transiciones → nada; gate de completitud bloquea `Enviar a Revisión`; gate OK → `executeTransition` + `onTransition`; `requiereRazon` pide motivo antes de ejecutar; estados terminales. |

## `set-state-in-effect` → "error" en la ruta

`eslint.config.mjs`: la regla vuelve a `"error"` para `src/components/visita-modulos/**` y `manual-drawer.tsx`. Correcciones para llegar a 0 violaciones:

- **`src/hooks/use-blob-preview-url.ts`** (nuevo) — `useMemo` para crear el object-URL + efecto solo-cleanup. Reemplaza el patrón `useState + useEffect(setPreview(...))` repetido **6 veces** en los 5 módulos de grupo (previsualización de evidencias).
- **`info-modulo.tsx`** — `EditableField`/`EditableTextArea`: el `useEffect(() => setLocal(value), [value])` pasa a ajuste de estado en render con `prevValue` de control (patrón de React docs).
- **`grupo-d-modulo.tsx`** — init de valores base 2.9 desde DB pasa a ajuste en render guardado por flag; se elimina el `eslint-disable exhaustive-deps` que lo acompañaba.
- **`manual-drawer.tsx`** — sync de índice por `pruebaCodigo` pasa a ajuste en render (una vez por combinación código × pruebas cargadas). La animación de entrada conserva **1 `eslint-disable` inline justificado**: `visible` controla el montaje y debe sobrevivir a `open=false` durante los 250 ms de salida.

## Cobertura

Thresholds por archivo (piso = valor actual) + glob para `visita-modulos/**` en `vitest.config.ts`. `manual-drawer` 95 % líneas, `visit-action-bar` 88 %, módulos de grupo 33–62 % (smoke).

## Verificación

`npm run verify` limpio: typecheck, lint (0 errores), format, **487 tests**, build.

## Doc

`docs/modules/10-ui-visita-modulos.md` — 10 secciones + log de decisiones.

## Con esto cierra Tier 6

Pendiente global (fuera de tiers, ya trackeado): matriz de escenarios manual de los módulos de grupo → Tier 3/4.
