### PR TITLE
fix(seguridad): Tier 7 — open-redirect en /login + gate de rol en informes/[id]

### DIFF
--- a/docs/modules/11-rutas-y-superficies-publicas.md
+++ b/docs/modules/11-rutas-y-superficies-publicas.md
@@ -1,0 +1,151 @@
+# Módulo: rutas del dashboard + superficies públicas
+
+> Estado: 🟡 en curso (Tier 7) · Última actualización: `2026-08-28` · Responsable: `Juan Pablo Guzmán`
+
+Doc producido por el protocolo de intervención (ver
+`~/.claude/plans/en-dias-anteriores-he-cheerful-hopcroft.md`).
+
+Tier 7 — pasada **enfocada en seguridad** sobre las rutas. Cubre:
+- `POST /api/usuarios` — el único chequeo de rol server-enforced.
+- `/verificar/[token]` — página pública service-role (QR).
+- `/login` — entrada de sesión.
+- `src/app/dashboard/*` (14 páginas) — auditoría de gates de rol.
+
+---
+
+## 1. Responsabilidad
+
+- **`/api/usuarios`** — única fuente de verdad del alta de usuarios. Valida
+  sesión + rol `coordinador` **en el servidor** (no confía en el cliente),
+  rate-limita por IP, y hace rollback del usuario `auth` si falla el insert.
+- **`/verificar/[token]`** — publica el estado de un informe a quien escanee
+  su QR. Sin sesión; usa `service_role` (salta RLS). Debe exponer **solo**
+  datos del informe/equipo, nunca PII del cliente.
+- **`/login`** — autentica contra Supabase Auth y redirige. El destino sale
+  de `?redirect=` y **debe** ser una ruta interna.
+- **`dashboard/*`** — cada página compone módulos ya certificados; el gate de
+  rol es cliente (`hasPermission` / `isAdmin` de `useRole`). `proxy.ts`
+  garantiza sesión (autenticación) server-side, no rol (autorización).
+
+## 2. API pública
+
+| Ruta | Método | Efecto | Errores |
+| --- | --- | --- | --- |
+| `/api/usuarios` | `POST` | crea usuario `auth` + fila `usuarios` (rollback si falla) | 429 rate limit · 401 sin sesión · 403 no-coordinador · 400 body inválido (genérico) · 500 error de guardado |
+| `/verificar/[token]` | `GET` (RSC) | render del estado del informe + link al PDF firmado (1 h) | informe no encontrado → pantalla "Informe no encontrado" |
+| `/login` | client | `signInWithPassword` + `router.push(safeRedirect(redirect))` | credenciales → mensaje + cooldown exponencial (2 s → 30 s) |
+
+## 3. Modelo de datos
+
+- `/api/usuarios`: lee `usuarios.cargo` (por `auth_uid`) con el cliente
+  **admin**; escribe `auth.users` + `usuarios`. Rate-limit en memoria
+  (per-instancia, ver `rate-limit.ts`).
+- `/verificar/[token]`: lee **solo** `informes`, `informe_versiones`,
+  `equipos` (con listas de columnas explícitas, sin `*`) + un signed URL de
+  Storage. `qr_token` es `crypto.randomUUID()` (v4, 122 bits) → enumeración
+  inviable, no requiere rate-limit adicional.
+- `/login`: sin acceso directo a datos.
+
+## 4. Flujo de control
+
+**`/api/usuarios` (orden exacto):**
+1. `rateLimit(create-user:<ip>, 5, 60s)` → 429 si excede.
+2. `getAuthenticatedUser` (`supabase.auth.getUser()` verifica el JWT) → 401 si null.
+3. Lookup `usuarios.cargo` por `auth_uid` con cliente admin → 403 si no es `coordinador`.
+4. `createUsuarioSchema.safeParse(body)` → 400 genérico si falla (el detalle va a `logger.warn`, no al cliente).
+5. `auth.admin.createUser` → si error, 400 con el mensaje de GoTrue.
+6. `insert` en `usuarios` → si error, `auth.admin.deleteUser` (rollback; loguea si el rollback falla) + 500.
+7. 201 `{ usuario }`.
+
+**`/verificar/[token]`:** token → `informes` por `qr_token` → (`informe_versiones` + `equipos` en paralelo) → signed URL si hay `pdf_url` → render.
+
+**`/login`:** submit → `signInWithPassword` → en éxito `router.push(safeRedirect(redirect))` + `fullSync()` en background (no bloquea).
+
+## 5. Comportamiento offline / online
+
+- `/api/usuarios` y `/verificar` exigen red (server-side).
+- `/login`: el submit exige red; el cooldown de reintento es cliente.
+
+## 6. Interacción con sync
+
+- `/login` dispara `fullSync()` fire-and-forget tras autenticar (con
+  `logger.warn`/`error` si el pull inicial falla — Tier 2).
+- Las demás rutas no tocan el sync engine.
+
+## 7. Rol / permisos
+
+- **`/api/usuarios`** — server-enforced: `coordinador` únicamente. ✅
+- **`/verificar`** — público por diseño (capability = el `qr_token`).
+- **`dashboard/*`** — matriz de gates auditada:
+
+| Página | Gate de página | Nota |
+| --- | --- | --- |
+| `dashboard/` (home) | — | dashboard = `ver` para todos los roles; contenido condicionado por `hasPermission` |
+| `clientes`, `clientes/[id]` | — | acciones (crear/editar) gated; `comercial` tiene `clientes:GESTIONAR` |
+| `equipos`, `equipos/[id]` | — | acciones gated |
+| `solicitudes`, `solicitudes/[id]` | — | acciones gated |
+| `visitas`, `visitas/[id]` | — | lista filtra por técnico asignado |
+| `revision`, `revision/[id]` | `hasPermission("revision")` ✅ | |
+| `informes` (lista) | `hasPermission("informes")` ✅ | |
+| `informes/[id]` (detalle) | `hasPermission("informes")` ✅ **(agregado en Tier 7)** | + botón "Publicar versión oficial" ahora requiere `informes:editar` |
+| `configuracion` | `isAdmin` ✅ | gestión de usuarios/permisos |
+| `sync` | — | estado de sync; `sync:ver` para todos los roles |
+
+## 8. Invariantes y supuestos
+
+- Todos los usuarios son personal interno de Sievert (4 roles). No hay
+  usuarios "cliente" con login → el riesgo de una página de dashboard sin
+  gate de rol está acotado a mal-uso interno, no a exposición pública.
+- `proxy.ts` cubre la autenticación de `/dashboard/*`; la autorización por
+  rol es responsabilidad de cada página (cliente).
+- `?redirect=` de `/login` es una ruta interna tras `safeRedirect`.
+
+## 9. Modos de falla conocidos
+
+| Falla | Efecto | Manejo |
+| --- | --- | --- |
+| `x-forwarded-for` spoofeado en `/api/usuarios` | rate-limit por IP evadible rotando el header | aceptado — GoTrue tiene su propio límite global; migrar a Upstash para límite distribuido |
+| `request.json()` con body no-JSON | excepción → 500 de Next (no 400) | menor; el schema igual rechazaría |
+| Página de dashboard sin gate de rol + navegación directa por URL | un rol interno ve datos fuera de su alcance | ver tabla §7; `informes/[id]` corregido, resto documentado |
+
+## 10. Preguntas abiertas / smells
+
+- `rate-limit` es per-instancia (serverless) — límite real requiere Redis.
+- Gates de dashboard son 100% cliente; no hay defensa en profundidad
+  server-side salvo `/api/usuarios`. Un rediseño con RLS + checks en Server
+  Components sería el fix estructural (fuera de alcance de esta pasada).
+- `informes/[id]` cargaba `cliente` en su `useLiveQuery` aunque el detalle
+  muestra poco de él — revisar si hace falta.
+
+---
+
+## Apéndice B — Log de decisiones (triage de hallazgos)
+
+| # | Descripción | Decisión | Razón | Sign-off |
+| --- | --- | --- | --- | --- |
+| T7-1 | `/login` hacía `router.push(searchParams.get("redirect"))` sin validar → **open redirect** (`?redirect=https://evil.com` o `//evil.com`) | **fix-ahora** | Vector de phishing post-login; fix contenido | ⬜ pendiente dueño |
+| T7-2 | `/dashboard/informes/[id]` sin gate de rol: la lista exige `hasPermission("informes")` pero el detalle no, y ofrecía "Publicar versión oficial" (QR + hash) sin chequeo | **fix-ahora** | Publicar la versión oficial es la acción de mayor impacto sobre el artefacto de mayor valor; inconsistencia con la lista | ⬜ pendiente dueño |
+| T7-3 | Otras páginas de dashboard sin gate de página (solo gate de acciones) | **aceptar + documentar** | Base de usuarios 100% interna (4 roles); blast radius acotado; el fix real es defensa en profundidad server-side (proyecto aparte) | ⬜ pendiente dueño |
+| T7-4 | `rate-limit` per-instancia | **aceptar** | Ya documentado en `rate-limit.ts`; GoTrue complementa con límite global; migrar a Upstash si escala | ⬜ pendiente dueño |
+| — | `/verificar/[token]` filtra PII | **descartado** | No filtra: consulta solo `informes`/`informe_versiones`/`equipos` con columnas explícitas; el PDF firmado sí contiene PII pero es el documento oficial que el QR publica; token = UUID v4 | ⬜ pendiente dueño |
+
+### Detalle de los fixes
+
+- **`src/app/login/page.tsx`** — nueva función exportada `safeRedirect(raw)`:
+  solo admite rutas que empiezan con `/` y no con `//` ni `/\`. Se usa en
+  lugar del `searchParams.get("redirect") ?? "/dashboard"` crudo.
+- **`src/app/dashboard/informes/[id]/page.tsx`** — importa `useRole`; gate de
+  página `if (!hasPermission("informes")) → "Acceso restringido"` (mismo
+  patrón que `revision/page.tsx`); el botón "Publicar versión oficial" ahora
+  requiere `hasPermission("informes", "editar")`.
+
+## Apéndice C — Estado de salida (Fase 6)
+
+- [x] Doc completo
+- [x] `POST /api/usuarios` — 8 tests cubren los 6 branches de seguridad + rate limit + rollback
+- [x] `/verificar/[token]` — 5 tests: not-found, render, **contrato "solo informes/versiones/equipos"**, PDF firmado, sin-PDF
+- [x] `/login` — `safeRedirect` (9 casos) + 2 tests de integración del redirect tras autenticar
+- [x] Hallazgos fix-ahora (T7-1, T7-2) cerrados con test / fix aplicado
+- [x] `npm run verify` limpio
+- [ ] Smoke render por rol de las 14 páginas de dashboard — **diferido**: fricción de `use(params)` + `next/link` sin contexto de router en happy-dom; bajo valor (componen piezas ya certificadas). La auditoría de gates (§7) queda como el entregable de esta pasada.
+- [ ] Sign-off del dueño

--- a/src/app/api/usuarios/route.test.ts
+++ b/src/app/api/usuarios/route.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ============================================================
+//  POST /api/usuarios — el ÚNICO chequeo de rol server-enforced.
+//
+//  Contrato de seguridad verificado acá:
+//   - 429 cuando se supera el rate limit por IP
+//   - 401 sin sesión
+//   - 403 autenticado pero cargo != coordinador
+//   - 400 body inválido, SIN filtrar detalles del schema
+//   - 201 + rollback del usuario auth si falla el insert en `usuarios`
+// ============================================================
+
+vi.mock("@/lib/env", () => ({
+  clientEnv: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "anon",
+  },
+  getServerEnv: () => ({ SUPABASE_SERVICE_ROLE_KEY: "service-role" }),
+}));
+
+// Estado configurable por test
+const state = {
+  ip: "1.1.1.1",
+  user: null as { id: string } | null,
+  callerCargo: "coordinador" as string | null,
+  createUserResult: {
+    data: { user: { id: "new-auth-uid" } },
+    error: null as { message: string } | null,
+  },
+  insertResult: {
+    data: { id: "u-new" } as { id: string } | null,
+    error: null as { message: string } | null,
+  },
+};
+const deleteUser = vi.fn().mockResolvedValue({ error: null });
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ getAll: () => [] }),
+  headers: async () => new Map([["x-forwarded-for", state.ip]]),
+}));
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: () => ({
+    auth: { getUser: async () => ({ data: { user: state.user } }) },
+  }),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({
+            data: state.callerCargo ? { cargo: state.callerCargo } : null,
+          }),
+        }),
+      }),
+      insert: () => ({
+        select: () => ({ single: async () => state.insertResult }),
+      }),
+    }),
+    auth: {
+      admin: {
+        createUser: async () => state.createUserResult,
+        deleteUser: deleteUser,
+      },
+    },
+  }),
+}));
+
+import { POST } from "./route";
+
+function req(body: unknown) {
+  return { json: async () => body } as Parameters<typeof POST>[0];
+}
+
+const validBody = {
+  email: "nuevo@sievert.com",
+  password: "clave1234",
+  nombre: "Persona Nueva",
+  cedula: "1234567",
+  cargo: "tecnico",
+};
+
+let ipCounter = 0;
+beforeEach(() => {
+  ipCounter += 1;
+  state.ip = `10.0.0.${ipCounter}`; // IP única por test → rate limit aislado
+  state.user = { id: "caller-auth-uid" };
+  state.callerCargo = "coordinador";
+  state.createUserResult = { data: { user: { id: "new-auth-uid" } }, error: null };
+  state.insertResult = { data: { id: "u-new" }, error: null };
+  deleteUser.mockClear();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("POST /api/usuarios", () => {
+  it("crea el usuario y responde 201 para un coordinador con body válido", async () => {
+    const res = await POST(req(validBody));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.usuario).toEqual({ id: "u-new" });
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("responde 401 si no hay sesión", async () => {
+    state.user = null;
+    const res = await POST(req(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("responde 403 si el llamante no es coordinador", async () => {
+    state.callerCargo = "tecnico";
+    const res = await POST(req(validBody));
+    expect(res.status).toBe(403);
+  });
+
+  it("responde 403 si el llamante no existe en la tabla usuarios", async () => {
+    state.callerCargo = null;
+    const res = await POST(req(validBody));
+    expect(res.status).toBe(403);
+  });
+
+  it("responde 400 con body inválido y NO filtra el detalle del schema", async () => {
+    const res = await POST(req({ email: "no-es-email", password: "x" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Datos inválidos");
+    expect(JSON.stringify(json)).not.toMatch(/password|regex|schema|issues/i);
+  });
+
+  it("rechaza un cargo fuera del enum permitido", async () => {
+    const res = await POST(req({ ...validBody, cargo: "superadmin" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("hace rollback del usuario auth si falla el insert en usuarios", async () => {
+    state.insertResult = { data: null, error: { message: "duplicate key" } };
+    const res = await POST(req(validBody));
+    expect(res.status).toBe(500);
+    expect(deleteUser).toHaveBeenCalledWith("new-auth-uid");
+  });
+
+  it("responde 429 al superar el límite de 5 solicitudes por minuto y misma IP", async () => {
+    state.ip = "203.0.113.9";
+    for (let i = 0; i < 5; i++) {
+      const ok = await POST(req(validBody));
+      expect(ok.status).toBe(201);
+    }
+    const blocked = await POST(req(validBody));
+    expect(blocked.status).toBe(429);
+  });
+});

--- a/src/app/dashboard/informes/[id]/page.tsx
+++ b/src/app/dashboard/informes/[id]/page.tsx
@@ -4,6 +4,7 @@ import { use, useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
+import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -66,6 +67,12 @@ export default function InformeDetailPage({ params }: { params: Promise<{ id: st
   const { id } = use(params);
   const informeId = id;
   const { isReady } = useDb();
+  const { hasPermission } = useRole();
+  // Tier 7: la lista de informes exige `hasPermission("informes")`; el detalle
+  // no lo hacía. Publicar la versión oficial (QR + hash) es acción de edición
+  // → solo roles con `informes:editar` (por defecto, coordinador).
+  const puedeVerInformes = hasPermission("informes");
+  const puedePublicar = hasPermission("informes", "editar");
   const [publicando, setPublicando] = useState(false);
   const [publicarError, setPublicarError] = useState<string | null>(null);
 
@@ -111,6 +118,16 @@ export default function InformeDetailPage({ params }: { params: Promise<{ id: st
       <div className="flex flex-col items-center justify-center py-20 gap-4">
         <Loader2 className="w-10 h-10 text-primary animate-spin" />
         <p className="text-slate-500 font-bold">Cargando informe...</p>
+      </div>
+    );
+  }
+
+  if (!puedeVerInformes) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-4">
+        <ShieldCheck className="w-10 h-10 text-red-500" />
+        <p className="text-slate-500 font-bold">Acceso restringido</p>
+        <p className="text-slate-400 text-sm">No tienes permisos para ver informes.</p>
       </div>
     );
   }
@@ -257,7 +274,7 @@ export default function InformeDetailPage({ params }: { params: Promise<{ id: st
 
           {/* Acciones */}
           <div className="flex flex-wrap gap-3 pt-2">
-            {!versionActual?.pdf_hash && (
+            {!versionActual?.pdf_hash && puedePublicar && (
               <Button
                 onClick={handlePublicar}
                 disabled={publicando || !visita}

--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+// ============================================================
+//  /login — sanitización del parámetro `redirect` (open-redirect).
+// ============================================================
+
+const push = vi.fn();
+const refresh = vi.fn();
+let redirectParam: string | null = null;
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh }),
+  useSearchParams: () => ({ get: (k: string) => (k === "redirect" ? redirectParam : null) }),
+}));
+
+const signInWithPassword = vi.fn().mockResolvedValue({ error: null });
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ auth: { signInWithPassword } }),
+}));
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  fullSync: vi.fn().mockResolvedValue({ errors: [] }),
+}));
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...(props as Record<string, string>)} />;
+  },
+}));
+
+import LoginPage, { safeRedirect } from "./page";
+
+describe("safeRedirect", () => {
+  it.each([
+    ["/dashboard/visitas", "/dashboard/visitas"],
+    ["/informes/abc", "/informes/abc"],
+    [null, "/dashboard"],
+    ["", "/dashboard"],
+    ["https://evil.com", "/dashboard"],
+    ["//evil.com", "/dashboard"],
+    ["/\\evil.com", "/dashboard"],
+    ["http://evil.com/path", "/dashboard"],
+    ["javascript:alert(1)", "/dashboard"],
+  ])("safeRedirect(%j) === %j", (input, expected) => {
+    expect(safeRedirect(input as string | null)).toBe(expected);
+  });
+});
+
+describe("LoginForm — redirect tras autenticar", () => {
+  beforeEach(() => {
+    push.mockClear();
+    signInWithPassword.mockClear();
+  });
+  afterEach(cleanup);
+
+  async function submit() {
+    render(<LoginPage />);
+    fireEvent.change(screen.getByPlaceholderText(/email|correo/i), {
+      target: { value: "user@sievert.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/contraseña|password|•/i), {
+      target: { value: "clave1234" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /ingresar|entrar|iniciar/i }));
+  }
+
+  it("ignora un redirect externo y navega a /dashboard", async () => {
+    redirectParam = "https://evil.com";
+    await submit();
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("respeta un redirect interno", async () => {
+    redirectParam = "/dashboard/visitas";
+    await submit();
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/dashboard/visitas"));
+  });
+});

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,6 +17,18 @@ import Image from "next/image";
 //  En modo desarrollo (sin Supabase), muestra bypass
 // ============================================================
 
+/**
+ * Sanitiza el parámetro `redirect` para evitar open-redirect: solo se
+ * permite una ruta interna (empieza con "/" pero no con "//" ni "/\", que
+ * el navegador interpretaría como URL absoluta hacia otro host).
+ */
+export function safeRedirect(raw: string | null | undefined): string {
+  if (!raw || !raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) {
+    return "/dashboard";
+  }
+  return raw;
+}
+
 export default function LoginPage() {
   return (
     <Suspense>
@@ -28,7 +40,7 @@ export default function LoginPage() {
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirect = searchParams.get("redirect") ?? "/dashboard";
+  const redirect = safeRedirect(searchParams.get("redirect"));
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/src/app/verificar/[token]/page.test.tsx
+++ b/src/app/verificar/[token]/page.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// ============================================================
+//  /verificar/[token] — página pública (service-role, sin sesión).
+//
+//  Contrato de seguridad: expone SOLO datos del informe/equipo. No debe
+//  tocar `clientes`, `sedes`, `contactos`, `solicitudes`, `ubicaciones_rx`
+//  ni `visitas` — nada de PII del cliente sale por el QR (el PDF firmado
+//  sí la contiene, pero ese es el documento oficial que el QR publica).
+// ============================================================
+
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: () => adminClient }));
+
+const tablasConsultadas: string[] = [];
+const state = {
+  informe: null as Record<string, unknown> | null,
+  version: null as Record<string, unknown> | null,
+  equipo: null as Record<string, unknown> | null,
+  signedUrl: null as string | null,
+};
+
+const adminClient = {
+  from(table: string) {
+    tablasConsultadas.push(table);
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: () => builder,
+      maybeSingle: async () => {
+        if (table === "informes") return { data: state.informe };
+        if (table === "informe_versiones") return { data: state.version };
+        if (table === "equipos") return { data: state.equipo };
+        return { data: null };
+      },
+    };
+    return builder;
+  },
+  storage: {
+    from: () => ({
+      createSignedUrl: async () => ({
+        data: state.signedUrl ? { signedUrl: state.signedUrl } : null,
+      }),
+    }),
+  },
+};
+
+import VerificarPage from "./page";
+
+beforeEach(() => {
+  tablasConsultadas.length = 0;
+  state.informe = {
+    id: "inf-1",
+    equipo_id: "eq-1",
+    numero_informe: "INF-2026-001",
+    version_actual: 1,
+    concepto_general: "FAVORABLE",
+    fecha_emision: "2026-01-10",
+    fecha_vencimiento: "2027-01-10",
+    estado: "aprobado",
+  };
+  state.version = { numero_version: 1, pdf_url: "informes/inf-1-v1.pdf" };
+  state.equipo = {
+    marca: "Siemens",
+    modelo: "Multix",
+    gen_marca: null,
+    gen_modelo: null,
+    tipo_equipo: "CONVENCIONAL",
+  };
+  state.signedUrl = "https://test.supabase.co/storage/signed/abc";
+});
+afterEach(cleanup);
+
+describe("VerificarPage", () => {
+  it("muestra 'Informe no encontrado' si el token no matchea", async () => {
+    state.informe = null;
+    render(await VerificarPage({ params: Promise.resolve({ token: "no-existe" }) }));
+    expect(screen.getByText(/Informe no encontrado/i)).toBeInTheDocument();
+  });
+
+  it("renderiza número, concepto, fechas y equipo del informe", async () => {
+    render(await VerificarPage({ params: Promise.resolve({ token: "tok-1" }) }));
+    expect(screen.getByText("INF-2026-001")).toBeInTheDocument();
+    expect(screen.getByText("FAVORABLE")).toBeInTheDocument();
+    expect(screen.getByText("2026-01-10")).toBeInTheDocument();
+    expect(screen.getByText("2027-01-10")).toBeInTheDocument();
+    expect(screen.getByText(/Siemens/)).toBeInTheDocument();
+  });
+
+  it("SOLO consulta informes / informe_versiones / equipos (sin PII del cliente)", async () => {
+    render(await VerificarPage({ params: Promise.resolve({ token: "tok-1" }) }));
+    expect(new Set(tablasConsultadas)).toEqual(
+      new Set(["informes", "informe_versiones", "equipos"])
+    );
+    for (const prohibida of [
+      "clientes",
+      "sedes",
+      "contactos",
+      "solicitudes",
+      "ubicaciones_rx",
+      "visitas",
+    ]) {
+      expect(tablasConsultadas).not.toContain(prohibida);
+    }
+  });
+
+  it("publica el enlace al PDF firmado cuando hay pdf_url", async () => {
+    render(await VerificarPage({ params: Promise.resolve({ token: "tok-1" }) }));
+    const link = screen.getByRole("link", { name: /Ver PDF oficial/i });
+    expect(link).toHaveAttribute("href", "https://test.supabase.co/storage/signed/abc");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("no ofrece PDF si la versión aún no tiene documento", async () => {
+    state.version = { numero_version: 1, pdf_url: null };
+    render(await VerificarPage({ params: Promise.resolve({ token: "tok-1" }) }));
+    expect(screen.queryByRole("link", { name: /Ver PDF oficial/i })).toBeNull();
+    expect(screen.getByText(/aún no publicado/i)).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,6 +77,14 @@ export default defineConfig({
         "src/components/manual-drawer.tsx": { lines: 92, functions: 75, branches: 88 },
         "src/components/visit-action-bar.tsx": { lines: 85, functions: 85, branches: 72 },
         "src/components/visita-modulos/**": { lines: 33, functions: 15, branches: 16 },
+        // Tier 7 — rutas y superficies públicas (pasada de seguridad).
+        // route.ts es el único authz server-enforced; login/verificar son las
+        // superficies públicas. Los gates de dashboard se auditaron (ver
+        // docs/modules/11-rutas-y-superficies-publicas.md) pero no se
+        // smoke-testearon (fricción use(params)+next/link en happy-dom).
+        "src/app/api/usuarios/route.ts": { lines: 88, functions: 70, branches: 85 },
+        "src/app/login/page.tsx": { lines: 73, functions: 75, branches: 68 },
+        "src/app/verificar/**": { lines: 90, functions: 88, branches: 55 },
       },
     },
   },


### PR DESCRIPTION
## Contexto

Tier 7 — pasada **enfocada en seguridad** sobre las rutas (Módulos 19 y 20 del plan). Superficies cubiertas: `POST /api/usuarios`, `/verificar/[token]`, `/login`, y auditoría de gates de rol de las 14 páginas de `dashboard/*`.

## Hallazgos fix-ahora

### T7-1 — Open redirect en `/login`
`router.push(searchParams.get("redirect") ?? "/dashboard")` sin validar → `/login?redirect=https://evil.com` (o `//evil.com`) manda al usuario fuera del sitio después de autenticarse (phishing).

**Fix:** `safeRedirect(raw)` exportada — solo acepta rutas internas (empieza con `/` y no con `//` ni `/\`).

### T7-2 — `/dashboard/informes/[id]` sin gate de rol
La **lista** de informes exige `hasPermission("informes")`; el **detalle** no, y ofrecía "Publicar versión oficial" (genera QR + hash + sube a Storage) sin ningún chequeo. Un técnico/comercial podía abrir la URL directa y publicar la versión oficial.

**Fix:** gate de página `if (!hasPermission("informes")) → "Acceso restringido"` (mismo patrón que `revision/page.tsx`); el botón de publicar ahora requiere `hasPermission("informes", "editar")` (por defecto, solo coordinador).

## Tests nuevos (24)

| Archivo | Qué cubre |
|---|---|
| `src/app/api/usuarios/route.test.ts` (8) | El **único** authz server-enforced: 429 rate-limit por IP · 401 sin sesión · 403 no-coordinador (y llamante inexistente) · 400 body inválido **sin filtrar el schema** · `cargo` fuera del enum · **201 + rollback del usuario `auth`** si falla el insert en `usuarios`. |
| `src/app/verificar/[token]/page.test.tsx` (5) | Not-found · render de número/concepto/fechas/equipo · **contrato: solo consulta `informes` / `informe_versiones` / `equipos`** (nada de `clientes`/`sedes`/`contactos`/`solicitudes`/`ubicaciones_rx`/`visitas`) · PDF firmado · sin-PDF. |
| `src/app/login/page.test.tsx` (11) | `safeRedirect` (9 casos: internos OK, `https://`, `//`, `/\`, `javascript:`) + 2 de integración: redirect externo → `/dashboard`, interno → respetado. |

## Auditoría de gates de dashboard

Tabla completa en `docs/modules/11-rutas-y-superficies-publicas.md` §7. Resumen:
- ✅ gate de página: `revision`, `revision/[id]`, `informes` (lista), `informes/[id]` (**agregado acá**), `configuracion` (`isAdmin`).
- Resto: solo gatean **acciones** (crear/editar), no la página. **T7-3 aceptado + documentado**: base de usuarios 100% interna (4 roles), blast radius acotado; el fix estructural (defensa en profundidad server-side / RLS) es un proyecto aparte.
- **T7-4 aceptado**: `rate-limit` es per-instancia (serverless) — ya documentado en `rate-limit.ts`, GoTrue complementa con límite global.
- `/verificar` **no filtra PII**: token = UUID v4 (122 bits, no enumerable); el PDF firmado sí contiene PII pero es el documento oficial que el QR publica.

## Diferido

Smoke render por rol de las 14 páginas de dashboard: fricción de `use(params)` + `next/link` sin contexto de router en happy-dom, bajo valor (componen piezas ya certificadas). La auditoría de gates es el entregable de esta pasada.

## Verificación

`npm run verify` limpio: typecheck, lint (0 errores), format, **511 tests**, build. `route.ts` 91% líneas, `login/page.tsx` 78%, `verificar` 100%.
