### PR TITLE
fix(sync): Paquete A1 — blobs en el pull + deleted_at en el PDF + migración RLS (#51, #59, #67 parcial)

### DIFF
--- a/src/lib/equipos/convencional/evaluacion.ts
+++ b/src/lib/equipos/convencional/evaluacion.ts
@@ -498,7 +498,14 @@ export function evaluarConceptoPrueba(codigo: string, d: DatosEvalConv): Concept
 }
 
 /** Carga todas las tablas conv_* necesarias para evaluar (sin fotos). */
+/** Excluye filas soft-deleted. Aplica a TODA lectura conv_* (#51). */
+const vivo = (r: { deleted_at?: string | null }): boolean => !r.deleted_at;
+
 export async function cargarTablasConv(visitaId: string): Promise<DatosEvalConv> {
+  // #51: el filtro de `deleted_at` estaba solo en 5 de las 15 lecturas — una
+  // medición borrada de RaySafe/CAE/DDI o un ítem de inspección borrado
+  // seguía alimentando la evaluación de conformidad y el PDF. Ahora se filtra
+  // en TODAS (tanto `.toArray()` como `.first()`).
   const [
     mediciones,
     inspeccion,
@@ -516,41 +523,21 @@ export async function cargarTablasConv(visitaId: string): Promise<DatosEvalConv>
     caeSetup,
     caeMediciones,
   ] = await Promise.all([
-    db.conv_mediciones
-      .where("visita_id")
-      .equals(visitaId)
-      .filter((r) => !r.deleted_at)
-      .toArray(),
-    db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray(),
-    db.conv_elementos_proteccion
-      .where("visita_id")
-      .equals(visitaId)
-      .filter((r) => !r.deleted_at)
-      .toArray(),
-    db.conv_colimacion.where("visita_id").equals(visitaId).first(),
-    db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
-    db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).toArray(),
-    db.conv_ddi_mediciones.where("visita_id").equals(visitaId).toArray(),
-    db.conv_uniformidad_detector
-      .where("visita_id")
-      .equals(visitaId)
-      .filter((r) => !r.deleted_at)
-      .toArray(),
-    db.conv_resolucion.where("visita_id").equals(visitaId).first(),
-    db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
-    db.conv_cassette_inspeccion
-      .where("visita_id")
-      .equals(visitaId)
-      .filter((r) => !r.deleted_at)
-      .toArray(),
-    db.conv_uniformidad_cr
-      .where("visita_id")
-      .equals(visitaId)
-      .filter((r) => !r.deleted_at)
-      .toArray(),
-    db.conv_mtf.where("visita_id").equals(visitaId).first(),
-    db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
-    db.conv_cae_mediciones.where("visita_id").equals(visitaId).toArray(),
+    db.conv_mediciones.where("visita_id").equals(visitaId).filter(vivo).toArray(),
+    db.conv_inspeccion_items.where("visita_id").equals(visitaId).filter(vivo).toArray(),
+    db.conv_elementos_proteccion.where("visita_id").equals(visitaId).filter(vivo).toArray(),
+    db.conv_colimacion.where("visita_id").equals(visitaId).filter(vivo).first(),
+    db.conv_raysafe_setup.where("visita_id").equals(visitaId).filter(vivo).first(),
+    db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).filter(vivo).toArray(),
+    db.conv_ddi_mediciones.where("visita_id").equals(visitaId).filter(vivo).toArray(),
+    db.conv_uniformidad_detector.where("visita_id").equals(visitaId).filter(vivo).toArray(),
+    db.conv_resolucion.where("visita_id").equals(visitaId).filter(vivo).first(),
+    db.conv_bajo_contraste.where("visita_id").equals(visitaId).filter(vivo).first(),
+    db.conv_cassette_inspeccion.where("visita_id").equals(visitaId).filter(vivo).toArray(),
+    db.conv_uniformidad_cr.where("visita_id").equals(visitaId).filter(vivo).toArray(),
+    db.conv_mtf.where("visita_id").equals(visitaId).filter(vivo).first(),
+    db.conv_cae_setup.where("visita_id").equals(visitaId).filter(vivo).first(),
+    db.conv_cae_mediciones.where("visita_id").equals(visitaId).filter(vivo).toArray(),
   ]);
 
   return {

--- a/src/lib/pdf/secciones-convencional.test.ts
+++ b/src/lib/pdf/secciones-convencional.test.ts
@@ -50,8 +50,8 @@ describe("recopilarDatosConv — carga de tablas", () => {
   });
 });
 
-describe("recopilarDatosConv — filtrado de deleted_at (INCONSISTENTE — finding)", () => {
-  it("conv_mediciones SÍ filtra deleted_at", async () => {
+describe("recopilarDatosConv — filtra deleted_at en TODAS las lecturas conv_* (#51)", () => {
+  it("conv_mediciones filtra deleted_at", async () => {
     await db.conv_mediciones.bulkAdd([
       row({ id: "m1", visita_id: V, punto_numero: 1, ...ok }),
       row({ id: "m2", visita_id: V, punto_numero: 2, ...del }),
@@ -60,23 +60,49 @@ describe("recopilarDatosConv — filtrado de deleted_at (INCONSISTENTE — findi
     expect(d.mediciones.map((m) => m.id)).toEqual(["m1"]);
   });
 
-  it("PIN: conv_raysafe_mediciones NO filtra deleted_at (fila borrada aparece en el PDF)", async () => {
+  it("conv_raysafe_mediciones filtra deleted_at (la fila borrada NO llega al PDF)", async () => {
     await db.conv_raysafe_mediciones.bulkAdd([
       row({ id: "r1", visita_id: V, toma_numero: 1, ...ok }),
       row({ id: "r2", visita_id: V, toma_numero: 2, ...del }),
     ]);
     const d = await recopilarDatosConv(V);
-    // Comportamiento ACTUAL (bug latente): devuelve las 2. → issue #51.
-    expect(d.raysafeMediciones.map((r) => r.id)).toEqual(["r1", "r2"]);
+    expect(d.raysafeMediciones.map((r) => r.id)).toEqual(["r1"]);
   });
 
-  it("PIN: conv_cae_mediciones y conv_ddi_mediciones tampoco filtran deleted_at", async () => {
-    await db.conv_cae_mediciones.add(row({ id: "c1", visita_id: V, toma_numero: 1, ...del }));
-    await db.conv_ddi_mediciones.add(
-      row({ id: "dd1", visita_id: V, grupo: 1, toma_numero: 1, ...del })
-    );
+  it("conv_cae_mediciones y conv_ddi_mediciones filtran deleted_at", async () => {
+    await db.conv_cae_mediciones.bulkAdd([
+      row({ id: "c0", visita_id: V, toma_numero: 0, ...ok }),
+      row({ id: "c1", visita_id: V, toma_numero: 1, ...del }),
+    ]);
+    await db.conv_ddi_mediciones.bulkAdd([
+      row({ id: "dd0", visita_id: V, grupo: 1, toma_numero: 0, ...ok }),
+      row({ id: "dd1", visita_id: V, grupo: 1, toma_numero: 1, ...del }),
+    ]);
     const d = await recopilarDatosConv(V);
-    expect(d.caeMediciones).toHaveLength(1);
-    expect(d.ddiMediciones).toHaveLength(1);
+    expect(d.caeMediciones.map((m) => m.id)).toEqual(["c0"]);
+    expect(d.ddiMediciones.map((m) => m.id)).toEqual(["dd0"]);
+  });
+
+  it("conv_inspeccion_items filtra deleted_at", async () => {
+    await db.conv_inspeccion_items.bulkAdd([
+      row({
+        id: "i1",
+        visita_id: V,
+        seccion: "equipo",
+        item_numero: 1,
+        concepto: "Conforme",
+        ...ok,
+      }),
+      row({
+        id: "i2",
+        visita_id: V,
+        seccion: "equipo",
+        item_numero: 2,
+        concepto: "Conforme",
+        ...del,
+      }),
+    ]);
+    const d = await recopilarDatosConv(V);
+    expect(d.inspeccion.map((i) => i.id)).toEqual(["i1"]);
   });
 });

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -175,6 +175,9 @@ function dedupePorClave<T>(
   return [...porClave.values()];
 }
 
+/** Excluye filas soft-deleted de las lecturas conv_* (#51). */
+const vivoConv = (r: { deleted_at?: string | null }): boolean => !r.deleted_at;
+
 export async function recopilarDatosConv(visitaId: string): Promise<DatosConvencional> {
   const [
     secciones,
@@ -198,48 +201,51 @@ export async function recopilarDatosConv(visitaId: string): Promise<DatosConvenc
     caeMediciones,
   ] = await Promise.all([
     db.conv_informe_secciones.where("visita_id").equals(visitaId).sortBy("orden"),
-    db.conv_levantamiento_setup.where("visita_id").equals(visitaId).first(),
-    db.conv_mediciones
+    // #51: el filtro de `deleted_at` estaba solo en 5 de las 17 lecturas — una
+    // medición borrada de RaySafe/CAE/DDI o un ítem de inspección borrado
+    // seguía saliendo en el PDF oficial. Ahora se filtra en TODAS.
+    db.conv_levantamiento_setup.where("visita_id").equals(visitaId).filter(vivoConv).first(),
+    db.conv_mediciones.where("visita_id").equals(visitaId).filter(vivoConv).sortBy("punto_numero"),
+    db.conv_inspeccion_items.where("visita_id").equals(visitaId).filter(vivoConv).toArray(),
+    db.conv_elementos_proteccion.where("visita_id").equals(visitaId).filter(vivoConv).toArray(),
+    db.conv_resultados_prueba.where("visita_id").equals(visitaId).filter(vivoConv).toArray(),
+    db.conv_evidencias.where("visita_id").equals(visitaId).filter(vivoConv).toArray(),
+    db.conv_colimacion.where("visita_id").equals(visitaId).filter(vivoConv).first(),
+    db.conv_raysafe_setup.where("visita_id").equals(visitaId).filter(vivoConv).first(),
+    db.conv_raysafe_mediciones
       .where("visita_id")
       .equals(visitaId)
-      .filter((r) => !r.deleted_at)
-      .sortBy("punto_numero"),
-    db.conv_inspeccion_items.where("visita_id").equals(visitaId).toArray(),
-    db.conv_elementos_proteccion
+      .filter(vivoConv)
+      .sortBy("toma_numero"),
+    db.conv_ddi_mediciones
       .where("visita_id")
       .equals(visitaId)
-      .filter((r) => !r.deleted_at)
-      .toArray(),
-    db.conv_resultados_prueba.where("visita_id").equals(visitaId).toArray(),
-    db.conv_evidencias
-      .where("visita_id")
-      .equals(visitaId)
-      .filter((r) => !r.deleted_at)
-      .toArray(),
-    db.conv_colimacion.where("visita_id").equals(visitaId).first(),
-    db.conv_raysafe_setup.where("visita_id").equals(visitaId).first(),
-    db.conv_raysafe_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
-    db.conv_ddi_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
+      .filter(vivoConv)
+      .sortBy("toma_numero"),
     db.conv_uniformidad_detector
       .where("visita_id")
       .equals(visitaId)
-      .filter((r) => !r.deleted_at)
+      .filter(vivoConv)
       .sortBy("item_numero"),
-    db.conv_resolucion.where("visita_id").equals(visitaId).first(),
-    db.conv_bajo_contraste.where("visita_id").equals(visitaId).first(),
+    db.conv_resolucion.where("visita_id").equals(visitaId).filter(vivoConv).first(),
+    db.conv_bajo_contraste.where("visita_id").equals(visitaId).filter(vivoConv).first(),
     db.conv_cassette_inspeccion
       .where("visita_id")
       .equals(visitaId)
-      .filter((r) => !r.deleted_at)
+      .filter(vivoConv)
       .sortBy("item_numero"),
     db.conv_uniformidad_cr
       .where("visita_id")
       .equals(visitaId)
-      .filter((r) => !r.deleted_at)
+      .filter(vivoConv)
       .sortBy("item_numero"),
-    db.conv_mtf.where("visita_id").equals(visitaId).first(),
-    db.conv_cae_setup.where("visita_id").equals(visitaId).first(),
-    db.conv_cae_mediciones.where("visita_id").equals(visitaId).sortBy("toma_numero"),
+    db.conv_mtf.where("visita_id").equals(visitaId).filter(vivoConv).first(),
+    db.conv_cae_setup.where("visita_id").equals(visitaId).filter(vivoConv).first(),
+    db.conv_cae_mediciones
+      .where("visita_id")
+      .equals(visitaId)
+      .filter(vivoConv)
+      .sortBy("toma_numero"),
   ]);
 
   // Deduplica ítems de inspección con el mismo (sección, número) — ver

--- a/src/lib/supabase/sync-engine.test.ts
+++ b/src/lib/supabase/sync-engine.test.ts
@@ -624,6 +624,74 @@ describe("sync-engine — pullSyncTable borra localmente cuando el remoto trae d
 });
 
 // ============================================================
+//  #67 — el pull NO debe borrar el blob local de una evidencia
+// ============================================================
+
+describe("sync-engine — pullSyncTable preserva blob_local en el pull", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    fakeClient = createFakeSupabaseClient() as FakeSupabaseClient;
+  });
+
+  it("una fila local con blob_local sobrevive al put del pull (el remoto trae url_storage, no el blob)", async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3, 4])], { type: "image/jpeg" });
+    await db.conv_evidencias.put({
+      id: "ev-1",
+      visita_id: "visita-1",
+      prueba_codigo: "2.2",
+      slot: "consola",
+      blob_local: blob,
+      sync_status: "synced",
+      last_modified: "2026-01-01T00:00:00.000Z",
+    });
+
+    // El remoto trae la metadata + url_storage, nunca el blob.
+    fakeClient.seedTable("conv_evidencias", [
+      {
+        id: "ev-1",
+        visita_id: "visita-1",
+        prueba_codigo: "2.2",
+        slot: "consola",
+        url_storage: "conv_evidencias/visita-1/ev-1.jpg",
+        last_modified: "2026-02-01T00:00:00.000Z",
+        sync_status: "synced",
+      },
+    ]);
+
+    await pullSyncTable(fakeClient, "conv_evidencias", "conv_evidencias");
+
+    const local = await db.conv_evidencias.get("ev-1");
+    // Sin el merge, el `put` del pull dejaría `blob_local` en undefined.
+    // (fake-indexeddb degrada el Blob a objeto plano al persistir, así que
+    // solo se puede afirmar que el binario sigue presente, no su tipo.)
+    expect(local?.blob_local).not.toBeUndefined();
+    expect(local?.blob_local).not.toBeNull();
+    // y además incorpora el url_storage que trajo el remoto
+    expect(local?.url_storage).toBe("conv_evidencias/visita-1/ev-1.jpg");
+  });
+
+  it("si la fila local no tiene blob, el pull aplica el remoto tal cual", async () => {
+    fakeClient.seedTable("conv_evidencias", [
+      {
+        id: "ev-2",
+        visita_id: "visita-1",
+        prueba_codigo: "2.2",
+        slot: "equipo_rayos_x",
+        url_storage: "conv_evidencias/visita-1/ev-2.jpg",
+        last_modified: "2026-02-01T00:00:00.000Z",
+        sync_status: "synced",
+      },
+    ]);
+
+    await pullSyncTable(fakeClient, "conv_evidencias", "conv_evidencias");
+
+    const local = await db.conv_evidencias.get("ev-2");
+    expect(local?.blob_local).toBeUndefined();
+    expect(local?.url_storage).toBe("conv_evidencias/visita-1/ev-2.jpg");
+  });
+});
+
+// ============================================================
 //  getAuthenticatedUser — reintento de sesión (bug del primer login)
 //
 //  `fullSync()` se dispara en el login como fire-and-forget, justo

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -132,6 +132,46 @@ const EXTRA_LOCAL_FIELDS: Record<string, string[]> = {
   ],
 };
 
+/**
+ * El pull trae la fila remota SIN los binarios (`blob_local` /
+ * `archivo_raysafe_blob` / `imagenes[].blob_local`) porque el push los
+ * descarta. Un `put` a ciegas del registro remoto borraría el binario
+ * local — con lo que la evidencia fotográfica capturada en este dispositivo
+ * desaparecería tras el primer ciclo de sync (#67). Este helper reinyecta
+ * los binarios que el registro local ya tenía y que el remoto no puede
+ * traer, conservando el resto de campos del remoto (incluido `url_storage`).
+ */
+function mergeLocalBinaries(
+  remoteRecord: Record<string, unknown>,
+  localRecord: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (!localRecord) return remoteRecord;
+  const merged: Record<string, unknown> = { ...remoteRecord };
+
+  for (const key of ["blob_local", "archivo_raysafe_blob"] as const) {
+    if (localRecord[key] != null && remoteRecord[key] == null) {
+      merged[key] = localRecord[key];
+    }
+  }
+
+  // Imágenes anidadas (grupo_resultados / prueba_resultados): el remoto trae
+  // la metadata de cada imagen pero no su blob. Se reinyecta el blob local
+  // matcheando por `slot_key`.
+  if (Array.isArray(merged.imagenes) && Array.isArray(localRecord.imagenes)) {
+    const localBySlot = new Map(
+      (localRecord.imagenes as Record<string, unknown>[]).map((img) => [img.slot_key, img])
+    );
+    merged.imagenes = (merged.imagenes as Record<string, unknown>[]).map((img) => {
+      const local = localBySlot.get(img.slot_key);
+      return local?.blob_local != null && img.blob_local == null
+        ? { ...img, blob_local: local.blob_local }
+        : img;
+    });
+  }
+
+  return merged;
+}
+
 /** Prepara un registro Dexie para enviar a Supabase (quita campos locales) */
 function prepareForRemote(
   record: Record<string, unknown>,
@@ -750,7 +790,11 @@ async function applyRemoteSyncRecord(
       await dexieTable.delete(remoteRecord.id as string);
       return 1;
     }
-    await dexieTable.put({ ...remoteRecord, sync_status: "synced" as SyncStatus });
+    const merged = mergeLocalBinaries(
+      remoteRecord as Record<string, unknown>,
+      localRecord as Record<string, unknown> | undefined
+    );
+    await dexieTable.put({ ...(merged as SyncableRecord), sync_status: "synced" as SyncStatus });
     return 1;
   }
 

--- a/supabase/migrations/017_rls_politicas_escritura_sync.sql
+++ b/supabase/migrations/017_rls_politicas_escritura_sync.sql
@@ -1,0 +1,139 @@
+-- ============================================================
+--  017 — Políticas RLS de escritura para TODAS las tablas de sync
+--
+--  Contexto (issue #59, hallazgo de la pasada de prueba E2E):
+--  Al capturar contactos desde Información General, el push respondía
+--  403 / 42501 ("new row violates row-level security policy for table
+--  contactos"). Causa: RLS habilitado en `contactos` (y potencialmente
+--  en otras) SIN políticas permisivas de INSERT/UPDATE → todo write del
+--  usuario autenticado se rechaza.
+--
+--  El motor de sync escribe con el cliente de sesión (anon key + JWT del
+--  usuario), así que TODO pasa por RLS como `authenticated`. Esta app no
+--  implementa ownership por fila; el modelo de acceso real es "cualquier
+--  usuario autenticado del staff puede leer/escribir los datos de
+--  campo". Esta migración deja ese modelo CONSISTENTE en todas las
+--  tablas de sync: RLS habilitado + una política permisiva por comando
+--  para el rol `authenticated`.
+--
+--  Defensa en profundidad (ownership / RLS por rol) es un proyecto
+--  aparte (ver #38 y siguientes). Esto NO agrega restricciones nuevas:
+--  restaura el estado de escritura que las tablas que hoy SÍ funcionan
+--  ya tienen de facto.
+--
+--  Idempotente (DROP POLICY IF EXISTS). Correr en Supabase → SQL Editor.
+--
+--  Antes de correr, para inventariar el estado actual:
+--
+--    -- tablas con RLS on pero sin política de escritura:
+--    SELECT c.relname
+--    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+--    WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relrowsecurity
+--      AND NOT EXISTS (
+--        SELECT 1 FROM pg_policies p
+--        WHERE p.tablename = c.relname AND p.cmd IN ('INSERT','UPDATE','ALL')
+--      )
+--    ORDER BY c.relname;
+--
+--    -- todas las políticas de las tablas de sync:
+--    SELECT tablename, policyname, cmd, roles, qual, with_check
+--    FROM pg_policies
+--    WHERE tablename = ANY(ARRAY[
+--      'clientes','contactos','sedes','ubicaciones_rx','equipos','equipo_movimientos',
+--      'tubos','colimadores','gantry','solicitudes','visitas','grupo_resultados',
+--      'prueba_resultados','mediciones_radiometricas','evidencias',
+--      'conv_levantamiento_setup','conv_mediciones','conv_inspeccion_items',
+--      'conv_elementos_proteccion','conv_raysafe_setup','conv_raysafe_mediciones',
+--      'conv_cae_setup','conv_cae_mediciones','conv_ddi_mediciones',
+--      'conv_cassette_inspeccion','conv_uniformidad_cr','conv_colimacion',
+--      'conv_uniformidad_detector','conv_resolucion','conv_bajo_contraste','conv_mtf',
+--      'conv_informe_secciones','conv_resultados_prueba','conv_evidencias'])
+--    ORDER BY tablename, cmd;
+-- ============================================================
+
+DO $$
+DECLARE
+  t text;
+  sync_tables text[] := ARRAY[
+    'clientes','contactos','sedes','ubicaciones_rx','equipos','equipo_movimientos',
+    'tubos','colimadores','gantry','solicitudes',
+    'visitas','grupo_resultados','prueba_resultados','mediciones_radiometricas','evidencias',
+    'conv_levantamiento_setup','conv_mediciones','conv_inspeccion_items','conv_elementos_proteccion',
+    'conv_raysafe_setup','conv_raysafe_mediciones','conv_cae_setup','conv_cae_mediciones',
+    'conv_ddi_mediciones','conv_cassette_inspeccion','conv_uniformidad_cr','conv_colimacion',
+    'conv_uniformidad_detector','conv_resolucion','conv_bajo_contraste','conv_mtf',
+    'conv_informe_secciones','conv_resultados_prueba','conv_evidencias'
+  ];
+BEGIN
+  FOREACH t IN ARRAY sync_tables LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = t
+    ) THEN
+      RAISE NOTICE 'tabla % no existe — se omite', t;
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t);
+
+    -- SELECT
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', t || '_auth_select', t);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR SELECT TO authenticated USING (true)',
+      t || '_auth_select', t
+    );
+
+    -- INSERT
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', t || '_auth_insert', t);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR INSERT TO authenticated WITH CHECK (true)',
+      t || '_auth_insert', t
+    );
+
+    -- UPDATE (incluye el UPSERT ON CONFLICT del sync)
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', t || '_auth_update', t);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR UPDATE TO authenticated USING (true) WITH CHECK (true)',
+      t || '_auth_update', t
+    );
+
+    -- DELETE (el borrado real es soft-delete vía UPDATE, pero se deja por
+    -- si algún flujo administrativo hace hard-delete).
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', t || '_auth_delete', t);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR DELETE TO authenticated USING (true)',
+      t || '_auth_delete', t
+    );
+
+    RAISE NOTICE 'RLS + políticas authenticated aplicadas a %', t;
+  END LOOP;
+END $$;
+
+-- Defensivo (issue #35): el valor `sync_status = 'conflict'` se retiró del
+-- enum del cliente en Tier 2. Si quedaron filas viejas en ese estado,
+-- pasarlas a 'pending' para que el próximo push las reintente.
+DO $$
+DECLARE
+  t text;
+  sync_tables text[] := ARRAY[
+    'clientes','contactos','sedes','ubicaciones_rx','equipos','equipo_movimientos',
+    'tubos','colimadores','gantry','solicitudes',
+    'visitas','grupo_resultados','prueba_resultados','mediciones_radiometricas','evidencias',
+    'conv_levantamiento_setup','conv_mediciones','conv_inspeccion_items','conv_elementos_proteccion',
+    'conv_raysafe_setup','conv_raysafe_mediciones','conv_cae_setup','conv_cae_mediciones',
+    'conv_ddi_mediciones','conv_cassette_inspeccion','conv_uniformidad_cr','conv_colimacion',
+    'conv_uniformidad_detector','conv_resolucion','conv_bajo_contraste','conv_mtf',
+    'conv_informe_secciones','conv_resultados_prueba','conv_evidencias'
+  ];
+BEGIN
+  FOREACH t IN ARRAY sync_tables LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = t AND column_name = 'sync_status'
+    ) THEN
+      EXECUTE format(
+        'UPDATE public.%I SET sync_status = ''pending'' WHERE sync_status = ''conflict''', t
+      );
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Contexto

Primer bloque del **Paquete A** del plan de corrección de los issues de la pasada de prueba E2E (`~/.claude/plans/en-dias-anteriores-he-cheerful-hopcroft.md`). Paquete A se partió en dos: **A1 (este PR)** — lo que está 100% en nuestro control y testeable; **A2 (siguiente)** — el pipeline completo de subida de imágenes a Storage (#67) que además necesita que el dueño cree el bucket.

## Cambios

### #67 (parcial) — el pull ya no borra los blobs locales

`applyRemoteSyncRecord` hacía `put({...remoteRecord})` a ciegas. El registro remoto **nunca trae los binarios** (`blob_local` se descarta en el push), así que ese `put` dejaba `blob_local` en `undefined` → la evidencia fotográfica capturada en el dispositivo **desaparecía tras el primer ciclo de sync completo**. Ahora `mergeLocalBinaries` reinyecta `blob_local` / `archivo_raysafe_blob` / `imagenes[].blob_local` del registro local, conservando `url_storage` y el resto de campos del remoto.

Tests nuevos en `sync-engine.test.ts` (2): el blob sobrevive al pull + se incorpora el `url_storage` remoto; sin blob local, el pull aplica el remoto tal cual.

### #51 — `deleted_at` se filtra ahora en TODAS las lecturas conv_*

El filtro estaba solo en 5 de ~17 lecturas, tanto en `recopilarDatosConv` (`secciones-convencional.ts`) como en `cargarTablasConv` (`evaluacion.ts`). Una medición borrada de RaySafe / CAE / DDI o un ítem de inspección borrado seguía alimentando el veredicto de conformidad y el **PDF oficial**. Los PIN tests que fijaban el bug se dieron vuelta para fijar el fix (+1 test nuevo para `conv_inspeccion_items`).

### #59 (para el dueño) — migración `017_rls_politicas_escritura_sync.sql`

Habilita RLS + políticas permisivas `SELECT`/`INSERT`/`UPDATE`/`DELETE` para el rol `authenticated` en las 33 tablas de sync + `conv_*`, de forma **consistente**. No agrega restricciones: restaura el modelo de escritura que las tablas que hoy funcionan ya tienen de facto. `contactos` daba **403 / 42501** ("new row violates row-level security policy") porque tenía RLS sin políticas. Incluye las queries de inventario (en comentarios) y un `UPDATE` defensivo para filas viejas en `sync_status='conflict'` (#35 — valor ya retirado del enum en Tier 2).

**El dueño corre la migración en Supabase → SQL Editor.** Criterio de cierre de #59: correr el flujo E2E completo y verificar 0 filas en `sync_status:"error"` por RLS.

## Verificación

`npm run verify` limpio: typecheck, lint (0 errores), format, **514 tests**, build.

## Pendiente (Paquete A2)

- #67 completo: bucket de Storage, subida de `blob_local` en el push, `url_storage` como path, resolución de signed URLs, fallback de display en `ImageSlot`, compresión.
- #39: guard de columnas Dexie vs Supabase.
- #34 queda abierto (latente — no hay UI de borrado de maestras todavía; el issue mismo lo difiere).
