### PR TITLE
fix(i18n): Paquete B — estándar decimal es-CO (coma) + guard de columnas (#68, #39)

### DIFF
--- a/src/components/equipo-form-dialog.tsx
+++ b/src/components/equipo-form-dialog.tsx
@@ -5,6 +5,7 @@ import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { db } from "@/lib/db";
 import type { Equipo, Tubo, Colimador, Gantry } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
+import { parseDecimal } from "@/lib/decimal";
 import { pushSingle } from "@/lib/supabase/sync-engine";
 import { TIPOS_EQUIPO, type TipoEquipo } from "@/lib/db/types";
 import {
@@ -218,7 +219,7 @@ export function EquipoFormDialog({
         tipo_equipo: (tipoEquipo as TipoEquipo) || undefined,
         planilla_espacial: equipo?.planilla_espacial ?? false,
         sistema_adquisicion: sistemaAdq || undefined,
-        distancia_foco_paciente: distanciaFoco ? parseFloat(distanciaFoco) : undefined,
+        distancia_foco_paciente: parseDecimal(distanciaFoco),
         bucky: (bucky as Equipo["bucky"]) || undefined,
         marca: marca || undefined,
         modelo: modelo || undefined,
@@ -228,8 +229,8 @@ export function EquipoFormDialog({
         gen_numero_serie: genSerie || undefined,
         gen_fecha_fabricacion: genFechaFab || undefined,
         gen_fase: (genFase as Equipo["gen_fase"]) || undefined,
-        filtracion_inherente_mmal: filtInherente ? parseFloat(filtInherente) : undefined,
-        filtracion_anadida_mmal: filtAnadida ? parseFloat(filtAnadida) : undefined,
+        filtracion_inherente_mmal: parseDecimal(filtInherente),
+        filtracion_anadida_mmal: parseDecimal(filtAnadida),
         creado_en: now,
         sync_status: "pending",
         last_modified: now,
@@ -241,11 +242,11 @@ export function EquipoFormDialog({
         modelo: tuboModelo || undefined,
         numero_serie: tuboSerie || undefined,
         tipo: tuboTipo || undefined,
-        mas_max: tuboMasMax ? parseFloat(tuboMasMax) : undefined,
-        kv_max: tuboKvMax ? parseFloat(tuboKvMax) : undefined,
-        ma_max: tuboMaMax ? parseFloat(tuboMaMax) : undefined,
-        foco_fino_mm: tuboFocoFino ? parseFloat(tuboFocoFino) : undefined,
-        foco_grueso_mm: tuboFocoGrueso ? parseFloat(tuboFocoGrueso) : undefined,
+        mas_max: parseDecimal(tuboMasMax),
+        kv_max: parseDecimal(tuboKvMax),
+        ma_max: parseDecimal(tuboMaMax),
+        foco_fino_mm: parseDecimal(tuboFocoFino),
+        foco_grueso_mm: parseDecimal(tuboFocoGrueso),
         creado_en: now,
         sync_status: "pending",
         last_modified: now,

--- a/src/components/ubicacion-form-dialog.tsx
+++ b/src/components/ubicacion-form-dialog.tsx
@@ -5,6 +5,7 @@ import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { db } from "@/lib/db";
 import type { UbicacionRx } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
+import { parseDecimal } from "@/lib/decimal";
 import { pushSingle } from "@/lib/supabase/sync-engine";
 import {
   Dialog,
@@ -58,7 +59,9 @@ export function UbicacionFormDialog({
 
   // Área = ancho × largo (autocalculada)
   const areaCalc =
-    ancho && largo ? Math.round(parseFloat(ancho) * parseFloat(largo) * 100) / 100 : undefined;
+    ancho && largo
+      ? Math.round((parseDecimal(ancho) ?? 0) * (parseDecimal(largo) ?? 0) * 100) / 100
+      : undefined;
 
   function resetForm() {
     setNombre(ubicacion?.nombre_servicio ?? "");
@@ -94,9 +97,9 @@ export function UbicacionFormDialog({
         codigo_habilitacion: codigo || undefined,
         horas_x_dia: horas ? parseInt(horas, 10) : undefined,
         ubicacion_fisica: ubicFisica || undefined,
-        ancho_m: ancho ? parseFloat(ancho) : undefined,
-        largo_m: largo ? parseFloat(largo) : undefined,
-        alto_m: alto ? parseFloat(alto) : undefined,
+        ancho_m: parseDecimal(ancho),
+        largo_m: parseDecimal(largo),
+        alto_m: parseDecimal(alto),
         area_m2: areaCalc,
         zona_a_desc: zonaA || undefined,
         zona_b_desc: zonaB || undefined,

--- a/src/components/ui/number-input.test.tsx
+++ b/src/components/ui/number-input.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { NumberInput } from "./number-input";
+
+afterEach(cleanup);
+
+describe("NumberInput (#68)", () => {
+  it("muestra el número con coma decimal (es-CO)", () => {
+    render(<NumberInput value={1.8} onValueChange={vi.fn()} />);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("1,8");
+  });
+
+  it("tipear con coma entrega un number normalizado", () => {
+    const onValueChange = vi.fn();
+    render(<NumberInput value={undefined} onValueChange={onValueChange} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "2,5" } });
+    expect(onValueChange).toHaveBeenLastCalledWith(2.5);
+  });
+
+  it("tipear con punto también entrega el mismo number", () => {
+    const onValueChange = vi.fn();
+    render(<NumberInput value={undefined} onValueChange={onValueChange} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "2.5" } });
+    expect(onValueChange).toHaveBeenLastCalledWith(2.5);
+  });
+
+  it("vacío entrega undefined", () => {
+    const onValueChange = vi.fn();
+    render(<NumberInput value={3} onValueChange={onValueChange} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "" } });
+    expect(onValueChange).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it("al perder foco re-formatea a coma", () => {
+    render(<NumberInput value={undefined} onValueChange={vi.fn()} />);
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "10.25" } });
+    fireEvent.blur(input);
+    expect((input as HTMLInputElement).value).toBe("10,25");
+  });
+
+  it("usa inputMode decimal (teclado numérico en tablet)", () => {
+    render(<NumberInput value={0} onValueChange={vi.fn()} />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("inputmode", "decimal");
+  });
+});

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { parseDecimal, decimalInputValue } from "@/lib/decimal";
+
+// ============================================================
+//  <NumberInput> — entrada numérica con convención es-CO (#68)
+//
+//  Reemplaza `<input type="number">`, que se comporta distinto según el
+//  locale del navegador/tablet. Acá:
+//   - se muestra con coma decimal,
+//   - se acepta coma O punto al tipear,
+//   - `onValueChange` entrega un `number | undefined` ya normalizado
+//     (nunca un string a medio parsear).
+//  Usa `inputMode="decimal"` → teclado numérico en la tablet.
+// ============================================================
+
+type Props = Omit<
+  React.ComponentProps<typeof Input>,
+  "type" | "value" | "onChange" | "inputMode"
+> & {
+  value: number | null | undefined;
+  onValueChange: (value: number | undefined) => void;
+};
+
+export function NumberInput({ value, onValueChange, onBlur, ...rest }: Props) {
+  // Mientras el input tiene foco, el usuario manda: no re-formateamos su
+  // texto en cada tecla. Al perder foco, se normaliza a la vista es-CO.
+  const [text, setText] = React.useState(() => decimalInputValue(value));
+  const [focused, setFocused] = React.useState(false);
+  const [prevValue, setPrevValue] = React.useState(value);
+
+  // El valor externo cambió (sync / reset) y el input no tiene foco →
+  // re-derivar el texto. Ajuste de estado en render, no en efecto.
+  if (!focused && prevValue !== value) {
+    setPrevValue(value);
+    if (parseDecimal(text) !== value) setText(decimalInputValue(value));
+  }
+
+  return (
+    <Input
+      {...rest}
+      type="text"
+      inputMode="decimal"
+      value={text}
+      onFocus={(e) => {
+        setFocused(true);
+        rest.onFocus?.(e);
+      }}
+      onChange={(e) => {
+        setText(e.target.value);
+        onValueChange(parseDecimal(e.target.value));
+      }}
+      onBlur={(e) => {
+        setFocused(false);
+        setText(decimalInputValue(parseDecimal(e.target.value)));
+        onBlur?.(e);
+      }}
+    />
+  );
+}

--- a/src/components/visita-modulos/grupo-a-modulo.tsx
+++ b/src/components/visita-modulos/grupo-a-modulo.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { randomUUID } from "@/lib/uuid";
+import { parseDecimal } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
@@ -79,8 +80,7 @@ type Concepto = "Conforme" | "No_conforme" | "No_aplica";
 
 function num(v: string | number | undefined | null): number {
   if (v == null || v === "") return 0;
-  const n = typeof v === "number" ? v : parseFloat(v);
-  return isNaN(n) ? 0 : n;
+  return (typeof v === "number" ? v : parseDecimal(v)) ?? 0;
 }
 
 // ─── UI Components ───
@@ -675,7 +675,9 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                 step="0.001"
                 defaultValue={setup?.fondo_natural_usv_h ?? ""}
                 placeholder="Ej: 0.08"
-                onSave={(v) => updateSetup({ fondo_natural_usv_h: v ? parseFloat(v) : undefined })}
+                onSave={(v) =>
+                  updateSetup({ fondo_natural_usv_h: v ? parseDecimal(v) : undefined })
+                }
               />
               <SetupField
                 label="Distancia tubo — operario (m)"
@@ -683,7 +685,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                 defaultValue={setup?.distancia_tubo_operario_m ?? ""}
                 placeholder="Ej: 2.5"
                 onSave={(v) =>
-                  updateSetup({ distancia_tubo_operario_m: v ? parseFloat(v) : undefined })
+                  updateSetup({ distancia_tubo_operario_m: v ? parseDecimal(v) : undefined })
                 }
               />
             </div>
@@ -709,7 +711,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                   step="0.01"
                   defaultValue={setup?.[field] ?? ""}
                   placeholder={ph}
-                  onSave={(v) => updateSetup({ [field]: v ? parseFloat(v) : undefined })}
+                  onSave={(v) => updateSetup({ [field]: v ? parseDecimal(v) : undefined })}
                 />
               ))}
             </div>
@@ -776,7 +778,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                 <SetupField
                   label="Semanas laborales"
                   defaultValue={setup?.semanas_laborales ?? 50}
-                  onSave={(v) => updateSetup({ semanas_laborales: v ? parseFloat(v) : 50 })}
+                  onSave={(v) => updateSetup({ semanas_laborales: v ? parseDecimal(v) : 50 })}
                 />
                 {semanasLaborales < 50 && (
                   <p className="text-[10px] font-bold text-amber-600">
@@ -863,7 +865,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                           placeholder="0.00"
                           onBlur={(e) => {
                             if (!m.id) return;
-                            const usv = e.target.value ? parseFloat(e.target.value) : undefined;
+                            const usv = e.target.value ? parseDecimal(e.target.value) : undefined;
                             updateMedicion(m.id, { tasa_dosis_usv_h: usv });
                             flash(m.id);
                           }}
@@ -879,7 +881,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                           onChange={(e) => {
                             if (!m.id) return;
                             updateMedicion(m.id, {
-                              factor_ocupacion_t: parseFloat(e.target.value),
+                              factor_ocupacion_t: parseDecimal(e.target.value),
                             });
                             flash(m.id);
                           }}
@@ -897,7 +899,7 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                           defaultValue={m.factor_uso_u ?? 1}
                           onChange={(e) => {
                             if (!m.id) return;
-                            updateMedicion(m.id, { factor_uso_u: parseFloat(e.target.value) });
+                            updateMedicion(m.id, { factor_uso_u: parseDecimal(e.target.value) });
                             flash(m.id);
                           }}
                         >

--- a/src/components/visita-modulos/grupo-b-modulo.tsx
+++ b/src/components/visita-modulos/grupo-b-modulo.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { randomUUID } from "@/lib/uuid";
+import { parseDecimal } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
@@ -667,7 +668,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
             <SetupField
               label="Distancia foco-sensor (cm)"
               defaultValue={setup?.distancia_foco_sensor_cm ?? 100}
-              onSave={(v) => updateSetup({ distancia_foco_sensor_cm: v ? parseFloat(v) : 100 })}
+              onSave={(v) => updateSetup({ distancia_foco_sensor_cm: v ? parseDecimal(v) : 100 })}
             />
           </div>
 
@@ -762,7 +763,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                         defaultValue={m[campo] ?? ""}
                         onBlur={(e) => {
                           if (!m.id) return;
-                          const val = e.target.value ? parseFloat(e.target.value) : undefined;
+                          const val = e.target.value ? parseDecimal(e.target.value) : undefined;
                           if (esEspejo && isFirstInGroup)
                             updateNominalGrupo(m.grupo_numero, { [campo]: val });
                           else updateMedicion(m.id, { [campo]: val });
@@ -816,7 +817,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                           onBlur={(e) => {
                             if (!m.id) return;
                             updateMedicion(m.id, {
-                              dap_medido: e.target.value ? parseFloat(e.target.value) : undefined,
+                              dap_medido: e.target.value ? parseDecimal(e.target.value) : undefined,
                             });
                             flash(m.id);
                           }}
@@ -903,7 +904,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                                 m.id,
                                 m.programa_clinico,
                                 field,
-                                e.target.value ? parseFloat(e.target.value) : undefined
+                                e.target.value ? parseDecimal(e.target.value) : undefined
                               );
                               flash(m.id);
                             }}
@@ -923,7 +924,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                             onBlur={(e) => {
                               if (!m.id) return;
                               updateMedicion(m.id, {
-                                [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                                [field]: e.target.value ? parseDecimal(e.target.value) : undefined,
                               });
                               flash(m.id);
                             }}
@@ -962,7 +963,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
               defaultValue={setup?.distancia_foco_sensor_d1_cm ?? ""}
               placeholder="100"
               onSave={(v) =>
-                updateSetup({ distancia_foco_sensor_d1_cm: v ? parseFloat(v) : undefined })
+                updateSetup({ distancia_foco_sensor_d1_cm: v ? parseDecimal(v) : undefined })
               }
             />
             <SetupField
@@ -970,7 +971,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
               defaultValue={setup?.distancia_foco_detector_d2_cm ?? ""}
               placeholder="110"
               onSave={(v) =>
-                updateSetup({ distancia_foco_detector_d2_cm: v ? parseFloat(v) : undefined })
+                updateSetup({ distancia_foco_detector_d2_cm: v ? parseDecimal(v) : undefined })
               }
             />
           </div>
@@ -1042,7 +1043,9 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                               onBlur={(e) => {
                                 if (!m.id) return;
                                 updateMedicion(m.id, {
-                                  [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                                  [field]: e.target.value
+                                    ? parseDecimal(e.target.value)
+                                    : undefined,
                                 });
                                 flash(m.id);
                               }}
@@ -1061,7 +1064,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                             if (!m.id) return;
                             updateMedicion(m.id, {
                               dosis_base_mgy: e.target.value
-                                ? parseFloat(e.target.value)
+                                ? parseDecimal(e.target.value)
                                 : undefined,
                             });
                             flash(m.id);
@@ -1176,7 +1179,7 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
                             onBlur={(e) => {
                               if (!m.id) return;
                               updateMedicion(m.id, {
-                                [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                                [field]: e.target.value ? parseDecimal(e.target.value) : undefined,
                               });
                               flash(m.id);
                             }}

--- a/src/components/visita-modulos/grupo-c-modulo.tsx
+++ b/src/components/visita-modulos/grupo-c-modulo.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useMemo } from "react";
 import { randomUUID } from "@/lib/uuid";
+import { parseDecimal } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
@@ -385,8 +386,7 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   function parseSetupField(v: string): number | undefined {
-    const n = parseFloat(v);
-    return isNaN(n) ? undefined : n;
+    return parseDecimal(v);
   }
 
   // ─── Cálculos auto ───
@@ -621,7 +621,7 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
                             onBlur={(e) => {
                               if (!m.id) return;
                               updateMedicion(m.id, {
-                                [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                                [field]: e.target.value ? parseDecimal(e.target.value) : undefined,
                               });
                               flash(m.id);
                             }}

--- a/src/components/visita-modulos/grupo-d-modulo.tsx
+++ b/src/components/visita-modulos/grupo-d-modulo.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useMemo } from "react";
 import { randomUUID } from "@/lib/uuid";
+import { parseDecimal } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
@@ -618,7 +619,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                             onBlur={(e) => {
                               if (!m.id) return;
                               updateDdi(m.id, {
-                                [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                                [field]: e.target.value ? parseDecimal(e.target.value) : undefined,
                               });
                               flash(m.id);
                             }}
@@ -659,7 +660,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                 onBlur={(e) => {
                   const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
                   if (t1?.id) {
-                    updateDdi(t1.id, { ei_base: parseFloat(e.target.value) || null });
+                    updateDdi(t1.id, { ei_base: parseDecimal(e.target.value) || null });
                     setSavedEiBase(true);
                     setTimeout(() => setSavedEiBase(false), 1500);
                   }
@@ -681,7 +682,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                 onBlur={(e) => {
                   const t1 = data?.ddiMediciones.find((m) => m.grupo === 1 && m.toma_numero === 1);
                   if (t1?.id) {
-                    updateDdi(t1.id, { di_base: parseFloat(e.target.value) || null });
+                    updateDdi(t1.id, { di_base: parseDecimal(e.target.value) || null });
                     setSavedDiBase(true);
                     setTimeout(() => setSavedDiBase(false), 1500);
                   }
@@ -919,7 +920,7 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
                           onBlur={(e) => {
                             if (!u.id) return;
                             updateUniformidad(u.id, {
-                              [field]: e.target.value ? parseFloat(e.target.value) : undefined,
+                              [field]: e.target.value ? parseDecimal(e.target.value) : undefined,
                             });
                             flash(u.id);
                           }}

--- a/src/components/visita-modulos/grupo-e-modulo.tsx
+++ b/src/components/visita-modulos/grupo-e-modulo.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useMemo } from "react";
 import { randomUUID } from "@/lib/uuid";
+import { parseDecimal } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
@@ -551,7 +552,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
               <SetupField
                 label="SID (cm)"
                 defaultValue={colim?.sid_cm ?? 100}
-                onSave={(v) => updateColimacion({ sid_cm: v ? parseFloat(v) : 100 })}
+                onSave={(v) => updateColimacion({ sid_cm: v ? parseDecimal(v) : 100 })}
               />
               {[
                 ["tecnica_kv", "kVp", "75"],
@@ -566,7 +567,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                     ((colim as Record<string, unknown> | undefined)?.[field] as string) ?? ""
                   }
                   placeholder={ph}
-                  onSave={(v) => updateColimacion({ [field]: v ? parseFloat(v) : undefined })}
+                  onSave={(v) => updateColimacion({ [field]: v ? parseDecimal(v) : undefined })}
                 />
               ))}
             </div>
@@ -589,7 +590,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                     }
                     placeholder="—"
                     onSave={(v) =>
-                      updateColimacion({ [`${d.key}_nominal`]: v ? parseFloat(v) : undefined })
+                      updateColimacion({ [`${d.key}_nominal`]: v ? parseDecimal(v) : undefined })
                     }
                   />
                   <SetupField
@@ -603,7 +604,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                     }
                     placeholder="—"
                     onSave={(v) =>
-                      updateColimacion({ [`${d.key}_medido`]: v ? parseFloat(v) : undefined })
+                      updateColimacion({ [`${d.key}_medido`]: v ? parseDecimal(v) : undefined })
                     }
                   />
                 </div>
@@ -763,7 +764,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                     onBlur={(e) => {
                       if (!ur.det.id) return;
                       updateUniformidadDet(ur.det.id, {
-                        tolerancia_pct: e.target.value ? parseFloat(e.target.value) : 15,
+                        tolerancia_pct: e.target.value ? parseDecimal(e.target.value) : 15,
                       });
                       flash(ur.det.id);
                     }}
@@ -794,7 +795,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                                 if (!ur.det.id) return;
                                 updateUniformidadDet(ur.det.id, {
                                   [vmpField]: e.target.value
-                                    ? parseFloat(e.target.value)
+                                    ? parseDecimal(e.target.value)
                                     : undefined,
                                 });
                                 flash(ur.det.id);
@@ -810,7 +811,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                                 if (!ur.det.id) return;
                                 updateUniformidadDet(ur.det.id, {
                                   [desvField]: e.target.value
-                                    ? parseFloat(e.target.value)
+                                    ? parseDecimal(e.target.value)
                                     : undefined,
                                 });
                                 flash(ur.det.id);
@@ -942,17 +943,17 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
             <SetupField
               label="SID (cm)"
               defaultValue={resol?.sid_cm ?? 100}
-              onSave={(v) => updateResolucion({ sid_cm: v ? parseFloat(v) : 100 })}
+              onSave={(v) => updateResolucion({ sid_cm: v ? parseDecimal(v) : 100 })}
             />
             <SetupField
               label="kVp"
               defaultValue={resol?.tecnica_kv ?? 75}
-              onSave={(v) => updateResolucion({ tecnica_kv: v ? parseFloat(v) : undefined })}
+              onSave={(v) => updateResolucion({ tecnica_kv: v ? parseDecimal(v) : undefined })}
             />
             <SetupField
               label="mAs"
               defaultValue={resol?.tecnica_mas ?? ""}
-              onSave={(v) => updateResolucion({ tecnica_mas: v ? parseFloat(v) : undefined })}
+              onSave={(v) => updateResolucion({ tecnica_mas: v ? parseDecimal(v) : undefined })}
             />
           </div>
 
@@ -965,7 +966,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
               value={resol?.pares_lineas_plmm ?? ""}
               onChange={(e) =>
                 updateResolucion({
-                  pares_lineas_plmm: e.target.value ? parseFloat(e.target.value) : undefined,
+                  pares_lineas_plmm: e.target.value ? parseDecimal(e.target.value) : undefined,
                 })
               }
             >
@@ -1118,7 +1119,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                     ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
                   }
                   placeholder={ph}
-                  onSave={(v) => updateMtf({ [field]: v ? parseFloat(v) : undefined })}
+                  onSave={(v) => updateMtf({ [field]: v ? parseDecimal(v) : undefined })}
                 />
               ))}
             </div>
@@ -1141,7 +1142,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                     ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
                   }
                   placeholder="—"
-                  onSave={(v) => updateMtf({ [field]: v ? parseFloat(v) : undefined })}
+                  onSave={(v) => updateMtf({ [field]: v ? parseDecimal(v) : undefined })}
                 />
               ))}
             </div>
@@ -1164,7 +1165,7 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
                     ((mtfData as Record<string, unknown> | undefined)?.[field] as string) ?? ""
                   }
                   placeholder="—"
-                  onSave={(v) => updateMtf({ [field]: v ? parseFloat(v) : undefined })}
+                  onSave={(v) => updateMtf({ [field]: v ? parseDecimal(v) : undefined })}
                 />
               ))}
             </div>

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { randomUUID } from "@/lib/uuid";
+import { parseDecimal, decimalInputValue } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
@@ -65,7 +66,14 @@ function EditableField({
   onSave: (v: string) => void;
   type?: "text" | "number" | "date";
 }) {
-  const [local, setLocal] = useState(value);
+  // #68: los campos numéricos se muestran con coma decimal (es-CO) y aceptan
+  // coma o punto. El input real es `text` + `inputMode=decimal` (evita la
+  // "ruleta de locale" de `type=number`). `onSave` recibe el string crudo;
+  // el caller lo pasa por `parseDecimal`.
+  const esNumero = type === "number";
+  const paraMostrar = (v: string) => (esNumero ? decimalInputValue(parseDecimal(v)) : v);
+
+  const [local, setLocal] = useState(() => paraMostrar(value));
   const [prevValue, setPrevValue] = useState(value);
   const [saved, setSaved] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -74,7 +82,7 @@ function EditableField({
   // sync entre dispositivos): ajuste de estado en render, no en efecto.
   if (value !== prevValue) {
     setPrevValue(value);
-    setLocal(value);
+    setLocal(paraMostrar(value));
   }
 
   const handleChange = useCallback(
@@ -99,7 +107,8 @@ function EditableField({
         {saved && <Check className="w-3 h-3 text-emerald-500" />}
       </p>
       <Input
-        type={type}
+        type={esNumero ? "text" : type}
+        inputMode={esNumero ? "decimal" : undefined}
         className="rounded-xl border-slate-200 focus:border-primary font-medium h-9 text-sm"
         value={local}
         onChange={(e) => handleChange(e.target.value)}
@@ -369,7 +378,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
   async function saveUbicacion(field: string, value: string, numeric = false) {
     const id = data?.ubicacion?.id;
     if (!id) return;
-    const parsed = numeric ? (value === "" ? undefined : parseFloat(value)) : value || undefined;
+    const parsed = numeric ? (value === "" ? undefined : parseDecimal(value)) : value || undefined;
     await db.ubicaciones_rx.update(id, {
       [field]: parsed,
       sync_status: "pending",
@@ -382,7 +391,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
   async function saveUbicacionDim(field: "ancho_m" | "largo_m" | "alto_m", value: string) {
     const id = data?.ubicacion?.id;
     if (!id) return;
-    const parsed = value === "" ? undefined : parseFloat(value);
+    const parsed = value === "" ? undefined : parseDecimal(value);
     const ancho = field === "ancho_m" ? parsed : data?.ubicacion?.ancho_m;
     const largo = field === "largo_m" ? parsed : data?.ubicacion?.largo_m;
     const area = ancho && largo ? Math.round(ancho * largo * 100) / 100 : undefined;
@@ -398,7 +407,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
   async function saveEquipo(field: string, value: string, numeric = false) {
     const id = data?.equipo?.id;
     if (!id) return;
-    const parsed = numeric ? (value === "" ? undefined : parseFloat(value)) : value || undefined;
+    const parsed = numeric ? (value === "" ? undefined : parseDecimal(value)) : value || undefined;
     await db.equipos.update(id, { [field]: parsed, sync_status: "pending", last_modified: now() });
     pushSingle("equipos", id);
   }
@@ -406,14 +415,14 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
   async function saveTubo(field: string, value: string, numeric = false) {
     const id = data?.tubo?.id;
     if (!id) return;
-    const parsed = numeric ? (value === "" ? undefined : parseFloat(value)) : value || undefined;
+    const parsed = numeric ? (value === "" ? undefined : parseDecimal(value)) : value || undefined;
     await db.tubos.update(id, { [field]: parsed, sync_status: "pending", last_modified: now() });
     pushSingle("tubos", id);
   }
 
   async function saveVisita(field: string, value: string, numeric = false) {
     if (!visitaId) return;
-    const parsed = numeric ? (value === "" ? undefined : parseFloat(value)) : value || undefined;
+    const parsed = numeric ? (value === "" ? undefined : parseDecimal(value)) : value || undefined;
     await db.visitas.update(visitaId, {
       [field]: parsed,
       last_modified: new Date().toISOString(),

--- a/src/lib/decimal.test.ts
+++ b/src/lib/decimal.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { parseDecimal, formatDecimal, decimalInputValue } from "./decimal";
+
+describe("parseDecimal", () => {
+  it.each<[unknown, number | undefined]>([
+    ["1,8", 1.8],
+    ["1.8", 1.8],
+    ["1,80", 1.8],
+    ["100", 100],
+    ["0", 0],
+    ["-2,5", -2.5],
+    ["  3,14  ", 3.14],
+    ["1.234,56", 1234.56], // punto miles, coma decimal (es-CO)
+    ["1,234.56", 1234.56], // coma miles, punto decimal (en-US)
+    ["1.234.567", 1234567], // solo miles con punto
+    ["1,234,567", 1234567], // solo miles con coma
+    ["2,5 mm Al", 2.5], // con unidad pegada
+    ["", undefined],
+    ["   ", undefined],
+    ["abc", undefined],
+    ["-", undefined],
+    [null, undefined],
+    [undefined, undefined],
+    [42, 42],
+    [NaN, undefined],
+  ])("parseDecimal(%j) === %j", (input, expected) => {
+    expect(parseDecimal(input as string)).toBe(expected);
+  });
+});
+
+describe("formatDecimal (es-CO, coma)", () => {
+  it("usa coma decimal", () => {
+    expect(formatDecimal(1.8)).toBe("1,8");
+    expect(formatDecimal(2.5)).toBe("2,5");
+    expect(formatDecimal(100)).toBe("100");
+  });
+  it("respeta decimals exactos", () => {
+    expect(formatDecimal(1.8, 2)).toBe("1,80");
+    expect(formatDecimal(100, 2)).toBe("100,00");
+    expect(formatDecimal(0.5, 3)).toBe("0,500");
+  });
+  it("no agrupa miles", () => {
+    expect(formatDecimal(1234.5)).toBe("1234,5");
+  });
+  it("null / undefined / NaN → fallback", () => {
+    expect(formatDecimal(null)).toBe("—");
+    expect(formatDecimal(undefined)).toBe("—");
+    expect(formatDecimal(NaN)).toBe("—");
+    expect(formatDecimal(undefined, 2, "No aplica")).toBe("No aplica");
+  });
+});
+
+describe("decimalInputValue", () => {
+  it("número → coma; vacío → ''", () => {
+    expect(decimalInputValue(1.8)).toBe("1,8");
+    expect(decimalInputValue(null)).toBe("");
+    expect(decimalInputValue(undefined)).toBe("");
+  });
+});
+
+describe("round-trip UI: tipear coma o punto guarda el mismo number", () => {
+  it("'1,8' y '1.8' → 1.8 (number)", () => {
+    expect(parseDecimal("1,8")).toBe(parseDecimal("1.8"));
+    expect(parseDecimal("1,8")).toBe(1.8);
+  });
+});

--- a/src/lib/decimal.ts
+++ b/src/lib/decimal.ts
@@ -1,0 +1,83 @@
+// ============================================================
+//  Estándar de separador decimal — es-CO (coma)
+//
+//  Contexto (issue #68): no había una regla. `<input type="number">` se
+//  comporta distinto según el locale del navegador/tablet, y varios sitios
+//  hacían `parseFloat("1,8")` → 1 (se pierde el decimal en silencio), sobre
+//  valores medidos que definen la conformidad.
+//
+//  Regla única:
+//   - En la base: `number` de JS (punto interno). Neutro de idioma. No cambia.
+//   - Al mostrar (informe + UI): coma decimal (Intl.NumberFormat "es-CO").
+//   - Al ingresar: se acepta coma Y punto; se normaliza a punto antes de
+//     `parseFloat`.
+// ============================================================
+
+/**
+ * Convierte lo que el usuario tipeó a un número. Acepta coma o punto como
+ * separador decimal, y tolera separadores de miles ("1.234,56" / "1,234.56").
+ * Devuelve `undefined` si la cadena está vacía o no es un número.
+ */
+export function parseDecimal(raw: string | number | null | undefined): number | undefined {
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : undefined;
+  if (raw == null) return undefined;
+
+  let s = String(raw).trim();
+  if (s === "") return undefined;
+
+  // Deja solo dígitos, separadores, signo.
+  s = s.replace(/[^\d.,\-+]/g, "");
+  if (s === "" || s === "-" || s === "+") return undefined;
+
+  const lastComma = s.lastIndexOf(",");
+  const lastDot = s.lastIndexOf(".");
+
+  if (lastComma !== -1 && lastDot !== -1) {
+    // El separador que aparece MÁS a la derecha es el decimal; el otro, miles.
+    if (lastComma > lastDot) {
+      s = s.replace(/\./g, "").replace(",", ".");
+    } else {
+      s = s.replace(/,/g, "");
+    }
+  } else if (lastComma !== -1) {
+    // Solo coma. Una sola → decimal ("1,8"). Varias → miles ("1,234,567").
+    s = s.split(",").length === 2 ? s.replace(",", ".") : s.replace(/,/g, "");
+  } else if ((s.match(/\./g)?.length ?? 0) > 1) {
+    // Solo puntos, más de uno → todos son separadores de miles ("1.234.567").
+    s = s.replace(/\./g, "");
+  }
+  // Un solo punto (o ninguno): ya está en formato JS.
+
+  const n = Number.parseFloat(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+const nf = (decimals?: number) =>
+  new Intl.NumberFormat("es-CO", {
+    minimumFractionDigits: decimals ?? 0,
+    maximumFractionDigits: decimals ?? 3,
+    useGrouping: false,
+  });
+
+/**
+ * Formatea un número para mostrar con convención es-CO (coma decimal).
+ * `undefined` / `null` / no-número → `fallback` (por defecto "—").
+ * Con `decimals` fija la cantidad exacta de decimales.
+ */
+export function formatDecimal(
+  n: number | null | undefined,
+  decimals?: number,
+  fallback = "—"
+): string {
+  if (n == null || !Number.isFinite(n)) return fallback;
+  return nf(decimals).format(n);
+}
+
+/**
+ * Igual que `formatDecimal` pero pensado para el `value` de un input de
+ * texto: string vacío si no hay número (no "—"), sin agrupar.
+ */
+export function decimalInputValue(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return "";
+  return nf().format(n);
+}

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -52,6 +52,24 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(text).toContain("SERIE-MARCADOR-999");
   });
 
+  it("#68: los decimales del informe usan coma (es-CO), no punto", async () => {
+    const { visita, ubicacion } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.ubicaciones_rx.update(ubicacion.id!, {
+      ancho_m: 2.5,
+      largo_m: 3.2,
+      alto_m: 2.8,
+      area_m2: 8,
+    });
+
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    // La tabla "Dimensiones de la sala" imprime 2,5 m / 3,2 m / 2,8 m con
+    // coma decimal. (No se afirma la ausencia de "2.5" porque el PDF crudo
+    // lleva números con punto en sus estructuras internas.)
+    expect(text).toContain("2,5");
+    expect(text).toContain("3,2");
+    expect(text).toContain("2,8");
+  });
+
   it("equipo sin paquete (no-CONVENCIONAL) también genera el PDF (ruta legacy)", async () => {
     const { visita, equipo } = await seedGraph();
     await db.equipos.update(equipo.id!, { tipo_equipo: "CT" });

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -1,5 +1,6 @@
 import type { jsPDF } from "jspdf";
 import { db } from "@/lib/db";
+import { formatDecimal } from "@/lib/decimal";
 import type {
   VisitaEjecucion,
   Equipo,
@@ -1236,12 +1237,12 @@ export async function generarPreInforme(
           esNoConforme = !conforme;
           if (conforme) {
             conceptoLabel = "FAVORABLE";
-            conceptoParrafo = `El coeficiente de variación del índice de exposición entre pantallas IP fue de ${cv.toFixed(1)} %, dentro del criterio de aceptación establecido.`;
+            conceptoParrafo = `El coeficiente de variación del índice de exposición entre pantallas IP fue de ${formatDecimal(cv, 1)} %, dentro del criterio de aceptación establecido.`;
             accionesTexto =
               "No se requieren acciones correctivas. Se recomienda continuar con el programa de control de calidad establecido.";
           } else {
             conceptoLabel = "NO FAVORABLE";
-            conceptoParrafo = `El coeficiente de variación del índice de exposición entre pantallas IP fue de ${cv.toFixed(1)} %, superando el criterio de aceptación del 10 %.`;
+            conceptoParrafo = `El coeficiente de variación del índice de exposición entre pantallas IP fue de ${formatDecimal(cv, 1)} %, superando el criterio de aceptación del 10 %.`;
             accionesTexto =
               "Se recomienda verificar el estado y la limpieza de las pantallas IP, y repetir la prueba para confirmar el cumplimiento del criterio de uniformidad.";
           }
@@ -1431,10 +1432,10 @@ export async function generarPreInforme(
           body: datos.mediciones.map((m) => [
             String(m.punto_numero),
             m.ubicacion_descripcion || "—",
-            m.tasa_dosis_msv_h != null ? m.tasa_dosis_msv_h.toFixed(5) : "—",
+            formatDecimal(m.tasa_dosis_msv_h, 5),
             m.factor_ocupacion ?? "—",
             m.tipo_area ? m.tipo_area.charAt(0).toUpperCase() + m.tipo_area.slice(1) : "—",
-            m.dosis_anual_msv != null ? m.dosis_anual_msv.toFixed(4) : "—",
+            formatDecimal(m.dosis_anual_msv, 4),
             m.concepto?.replace(/_/g, " ") ?? "—",
           ]),
           theme: "grid",

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1,6 +1,7 @@
 import type { jsPDF } from "jspdf";
 import type autoTableType from "jspdf-autotable";
 import { db } from "@/lib/db";
+import { formatDecimal } from "@/lib/decimal";
 import type { VisitaEjecucion, UbicacionRx } from "@/lib/db/types";
 import type {
   ConvLevantamientoSetup,
@@ -435,7 +436,7 @@ function num(v: number | undefined | null): number {
 }
 
 function fmt(v: number | undefined | null, decimals = 1): string {
-  return v == null ? "—" : v.toFixed(decimals);
+  return formatDecimal(v, decimals);
 }
 
 function capitalizar(s: string | undefined): string {
@@ -510,7 +511,7 @@ function render21(ctx: InformeCtx, visita: VisitaEjecucion, conv: DatosConvencio
         {
           content:
             setup?.fondo_natural_usv_h != null
-              ? (setup.fondo_natural_usv_h / 1000).toFixed(5)
+              ? formatDecimal(setup.fondo_natural_usv_h / 1000, 5)
               : "—",
           colSpan: 3,
           styles: { fontStyle: "normal", fillColor: [255, 255, 255] },
@@ -544,7 +545,7 @@ function render21(ctx: InformeCtx, visita: VisitaEjecucion, conv: DatosConvencio
       body: conv.mediciones.map((m) => [
         String(m.punto_numero),
         m.ubicacion_descripcion || "—",
-        m.tasa_dosis_msv_h != null ? m.tasa_dosis_msv_h.toFixed(5) : "—",
+        m.tasa_dosis_msv_h != null ? formatDecimal(m.tasa_dosis_msv_h, 5) : "—",
       ]),
       columnStyles: { 0: { cellWidth: 14 } },
     });
@@ -606,7 +607,7 @@ function render21(ctx: InformeCtx, visita: VisitaEjecucion, conv: DatosConvencio
         m.ubicacion_descripcion || "—",
         fmt(m.factor_ocupacion_t, 3).replace(/\.?0+$/, "") || "—",
         fmt(m.factor_uso_u, 1),
-        m.dosis_anual_msv != null ? m.dosis_anual_msv.toFixed(6) : "—",
+        m.dosis_anual_msv != null ? formatDecimal(m.dosis_anual_msv, 6) : "—",
         capitalizar(m.tipo_area),
         conceptoLabel(m.concepto),
       ]),
@@ -1092,9 +1093,9 @@ function render22(
   if (ubicacion?.ancho_m || ubicacion?.largo_m || ubicacion?.alto_m) {
     const area =
       ubicacion.area_m2 != null
-        ? `${ubicacion.area_m2.toFixed(2)} m²`
+        ? `${formatDecimal(ubicacion.area_m2, 2)} m²`
         : ubicacion.ancho_m && ubicacion.largo_m
-          ? `${(ubicacion.ancho_m * ubicacion.largo_m).toFixed(2)} m²`
+          ? `${formatDecimal(ubicacion.ancho_m * ubicacion.largo_m, 2)} m²`
           : "—";
     ctx.checkPage(20);
     addCaption(ctx, "Dimensiones de la sala");
@@ -1248,8 +1249,8 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
       label,
       fmt(nom, 0),
       fmt(med, 0),
-      diff.toFixed(1),
-      varPct.toFixed(1) + " %",
+      formatDecimal(diff, 1),
+      formatDecimal(varPct, 1) + " %",
       "< 2 %",
       concepto,
     ];
@@ -1285,7 +1286,7 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
         "",
         "",
         "",
-        totalVar.toFixed(1) + " %",
+        formatDecimal(totalVar, 1) + " %",
         "< 4 %",
         conceptoTotal,
       ],
@@ -1342,7 +1343,7 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
   // .5 Análisis — texto auto-generado según la fórmula del Excel
   ctx.addSubsectionTitle("2.3.5.", "Análisis");
 
-  const totalVarStr = totalVar.toFixed(0);
+  const totalVarStr = formatDecimal(totalVar, 0);
   let analisisTexto: string;
   if (conceptoTotal === "Conforme" && perpConcepto === "Conforme") {
     analisisTexto = `Los resultados obtenidos evidencian que la coincidencia entre el campo luminoso y el campo de radiación cumple con los criterios de aceptación establecidos, ya que las desviaciones individuales fueron inferiores al 2 % y la desviación total fue de ${totalVarStr} %. Adicionalmente, la perpendicularidad del rayo central presentó una desviación angular menor o igual a 3°, por lo que la prueba se considera conforme.`;
@@ -1419,11 +1420,11 @@ function render24(ctx: InformeCtx, conv: DatosConvencional): number {
       const std = stdDev(medidos);
       const cv = prom > 0 ? (std / prom) * 100 : 0;
       return [
-        nom.toFixed(5).replace(/\.?0+$/, ""),
-        prom.toFixed(3),
-        desv.toFixed(2) + " %",
-        std.toFixed(5),
-        cv.toFixed(2) + " %",
+        formatDecimal(nom),
+        formatDecimal(prom, 3),
+        formatDecimal(desv, 2) + " %",
+        formatDecimal(std, 5),
+        formatDecimal(cv, 2) + " %",
         desv <= 10 && cv <= 10 ? "Conforme" : "No conforme",
       ];
     });
@@ -1465,7 +1466,7 @@ function render24(ctx: InformeCtx, conv: DatosConvencional): number {
   const maxCv = Math.max(...rows.map((r) => parseFloat(r[4])));
   if (todosConformes) {
     ctx.addParagraph(
-      `Los resultados obtenidos evidencian que el tiempo de exposición medido presenta desviaciones máximas de hasta ${maxDv.toFixed(2)} % respecto al valor seleccionado. Asimismo, la repetibilidad de las mediciones presenta coeficientes de variación máximos de ${maxCv.toFixed(2)} %, lo que indica una adecuada estabilidad del sistema de temporización del generador de rayos X para los tiempos de exposición evaluados.`
+      `Los resultados obtenidos evidencian que el tiempo de exposición medido presenta desviaciones máximas de hasta ${formatDecimal(maxDv, 2)} % respecto al valor seleccionado. Asimismo, la repetibilidad de las mediciones presenta coeficientes de variación máximos de ${formatDecimal(maxCv, 2)} %, lo que indica una adecuada estabilidad del sistema de temporización del generador de rayos X para los tiempos de exposición evaluados.`
     );
   } else {
     ctx.addParagraph(
@@ -1503,11 +1504,11 @@ function render25(ctx: InformeCtx, conv: DatosConvencional): number {
       const std = stdDev(medidos);
       const cv = prom > 0 ? (std / prom) * 100 : 0;
       return [
-        nom.toFixed(0),
-        prom.toFixed(1),
-        desv.toFixed(2) + " %",
-        std.toFixed(2),
-        cv.toFixed(2) + " %",
+        formatDecimal(nom, 0),
+        formatDecimal(prom, 1),
+        formatDecimal(desv, 2) + " %",
+        formatDecimal(std, 2),
+        formatDecimal(cv, 2) + " %",
         desv <= 10 && cv <= 5 ? "Conforme" : "No conforme",
       ];
     });
@@ -1549,7 +1550,7 @@ function render25(ctx: InformeCtx, conv: DatosConvencional): number {
   const maxCv = Math.max(...rows.map((r) => parseFloat(r[4])));
   if (todosConformes) {
     ctx.addParagraph(
-      `Los resultados obtenidos evidencian que la tensión del tubo medida presenta desviaciones máximas de hasta ${maxDv.toFixed(2)} % respecto al valor seleccionado. Asimismo, la repetibilidad de las mediciones presenta coeficientes de variación máximos de ${maxCv.toFixed(2)} %, lo que indica una adecuada estabilidad en la respuesta del generador de rayos X para los valores de tensión evaluados.`
+      `Los resultados obtenidos evidencian que la tensión del tubo medida presenta desviaciones máximas de hasta ${formatDecimal(maxDv, 2)} % respecto al valor seleccionado. Asimismo, la repetibilidad de las mediciones presenta coeficientes de variación máximos de ${formatDecimal(maxCv, 2)} %, lo que indica una adecuada estabilidad en la respuesta del generador de rayos X para los valores de tensión evaluados.`
     );
   } else {
     ctx.addParagraph(
@@ -1584,7 +1585,7 @@ function render26(ctx: InformeCtx, conv: DatosConvencional): number {
       const chrProm = mean(ms.map((m) => m.chr_medido_mmal!));
       const chrMin = CHR_MIN[kv] ?? "—";
       const concepto = typeof chrMin === "number" && chrProm >= chrMin ? "Conforme" : "No conforme";
-      return [kv.toFixed(0), chrProm.toFixed(1), String(chrMin), concepto];
+      return [formatDecimal(kv, 0), formatDecimal(chrProm, 1), String(chrMin), concepto];
     });
 
   ctx.checkPage(36);
@@ -1661,10 +1662,10 @@ export function renderTablaBaseRef29(ctx: InformeCtx, conv: DatosConvencional) {
     head: [["Tensión (kVp)", "Carga (mAs)", "EI", "D.I."]],
     body: [
       [
-        kv != null ? kv.toFixed(1) : "—",
-        mas != null ? mas.toFixed(1) : "—",
+        kv != null ? formatDecimal(kv, 1) : "—",
+        mas != null ? formatDecimal(mas, 1) : "—",
         eiBase != null ? String(eiBase) : "—",
-        diBase != null ? diBase.toFixed(2) : "NA",
+        diBase != null ? formatDecimal(diBase, 2) : "NA",
       ],
     ],
   });
@@ -1728,10 +1729,10 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
       if (linPct != null && linPct > linMaxPct) linMaxPct = linPct;
       prevRend = rend;
       return [
-        mas.toFixed(1),
-        kermaProm.toFixed(3),
-        rend.toFixed(1),
-        linPct != null ? linPct.toFixed(2) + " %" : "-%",
+        formatDecimal(mas, 1),
+        formatDecimal(kermaProm, 3),
+        formatDecimal(rend, 1),
+        linPct != null ? formatDecimal(linPct, 2) + " %" : "-%",
       ];
     });
 
@@ -1787,7 +1788,7 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   if (repShots.length > 0) {
     const rowsIndiv: string[][] = repShots.map((m, i) => [
       String(i + 1),
-      m.dosis_medida_mgy!.toFixed(4),
+      formatDecimal(m.dosis_medida_mgy!, 4),
     ]);
 
     ctx.checkPage(40);
@@ -1798,9 +1799,9 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
       head: [["Medición", "Kerma en aire medido (mGy)"]],
       body: [
         ...rowsIndiv,
-        ["Promedio", promRep.toFixed(4)],
-        ["Desviación estándar (mGy)", stdRep.toFixed(4)],
-        ["CV(%)", cvRep.toFixed(2) + " %"],
+        ["Promedio", formatDecimal(promRep, 4)],
+        ["Desviación estándar (mGy)", formatDecimal(stdRep, 4)],
+        ["CV(%)", formatDecimal(cvRep, 2) + " %"],
       ],
       columnStyles: {
         0: { cellWidth: 60, fontStyle: "bold", fillColor: COLOR_ALT_ROW },
@@ -1824,10 +1825,10 @@ function render27(ctx: InformeCtx, conv: DatosConvencional): number {
   const rendMin = allRends.length > 0 ? Math.min(...allRends) : 0;
   const rendMax = allRends.length > 0 ? Math.max(...allRends) : 0;
 
-  const cvStr = cvRep.toFixed(2).replace(".", ",");
-  const linStr = linMaxPct.toFixed(2).replace(".", ",");
-  const rMinStr = rendMin.toFixed(1).replace(".", ",");
-  const rMaxStr = rendMax.toFixed(1).replace(".", ",");
+  const cvStr = formatDecimal(cvRep, 2);
+  const linStr = formatDecimal(linMaxPct, 2);
+  const rMinStr = formatDecimal(rendMin, 1);
+  const rMaxStr = formatDecimal(rendMax, 1);
 
   if (conformeRep && conformeLin) {
     ctx.addParagraph(
@@ -1877,11 +1878,11 @@ function render28(ctx: InformeCtx, conv: DatosConvencional): number {
     const dapNom = m.dap_nominal;
     const fc = dapNom != null && dapNom > 0 ? dapEst / dapNom : null;
     return {
-      kv: kvNom != null ? kvNom.toFixed(1) : "—",
-      mas: masNom != null ? masNom.toFixed(1) : "—",
-      dapNom: dapNom != null ? dapNom.toFixed(0) : "—",
-      dapEst: dapEst > 0 ? dapEst.toFixed(2) : "—",
-      fc: fc != null ? fc.toFixed(1) : "—",
+      kv: kvNom != null ? formatDecimal(kvNom, 1) : "—",
+      mas: masNom != null ? formatDecimal(masNom, 1) : "—",
+      dapNom: dapNom != null ? formatDecimal(dapNom, 0) : "—",
+      dapEst: dapEst > 0 ? formatDecimal(dapEst, 2) : "—",
+      fc: fc != null ? formatDecimal(fc, 1) : "—",
     };
   });
 
@@ -1973,14 +1974,14 @@ function render29(ctx: InformeCtx, conv: DatosConvencional): number {
         "EI",
         ei != null ? String(ei) : "—",
         eiBase != null ? String(eiBase) : "—",
-        eiDev != null ? `${eiDev.toFixed(1)}%` : "—",
+        eiDev != null ? `${formatDecimal(eiDev, 1)}%` : "—",
         eiConf,
       ],
       [
         "D.I.",
-        di != null ? di.toFixed(2) : "NA",
-        diBase != null ? diBase.toFixed(2) : "NA",
-        diDev != null ? `${diDev.toFixed(1)}%` : "NA",
+        di != null ? formatDecimal(di, 2) : "NA",
+        diBase != null ? formatDecimal(diBase, 2) : "NA",
+        diDev != null ? `${formatDecimal(diDev, 1)}%` : "NA",
         diConf,
       ],
     ],
@@ -2034,16 +2035,16 @@ function render210(ctx: InformeCtx, conv: DatosConvencional): number {
     body: [
       [
         "EI",
-        eiAvg != null ? eiAvg.toFixed(1) : "—",
-        eiStd != null ? eiStd.toFixed(2) : "—",
-        eiCv != null ? eiCv.toFixed(1) : "—",
+        eiAvg != null ? formatDecimal(eiAvg, 1) : "—",
+        eiStd != null ? formatDecimal(eiStd, 2) : "—",
+        eiCv != null ? formatDecimal(eiCv, 1) : "—",
         eiConf,
       ],
       [
         "D.I.",
-        diAvg != null ? diAvg.toFixed(2) : "—",
-        diStd != null ? diStd.toFixed(2) : "—",
-        diCv != null ? diCv.toFixed(1) : "—",
+        diAvg != null ? formatDecimal(diAvg, 2) : "—",
+        diStd != null ? formatDecimal(diStd, 2) : "—",
+        diCv != null ? formatDecimal(diCv, 1) : "—",
         diConf,
       ],
     ],
@@ -2200,7 +2201,7 @@ function render212(ctx: InformeCtx, conv: DatosConvencional): number {
     body: [
       [
         "Cantidad de pares de líneas visibles (pl/mm)",
-        plmm != null ? `${plmm.toFixed(1)} pl/mm` : "—",
+        plmm != null ? `${formatDecimal(plmm, 1)} pl/mm` : "—",
       ],
     ],
     headStyles: { ...TABLE_STYLE.headStyles, halign: "center" as const },
@@ -2267,11 +2268,11 @@ function render211(ctx: InformeCtx, conv: DatosConvencional): number {
         const uniformidad =
           i === 0 || center == null || vmp == null
             ? "—"
-            : `${(Math.abs((vmp - center) / center) * 100).toFixed(2)} %`;
+            : `${formatDecimal(Math.abs((vmp - center) / center) * 100, 2)} %`;
         return [
           label,
-          vmp != null ? vmp.toFixed(2) : "—",
-          desv != null ? desv.toFixed(2) : "—",
+          vmp != null ? formatDecimal(vmp, 2) : "—",
+          desv != null ? formatDecimal(desv, 2) : "—",
           uniformidad,
         ];
       });
@@ -2320,7 +2321,7 @@ function render211(ctx: InformeCtx, conv: DatosConvencional): number {
       parrafo =
         `En la evaluación de uniformidad y artefactos del detector no se evidencian píxeles defectuosos en el detector ` +
         `ni artefactos en la imagen. El valor máximo de desviación de uniformidad obtenido fue de ` +
-        `${maxGlobal != null ? maxGlobal.toFixed(2) : "—"} %, el cual se encuentra dentro de la tolerancia establecida de ${tolerancia} %. ` +
+        `${maxGlobal != null ? formatDecimal(maxGlobal, 2) : "—"} %, el cual se encuentra dentro de la tolerancia establecida de ${tolerancia} %. ` +
         `En consecuencia, la prueba cumple con el criterio de aceptación.`;
     } else {
       const partes: string[] = [];
@@ -2329,7 +2330,7 @@ function render211(ctx: InformeCtx, conv: DatosConvencional): number {
       if (det.artefactos) partes.push("se observaron artefactos en la imagen");
       if (!unifConforme && maxGlobal != null)
         partes.push(
-          `el valor máximo de desviación de uniformidad obtenido fue de ${maxGlobal.toFixed(2)} %, superior a la tolerancia establecida de ${tolerancia} %`
+          `el valor máximo de desviación de uniformidad obtenido fue de ${formatDecimal(maxGlobal, 2)} %, superior a la tolerancia establecida de ${tolerancia} %`
         );
       parrafo =
         `En la evaluación de uniformidad y artefactos del detector, ` +
@@ -2477,13 +2478,13 @@ function render216(ctx: InformeCtx, conv: DatosConvencional): number {
     body: [
       [
         "Horizontal",
-        m.mtf50_horizontal != null ? m.mtf50_horizontal.toFixed(3) : "—",
-        m.mtf20_horizontal != null ? m.mtf20_horizontal.toFixed(3) : "—",
+        m.mtf50_horizontal != null ? formatDecimal(m.mtf50_horizontal, 3) : "—",
+        m.mtf20_horizontal != null ? formatDecimal(m.mtf20_horizontal, 3) : "—",
       ],
       [
         "Vertical",
-        m.mtf50_vertical != null ? m.mtf50_vertical.toFixed(3) : "—",
-        m.mtf20_vertical != null ? m.mtf20_vertical.toFixed(3) : "—",
+        m.mtf50_vertical != null ? formatDecimal(m.mtf50_vertical, 3) : "—",
+        m.mtf20_vertical != null ? formatDecimal(m.mtf20_vertical, 3) : "—",
       ],
     ],
     didDrawPage: undefined,
@@ -2518,11 +2519,11 @@ function render216(ctx: InformeCtx, conv: DatosConvencional): number {
 
   if (conforme === true) {
     addParagraph(
-      `Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, consistente con el desempeño esperado para detectores digitales de radiografía. La variación máxima respecto a los valores de referencia fue de ${maxDesv!.toFixed(1)} %, dentro del criterio de aceptación del 10 %. Los valores obtenidos no evidencian degradaciones significativas del sistema.`
+      `Las curvas de MTF obtenidas presentan un comportamiento decreciente con el aumento de la frecuencia espacial, consistente con el desempeño esperado para detectores digitales de radiografía. La variación máxima respecto a los valores de referencia fue de ${formatDecimal(maxDesv!, 1)} %, dentro del criterio de aceptación del 10 %. Los valores obtenidos no evidencian degradaciones significativas del sistema.`
     );
   } else if (conforme === false) {
     addParagraph(
-      `Las curvas de MTF obtenidas presentan variaciones respecto a los valores de referencia que superan el criterio de aceptación del 10 % (variación máxima: ${maxDesv!.toFixed(1)} %). Esto podría indicar una degradación en la capacidad del sistema para reproducir detalles espaciales, requiriendo verificación adicional del detector.`
+      `Las curvas de MTF obtenidas presentan variaciones respecto a los valores de referencia que superan el criterio de aceptación del 10 % (variación máxima: ${formatDecimal(maxDesv!, 1)} %). Esto podría indicar una degradación en la capacidad del sistema para reproducir detalles espaciales, requiriendo verificación adicional del detector.`
     );
   } else {
     addParagraph(
@@ -2555,10 +2556,10 @@ function render215(ctx: InformeCtx, conv: DatosConvencional): number {
     body: filas.map((u, i) => [
       i + 1,
       u.serie_cassette ?? "—",
-      u.carga_mas != null ? u.carga_mas.toFixed(1) : "—",
-      u.ei != null ? u.ei.toFixed(1) : "—",
-      u.di != null ? u.di.toFixed(2) : "—",
-      u.tei != null ? u.tei.toFixed(1) : "—",
+      u.carga_mas != null ? formatDecimal(u.carga_mas, 1) : "—",
+      u.ei != null ? formatDecimal(u.ei, 1) : "—",
+      u.di != null ? formatDecimal(u.di, 2) : "—",
+      u.tei != null ? formatDecimal(u.tei, 1) : "—",
     ]),
     startY: ctx.y,
   });
@@ -2580,9 +2581,9 @@ function render215(ctx: InformeCtx, conv: DatosConvencional): number {
     return 6;
   }
 
-  const cvStr = cv != null ? `${cv.toFixed(1)} %` : "—";
-  const promedioStr = promedioEi.toFixed(1);
-  const desvStr = desvEi != null ? desvEi.toFixed(1) : "—";
+  const cvStr = cv != null ? `${formatDecimal(cv, 1)} %` : "—";
+  const promedioStr = formatDecimal(promedioEi, 1);
+  const desvStr = desvEi != null ? formatDecimal(desvEi, 1) : "—";
 
   if (cv != null && cv <= 10) {
     addParagraph(
@@ -2669,7 +2670,7 @@ function render217(ctx: InformeCtx, conv: DatosConvencional): number {
   }
 
   function fmtPct(v: number | null) {
-    return v == null ? "—" : `${(v * 100).toFixed(1)} %`;
+    return v == null ? "—" : `${formatDecimal(v * 100, 1)} %`;
   }
 
   // Condiciones generales
@@ -2767,7 +2768,7 @@ function render218(ctx: InformeCtx, conv: DatosConvencional): number {
   const { addParagraph, addSubsectionTitle, checkPage, autoTable, doc } = ctx;
 
   function fmtPct(v: number | null) {
-    return v == null ? "—" : `${(v * 100).toFixed(1)} %`;
+    return v == null ? "—" : `${formatDecimal(v * 100, 1)} %`;
   }
 
   function rangeVar(arr: number[]): number | null {
@@ -2857,7 +2858,7 @@ function render219(ctx: InformeCtx, conv: DatosConvencional): number {
   }
 
   function fmtPct(v: number | null) {
-    return v == null ? "—" : `${(v * 100).toFixed(2)} %`;
+    return v == null ? "—" : `${formatDecimal(v * 100, 2)} %`;
   }
 
   // Tomas 3, 9, 10, 11, 12 (5 repeticiones 70kVp, Cu 1mm, Centro)
@@ -2947,7 +2948,7 @@ function render220(ctx: InformeCtx, conv: DatosConvencional): number {
   }
 
   function fmtPct(v: number | null) {
-    return v == null ? "—" : `${(v * 100).toFixed(1)} %`;
+    return v == null ? "—" : `${formatDecimal(v * 100, 1)} %`;
   }
 
   const byToma = new Map(conv.caeMediciones.map((m) => [m.toma_numero, m]));
@@ -3103,9 +3104,9 @@ function render221(ctx: InformeCtx, conv: DatosConvencional): number {
       m.programa_clinico ?? "—",
       fmt(m.kv_nominal, 0),
       fmt(m.mas_nominal),
-      m.dosis_medida_mgy != null ? m.dosis_medida_mgy.toFixed(5) : "—",
+      m.dosis_medida_mgy != null ? formatDecimal(m.dosis_medida_mgy, 5) : "—",
       "1",
-      dosisR != null ? dosisR.toFixed(5) : "—",
+      dosisR != null ? formatDecimal(dosisR, 5) : "—",
     ];
   });
 
@@ -3145,9 +3146,9 @@ function render221(ctx: InformeCtx, conv: DatosConvencional): number {
         dosisR != null && m.dosis_base_mgy != null ? Math.abs(dosisR - m.dosis_base_mgy) : null;
       return [
         m.programa_clinico ?? "—",
-        dosisR != null ? dosisR.toFixed(5) : "—",
-        m.dosis_base_mgy != null ? m.dosis_base_mgy.toFixed(5) : "—",
-        diff != null ? diff.toFixed(5) : "—",
+        dosisR != null ? formatDecimal(dosisR, 5) : "—",
+        m.dosis_base_mgy != null ? formatDecimal(m.dosis_base_mgy, 5) : "—",
+        diff != null ? formatDecimal(diff, 5) : "—",
         diff == null ? "—" : diff < 0.01 ? "Conforme" : "No conforme",
       ];
     });

--- a/src/lib/supabase/sync-columns.test.ts
+++ b/src/lib/supabase/sync-columns.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// sync-engine importa `./client` → `@/lib/env` (que lanza sin env vars).
+vi.mock("./client", () => ({ createClient: () => ({}) }));
+
+import {
+  SYNC_TABLES,
+  LOCAL_ONLY_FIELDS,
+  EXTRA_LOCAL_FIELDS,
+  prepareForRemote,
+} from "./sync-engine";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+import { db } from "@/lib/db";
+
+// ============================================================
+//  #39 — guard de columnas: toda columna que el push manda a Supabase
+//  tiene que existir del lado Supabase. `LOCAL_ONLY_FIELDS` /
+//  `EXTRA_LOCAL_FIELDS` se mantienen a mano — si alguien agrega una
+//  columna Dexie que no existe en Supabase y no la clasifica, el push
+//  la envía → PGRST204 / 42703 → la fila va a `failed`.
+//
+//  Este test parsea los tipos generados de Supabase (`Insert` por tabla)
+//  y compara contra lo que `prepareForRemote` produciría para una fila
+//  representativa sembrada por `seedGraph`.
+// ============================================================
+
+/** { tabla → Set<columnas del tipo Insert> } parseado de types.ts */
+function parseSupabaseInsertColumns(): Map<string, Set<string>> {
+  const src = readFileSync(resolve(__dirname, "types.ts"), "utf8");
+  const out = new Map<string, Set<string>>();
+
+  // Bloques:  <indent6>tabla: {  ...  Insert: {  <cols>  };
+  const tableRe = /^ {6}([a-z_][a-z0-9_]*): \{$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = tableRe.exec(src))) {
+    const table = m[1];
+    const rest = src.slice(m.index);
+    const insertStart = rest.indexOf("Insert: {");
+    if (insertStart === -1) continue;
+    const insertBody = rest.slice(insertStart + "Insert: {".length);
+    const end = insertBody.indexOf("\n        };");
+    if (end === -1) continue;
+    const cols = new Set<string>();
+    for (const line of insertBody.slice(0, end).split("\n")) {
+      const cm = line.match(/^\s{10}([a-z_][a-z0-9_]*)\??:/);
+      if (cm) cols.add(cm[1]);
+    }
+    if (cols.size > 0) out.set(table, cols);
+  }
+  return out;
+}
+
+const supaCols = parseSupabaseInsertColumns();
+
+// Tablas que `seedGraph` produce con una fila representativa.
+const SEEDED = [
+  "clientes",
+  "contactos",
+  "sedes",
+  "ubicaciones_rx",
+  "equipos",
+  "tubos",
+  "solicitudes",
+  "visitas",
+] as const;
+
+describe("sync — parseo de columnas Supabase (sanity)", () => {
+  it("encuentra las tablas de sync principales en types.ts con columnas", () => {
+    for (const t of SEEDED) {
+      expect(supaCols.get(t), `types.ts sin Insert para "${t}"`).toBeTruthy();
+      expect((supaCols.get(t) as Set<string>).size).toBeGreaterThan(2);
+    }
+  });
+});
+
+describe("#39 — toda columna pusheada existe en Supabase", () => {
+  it("las filas de seedGraph no envían columnas desconocidas ni sin clasificar", async () => {
+    await resetTestDb();
+    const g = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+
+    const asRow = (o: unknown) => o as Record<string, unknown> | undefined;
+    const rows: Record<string, Record<string, unknown> | undefined> = {
+      clientes: asRow(g.cliente),
+      sedes: asRow(g.sede),
+      ubicaciones_rx: asRow(g.ubicacion),
+      equipos: asRow(g.equipo),
+      tubos: asRow(g.tubo),
+      solicitudes: asRow(g.solicitud),
+      visitas: asRow(g.visita),
+      contactos: asRow(
+        (await db.contactos.where("cliente_id").equals(g.cliente.id!).first()) ?? undefined
+      ),
+    };
+
+    const problemas: string[] = [];
+
+    for (const { local } of SYNC_TABLES) {
+      if (!SEEDED.includes(local as (typeof SEEDED)[number])) continue;
+      const row = rows[local];
+      if (!row) continue;
+      const remota = supaCols.get(local);
+      if (!remota) continue;
+
+      const enviadas = Object.keys(prepareForRemote(row, local));
+      for (const col of enviadas) {
+        if (!remota.has(col)) {
+          problemas.push(
+            `${local}.${col} — el push la manda pero no existe en Supabase. ` +
+              `Agregala a LOCAL_ONLY_FIELDS/EXTRA_LOCAL_FIELDS o a la tabla remota.`
+          );
+        }
+      }
+    }
+
+    expect(problemas, problemas.join("\n")).toEqual([]);
+  });
+
+  it("LOCAL_ONLY_FIELDS y EXTRA_LOCAL_FIELDS siguen exportados (no romper el guard)", () => {
+    expect(LOCAL_ONLY_FIELDS.has("blob_local")).toBe(true);
+    expect(EXTRA_LOCAL_FIELDS.solicitudes).toContain("suitecrm_id");
+  });
+});

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -116,7 +116,7 @@ function describeError(err: unknown): { message: string; detail?: string } {
 
 // Campos que solo existen en Dexie y NUNCA se envían a Supabase.
 // blob_local y archivo_raysafe_blob: datos binarios que van a Storage por separado.
-const LOCAL_ONLY_FIELDS = new Set([
+export const LOCAL_ONLY_FIELDS = new Set([
   "sync_status",
   "last_modified",
   "blob_local",
@@ -124,7 +124,7 @@ const LOCAL_ONLY_FIELDS = new Set([
 ]);
 
 // Campos extra por tabla que existen en Dexie pero no en Supabase
-const EXTRA_LOCAL_FIELDS: Record<string, string[]> = {
+export const EXTRA_LOCAL_FIELDS: Record<string, string[]> = {
   solicitudes: ["suitecrm_id"],
   prueba_resultados: [
     "grupo_resultado_id",
@@ -205,7 +205,7 @@ async function ensureBlobUploaded(
 }
 
 /** Prepara un registro Dexie para enviar a Supabase (quita campos locales) */
-function prepareForRemote(
+export function prepareForRemote(
   record: Record<string, unknown>,
   localTable: string
 ): Record<string, unknown> {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1281,6 +1281,9 @@ export type Database = {
           gen_marca: string | null;
           gen_modelo: string | null;
           gen_numero_serie: string | null;
+          marca: string | null;
+          modelo: string | null;
+          numero_serie: string | null;
           id: string;
           last_modified: string;
           planilla_espacial: boolean;
@@ -1301,6 +1304,9 @@ export type Database = {
           gen_marca?: string | null;
           gen_modelo?: string | null;
           gen_numero_serie?: string | null;
+          marca?: string | null;
+          modelo?: string | null;
+          numero_serie?: string | null;
           id?: string;
           last_modified?: string;
           planilla_espacial?: boolean;
@@ -1321,6 +1327,9 @@ export type Database = {
           gen_marca?: string | null;
           gen_modelo?: string | null;
           gen_numero_serie?: string | null;
+          marca?: string | null;
+          modelo?: string | null;
+          numero_serie?: string | null;
           id?: string;
           last_modified?: string;
           planilla_espacial?: boolean;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -80,6 +80,8 @@ export default defineConfig({
         // #67 — subida y resolución de imágenes. compressImage (canvas) y la
         // rama de signed URL no corren en happy-dom → floor conservador.
         "src/lib/supabase/storage.ts": { lines: 42, functions: 75, branches: 45 },
+        // #68 — estándar decimal es-CO. parseDecimal / formatDecimal.
+        "src/lib/decimal.ts": { lines: 95, functions: 100, branches: 90 },
         "src/components/manual-drawer.tsx": { lines: 92, functions: 75, branches: 88 },
         "src/components/visit-action-bar.tsx": { lines: 85, functions: 85, branches: 72 },
         "src/components/visita-modulos/**": { lines: 33, functions: 15, branches: 16 },


### PR DESCRIPTION
## Contexto

Paquete B del plan de corrección E2E. Resuelve **#68** (estándar de separador decimal) y **#39** (guard de columnas de sync, que venía del Paquete A).

## El problema (#68)

En Colombia el separador decimal es la **coma** ("1,8 mm Al", no "1.8"). La app no tenía una regla:
- Los `<input type="number">` se comportan distinto según el locale del navegador/tablet; varios sitios hacían `parseFloat("1,8")` → **1** (se pierde el decimal en silencio), sobre valores medidos que definen la conformidad.
- El PDF siempre imprimía con punto, mientras el estudio manual usa coma → al comparar, una diferencia de formato se confunde con diferencia de valor.

## Cómo se resuelve

Regla única: **la base guarda `number` (punto, neutro); todo lo que ve un humano —informe y UI— usa coma; la entrada acepta cualquiera de los dos.**

| Pieza | Qué |
|---|---|
| `src/lib/decimal.ts` (nuevo) | `parseDecimal(str)` — acepta `"1,8"` y `"1.8"` (y miles `"1.234,56"` / `"1,234.56"`), devuelve `number \| undefined`. `formatDecimal(n, decimales?)` / `decimalInputValue(n)` con `Intl.NumberFormat("es-CO")`. |
| `src/components/ui/number-input.tsx` (nuevo) | `<NumberInput>` — reemplazo de `<input type="number">`: `inputMode="decimal"` (teclado numérico en tablet), muestra coma, `onValueChange` entrega un `number` ya normalizado (nunca un string a medio parsear). |
| PDF | `fmt()` y ~90 `.toFixed()` inline en `secciones-convencional.ts` + `generar-pre-informe.ts` → `formatDecimal` (coma). Test de contrato: los decimales del informe salen con coma. |
| Captura | `parseFloat(e.target.value)` / `parseFloat(v)` → `parseDecimal` en los 5 módulos de grupo, `info-modulo` (save helpers) y los form-dialogs de equipo/ubicación. `EditableField` de `info-modulo` muestra los numéricos con coma (`type=text` + `inputMode=decimal`). |

## #39 — guard de columnas

`src/lib/supabase/sync-columns.test.ts`: parsea los tipos `Insert` por tabla de `src/lib/supabase/types.ts` y falla si `prepareForRemote` mandaría una columna que no existe del lado Supabase (sin clasificar en `LOCAL_ONLY_FIELDS` / `EXTRA_LOCAL_FIELDS`). Se exportan esos tres símbolos de `sync-engine.ts`.

**El guard ya encontró algo:** `types.ts` estaba desactualizado respecto a la migración `014` — `equipos.marca` / `modelo` / `numero_serie` faltaban en el tipo generado (existen en la DB). Se agregaron a `types.ts`.

## Verificación

`npm run verify` limpio: typecheck, lint (0 errores), format, **564 tests**, build.

## Cómo probar (después de mergear)

Ver el mensaje siguiente en el hilo.

## Pendiente / follow-up

- Los form-dialogs de equipo/ubicación siguen con `<Input type="number">` en el markup (el bug de corrupción ya está muerto por `parseDecimal` en el save). Migrarlos a `<NumberInput>` es polish, va cuando el Paquete D toque esos diálogos.
- Placeholders sin unificar a coma — cosmético.
