### PR TITLE
fix(informe): Paquete C — logo tolerante a fallo, licencia "No aplica", sistema de adquisición como lista (#52, #60, #62)

### DIFF
--- a/src/components/equipo-form-dialog.tsx
+++ b/src/components/equipo-form-dialog.tsx
@@ -7,7 +7,7 @@ import type { Equipo, Tubo, Colimador, Gantry } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
 import { parseDecimal } from "@/lib/decimal";
 import { pushSingle } from "@/lib/supabase/sync-engine";
-import { TIPOS_EQUIPO, type TipoEquipo } from "@/lib/db/types";
+import { TIPOS_EQUIPO, SISTEMAS_ADQUISICION, type TipoEquipo } from "@/lib/db/types";
 import {
   Dialog,
   DialogContent,
@@ -401,16 +401,11 @@ export function EquipoFormDialog({
                     <SelectValue placeholder="Seleccionar..." />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="Digital">Digital</SelectItem>
-                    <SelectItem value="Digitalizado">Digitalizado</SelectItem>
-                    <SelectItem value="Análogo: Revelado manual">
-                      Análogo: Revelado manual
-                    </SelectItem>
-                    <SelectItem value="Análogo: Revelado automático">
-                      Análogo: Revelado automático
-                    </SelectItem>
-                    <SelectItem value="Monitor análogo">Monitor análogo</SelectItem>
-                    <SelectItem value="No Aplica">No Aplica</SelectItem>
+                    {SISTEMAS_ADQUISICION.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>
+                        {o.label}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -5,6 +5,7 @@ import { randomUUID } from "@/lib/uuid";
 import { parseDecimal, decimalInputValue } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
+import { SISTEMAS_ADQUISICION } from "@/lib/db/types";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { pushSingle } from "@/lib/supabase/sync-engine";
@@ -1017,9 +1018,10 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             ]}
             onSave={(v) => saveEquipo("bucky", v)}
           />
-          <EditableField
+          <SelectField
             label="Sistema de Adquisición de Imágenes"
             value={toStr(equipo?.sistema_adquisicion)}
+            options={SISTEMAS_ADQUISICION.map((o) => ({ label: o.label, value: o.value }))}
             onSave={(v) => saveEquipo("sistema_adquisicion", v)}
           />
           <EditableField

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -73,3 +73,22 @@ describe("visita-modulos — smoke", () => {
     });
   });
 });
+
+describe("InfoModulo — Sistema de Adquisición de Imágenes (#62)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+  });
+  afterEach(() => cleanup());
+
+  it("es una lista desplegable con el vocabulario cerrado del informe, no texto libre", async () => {
+    const { visita } = await seedGraph();
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    // Las 6 opciones de SISTEMAS_ADQUISICION quedan como <option> del <select>.
+    expect(screen.getByRole("option", { name: "Digitalizado" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Análogo: Revelado manual" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Monitor análogo" })).toBeInTheDocument();
+  });
+});

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -75,6 +75,19 @@ export const TIPOS_EQUIPO = [
 ] as const;
 export type TipoEquipo = (typeof TIPOS_EQUIPO)[number];
 
+// ─── Sistema de adquisición de imágenes ───
+// Opciones cerradas del informe FT-LEC-6c. Compartidas entre el diálogo de
+// creación de equipo y el módulo de Información General para que la captura
+// use siempre el mismo vocabulario que espera el PDF.
+export const SISTEMAS_ADQUISICION = [
+  { label: "Digital", value: "Digital" },
+  { label: "Digitalizado", value: "Digitalizado" },
+  { label: "Análogo: Revelado manual", value: "Análogo: Revelado manual" },
+  { label: "Análogo: Revelado automático", value: "Análogo: Revelado automático" },
+  { label: "Monitor análogo", value: "Monitor análogo" },
+  { label: "No Aplica", value: "No Aplica" },
+] as const;
+
 // ─── Núcleo ───
 
 export interface Cliente extends Partial<SyncFields> {

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -1,18 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // getLogoBase64 hace fetch("/logo-informe.png") — se mockea con un PNG mínimo.
-vi.stubGlobal(
-  "fetch",
-  vi.fn().mockResolvedValue({
+function okPngFetch() {
+  return vi.fn().mockResolvedValue({
+    ok: true,
     blob: async () =>
       new Blob([new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])], { type: "image/png" }),
-  })
-);
+  });
+}
+vi.stubGlobal("fetch", okPngFetch());
 
 import { db } from "@/lib/db";
 import { resetTestDb } from "@/test/db-reset";
 import { seedGraph } from "@/test/seed";
-import { generarPreInforme } from "./generar-pre-informe";
+import {
+  generarPreInforme,
+  getLogoBase64,
+  resetLogoCache,
+  textoCampo,
+  textoFecha,
+} from "./generar-pre-informe";
 
 // jsPDF no comprime por defecto → el texto dibujado queda legible en el
 // buffer crudo del PDF (operadores `(str) Tj`). Alcanza para tests de
@@ -26,6 +33,8 @@ async function pdfText(blob: Blob): Promise<string> {
 
 beforeEach(async () => {
   await resetTestDb();
+  resetLogoCache();
+  vi.stubGlobal("fetch", okPngFetch());
 });
 
 describe("generarPreInforme — contrato de datos", () => {
@@ -78,11 +87,64 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(blob!.type).toBe("application/pdf");
   });
 
+  it("#52: si falla la carga del logo, el PDF se genera igual (fallback de texto)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    resetLogoCache();
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const blob = await generarPreInforme(visita!.id!);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob!.type).toBe("application/pdf");
+  });
+
+  it("#52: getLogoBase64 resuelve a '' cuando el asset responde 404, sin lanzar", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    resetLogoCache();
+    await expect(getLogoBase64()).resolves.toBe("");
+  });
+
+  it("#60: la fecha de expiración de la licencia sale dd/mm/aaaa en el informe", async () => {
+    const { visita, ubicacion } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.ubicaciones_rx.update(ubicacion.id!, {
+      fecha_expiracion_licencia: "2027-03-15",
+    });
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("15/03/2027");
+  });
+
   it("versión oficial: acepta un qrDataUrl sin romper", async () => {
     const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "aprobada" });
     const qr =
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
     const blob = await generarPreInforme(visita!.id!, { qrDataUrl: qr });
     expect(blob).toBeInstanceOf(Blob);
+  });
+});
+
+describe("#60 — formateo de campos de licencia", () => {
+  it("textoCampo: null / undefined / '' / solo espacios → 'No aplica'", () => {
+    expect(textoCampo(null)).toBe("No aplica");
+    expect(textoCampo(undefined)).toBe("No aplica");
+    expect(textoCampo("")).toBe("No aplica");
+    expect(textoCampo("   ")).toBe("No aplica");
+  });
+
+  it("textoCampo: con contenido devuelve el valor recortado", () => {
+    expect(textoCampo("REPS-123")).toBe("REPS-123");
+    expect(textoCampo("  L-99 ")).toBe("L-99");
+  });
+
+  it("textoFecha: vacío → 'No aplica'", () => {
+    expect(textoFecha(null)).toBe("No aplica");
+    expect(textoFecha(undefined)).toBe("No aplica");
+    expect(textoFecha("")).toBe("No aplica");
+  });
+
+  it("textoFecha: ISO de solo día → dd/mm/aaaa sin correr el día por zona horaria", () => {
+    expect(textoFecha("2027-03-15")).toBe("15/03/2027");
+    expect(textoFecha("2027-03-15T00:00:00Z")).toBe("15/03/2027");
+  });
+
+  it("textoFecha: string no reconocible se devuelve tal cual", () => {
+    expect(textoFecha("no sé")).toBe("no sé");
   });
 });

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -18,6 +18,7 @@ import type {
   ParteEquipo,
 } from "@/lib/db/types";
 import { hasPackage } from "@/lib/equipos/registry";
+import { logger } from "@/lib/logger";
 import { getCatalogoSeccion } from "@/lib/equipos/convencional/informe-secciones";
 import { evaluarConceptoPrueba, tieneCriterio } from "@/lib/equipos/convencional/evaluacion";
 import {
@@ -45,18 +46,58 @@ import {
 
 let _logoCache: string | null = null;
 
-async function getLogoBase64(): Promise<string> {
-  if (_logoCache) return _logoCache;
-  const res = await fetch("/logo-informe.png");
-  const blob = await res.blob();
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      _logoCache = reader.result as string;
-      resolve(_logoCache);
-    };
-    reader.readAsDataURL(blob);
-  });
+/** Vacía el cache del logo. Solo para tests (forzar la ruta de recarga). */
+export function resetLogoCache(): void {
+  _logoCache = null;
+}
+
+/**
+ * Devuelve el logo del informe como data URL. Si el asset no está disponible
+ * (404, sin red, contexto sin `fetch`), devuelve "" y deja que cada
+ * `addImage` caiga en su fallback de texto: un logo faltante nunca debe
+ * impedir generar el PDF. El resultado (incluido el "") se cachea.
+ */
+export async function getLogoBase64(): Promise<string> {
+  if (_logoCache !== null) return _logoCache;
+  try {
+    const res = await fetch("/logo-informe.png");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob = await res.blob();
+    _logoCache = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.onerror = () => reject(reader.error ?? new Error("FileReader"));
+      reader.readAsDataURL(blob);
+    });
+  } catch (err) {
+    logger.warn("pdf", "No se pudo cargar el logo del informe; se usa el texto de reemplazo", err);
+    _logoCache = "";
+  }
+  return _logoCache;
+}
+
+// ─── Formateo de campos del informe ───
+
+/** "No aplica" para null / undefined / "" ; el valor tal cual si tiene contenido. */
+export function textoCampo(v: string | null | undefined, fallback = "No aplica"): string {
+  const s = (v ?? "").trim();
+  return s === "" ? fallback : s;
+}
+
+/**
+ * Fecha en dd/mm/aaaa. "No aplica" si viene vacía. Las fechas ISO de solo
+ * día (`aaaa-mm-dd`) se reformatean sin pasar por `Date` para no correr el
+ * día por la zona horaria; cualquier otro string reconocible se intenta con
+ * `Date`, y si no parsea se devuelve tal cual.
+ */
+export function textoFecha(v: string | null | undefined): string {
+  const s = (v ?? "").trim();
+  if (s === "") return "No aplica";
+  const iso = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (iso) return `${iso[3]}/${iso[2]}/${iso[1]}`;
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  return d.toLocaleDateString("es-CO", { day: "2-digit", month: "2-digit", year: "numeric" });
 }
 
 // ─── Tipos internos ───
@@ -565,13 +606,10 @@ export async function generarPreInforme(
   const datosInstalacion = [
     [
       "Número de la licencia para funcionamiento de equipos de RX",
-      datos.ubicacion?.licencia ?? "No Aplica",
+      textoCampo(datos.ubicacion?.licencia),
     ],
-    [
-      "Fecha de expiración de la licencia",
-      datos.ubicacion?.fecha_expiracion_licencia ?? "No Aplica",
-    ],
-    ["Código de habilitación del servicio", datos.ubicacion?.codigo_habilitacion ?? "—"],
+    ["Fecha de expiración de la licencia", textoFecha(datos.ubicacion?.fecha_expiracion_licencia)],
+    ["Código de habilitación del servicio", textoCampo(datos.ubicacion?.codigo_habilitacion)],
     ["Días Laborados por Semana", String(datos.visita.dias_laborados_semana ?? "—")],
     ["No. de Pacientes por Semana", String(datos.visita.pacientes_por_semana ?? "—")],
     ["KV máximo usado", String(datos.visita.kv_maximo_usado ?? "—")],


### PR DESCRIPTION
Tercer paquete del plan de remediación E2E. Tres arreglos chicos e independientes sobre el módulo de Información General y su informe.

## #52 — un logo faltante ya no rompe el PDF entero
`getLogoBase64()` hacía `fetch("/logo-informe.png")` sin `try/catch`. Si el asset da 404, no hay red, o el contexto no tiene `fetch`, el `Promise.all` de `generarPreInforme` rechazaba y **no se generaba ningún PDF**.

Ahora la función está envuelta: ante cualquier fallo devuelve `""`, loguea un `warn` y cada `doc.addImage(...)` cae en su fallback de texto ("Sievert") que ya existía. El resultado —incluido el `""`— se cachea.

## #60 — licencia / fecha de expiración / código de habilitación
`datos.ubicacion?.licencia ?? "No Aplica"` **no atrapaba el string vacío** `""`: un campo guardado en blanco salía vacío en el informe. Además la fecha se imprimía cruda (`2027-03-15`).

Dos helpers nuevos en `generar-pre-informe.ts`:
- `textoCampo(v)` — `null` / `undefined` / `""` / solo espacios → `"No aplica"`; si no, el valor recortado.
- `textoFecha(v)` — vacío → `"No aplica"`; ISO de solo día → `dd/mm/aaaa` reformateado a mano (no pasa por `Date`, así no corre el día por la zona horaria −5); otro string reconocible → `Date` + `es-CO`; ininteligible → tal cual.

Aplicados a las 3 filas de "Datos de la Instalación".

> **Nota sobre el toggle "Sin fecha de expiración" del plan:** no se agregó. Revisé el código y **ningún path setea una fecha por defecto** en `fecha_expiracion_licencia` (ni `info-modulo`, ni `ubicacion-form-dialog`, ni el servicio de informe — ese `fecha_vencimiento` es la validez del informe, otro campo). El `<input type="date">` ya arranca vacío y se puede limpiar. El problema real era solo el render del PDF. Si en la 2ª pasada aparece una fecha "fantasma", lo reabrimos.

## #62 — sistema de adquisición: de texto libre a lista
En Información General el campo era un `EditableField` de texto libre → cada técnico escribía distinto y el informe recibía basura. Ahora es un `SelectField` con el vocabulario cerrado del informe FT-LEC-6c.

Constante compartida `SISTEMAS_ADQUISICION` en `src/lib/db/types.ts` (6 opciones), usada por `info-modulo` **y** `equipo-form-dialog` — que tenía las mismas 6 opciones hardcodeadas en el JSX.

## Verificación
- `npm run verify` — typecheck + lint (0 errores) + format + **573 tests** + build. Verde.
- Tests nuevos:
  - `generar-pre-informe.test.ts` — PDF se genera con `fetch` del logo caído; `getLogoBase64` → `""` ante 404; fecha de expiración sale `15/03/2027` en el PDF; tabla de `textoCampo` / `textoFecha`.
  - `modulos-smoke.test.tsx` — el sistema de adquisición en `InfoModulo` es un `<select>` con las opciones del informe, no un input de texto.

## Cómo probar
Ver el mensaje siguiente en el hilo — se agrega la sección de Paquete C al runbook de QA.

## Issues
Relacionados: #52, #60, #62. El usuario los cierra manualmente al validarlos con el runbook.