### PR TITLE
feat(informe): Paquete D1 — piso y techo del blindaje (#63)

### DIFF
--- a/src/components/ubicacion-form-dialog.test.tsx
+++ b/src/components/ubicacion-form-dialog.test.tsx
@@ -117,6 +117,34 @@ describe("UbicacionFormDialog", () => {
     expect(todas[0].nombre_servicio).toBe("radiologia");
   });
 
+  it("#63: captura y persiste piso y techo del blindaje", async () => {
+    const ubicacion = await seedUbicacion({ nombre_servicio: "rayos x" });
+    const onSaved = vi.fn();
+
+    render(
+      <UbicacionFormDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        sedeId="sede-1"
+        ubicacion={ubicacion}
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/colindancia inferior/i), {
+      target: { value: "Losa 20cm + Pb 2mm" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/colindancia superior/i), {
+      target: { value: "Cubierta liviana, sin tránsito" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /guardar/i }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith(ubicacion.id));
+    const row = (await db.ubicaciones_rx.get(ubicacion.id!))!;
+    expect(row.piso_desc).toBe("Losa 20cm + Pb 2mm");
+    expect(row.techo_desc).toBe("Cubierta liviana, sin tránsito");
+  });
+
   it("no permite guardar sin nombre de servicio", async () => {
     render(
       <UbicacionFormDialog

--- a/src/components/ubicacion-form-dialog.tsx
+++ b/src/components/ubicacion-form-dialog.tsx
@@ -55,6 +55,8 @@ export function UbicacionFormDialog({
   const [zonaB, setZonaB] = useState(ubicacion?.zona_b_desc ?? "");
   const [zonaC, setZonaC] = useState(ubicacion?.zona_c_desc ?? "");
   const [zonaD, setZonaD] = useState(ubicacion?.zona_d_desc ?? "");
+  const [piso, setPiso] = useState(ubicacion?.piso_desc ?? "");
+  const [techo, setTecho] = useState(ubicacion?.techo_desc ?? "");
   const [saving, setSaving] = useState(false);
 
   // Área = ancho × largo (autocalculada)
@@ -77,6 +79,8 @@ export function UbicacionFormDialog({
     setZonaB(ubicacion?.zona_b_desc ?? "");
     setZonaC(ubicacion?.zona_c_desc ?? "");
     setZonaD(ubicacion?.zona_d_desc ?? "");
+    setPiso(ubicacion?.piso_desc ?? "");
+    setTecho(ubicacion?.techo_desc ?? "");
   }
 
   // El padre controla `open` seteando el prop directamente (no vía
@@ -105,6 +109,8 @@ export function UbicacionFormDialog({
         zona_b_desc: zonaB || undefined,
         zona_c_desc: zonaC || undefined,
         zona_d_desc: zonaD || undefined,
+        piso_desc: piso || undefined,
+        techo_desc: techo || undefined,
         creado_en: now,
         sync_status: "pending",
         last_modified: now,
@@ -300,6 +306,27 @@ export function UbicacionFormDialog({
                   <textarea
                     className="w-full rounded-xl border border-slate-200 p-2.5 text-sm font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
                     placeholder="Limita con… / puertas / barreras"
+                    value={val}
+                    onChange={(e) => setter(e.target.value)}
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {(
+                [
+                  ["Piso", piso, setPiso, "Material / plomo equiv. / colindancia inferior"],
+                  ["Techo", techo, setTecho, "Material / plomo equiv. / colindancia superior"],
+                ] as const
+              ).map(([label, val, setter, ph]) => (
+                <div key={label} className="space-y-2">
+                  <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                    {label}
+                  </Label>
+                  <textarea
+                    className="w-full rounded-xl border border-slate-200 p-2.5 text-sm font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                    placeholder={ph}
                     value={val}
                     onChange={(e) => setter(e.target.value)}
                   />

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -1135,6 +1135,26 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
               ))}
             </div>
           </div>
+
+          <div className="space-y-3 pt-3 border-t border-slate-100">
+            <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+              Piso y techo
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <EditableTextArea
+                label="Piso"
+                value={toStr(ubicacion.piso_desc)}
+                placeholder="Material / plomo equiv. / colindancia inferior"
+                onSave={(v) => saveUbicacion("piso_desc", v)}
+              />
+              <EditableTextArea
+                label="Techo"
+                value={toStr(ubicacion.techo_desc)}
+                placeholder="Material / plomo equiv. / colindancia superior"
+                onSave={(v) => saveUbicacion("techo_desc", v)}
+              />
+            </div>
+          </div>
         </SectionCard>
       )}
     </div>

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -175,6 +175,10 @@ export interface UbicacionRx extends Partial<SyncFields> {
   zona_b_desc?: string;
   zona_c_desc?: string;
   zona_d_desc?: string;
+  /** Barrera estructural del piso (material, plomo equivalente, colindancia inferior) */
+  piso_desc?: string;
+  /** Barrera estructural del techo (material, plomo equivalente, colindancia superior) */
+  techo_desc?: string;
   creado_en?: string;
 }
 

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -87,6 +87,17 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(blob!.type).toBe("application/pdf");
   });
 
+  it("#63: piso y techo del blindaje salen en la tabla de áreas colindantes", async () => {
+    const { visita, ubicacion } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.ubicaciones_rx.update(ubicacion.id!, {
+      piso_desc: "PISO-MARCADOR-63",
+      techo_desc: "TECHO-MARCADOR-63",
+    });
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("PISO-MARCADOR-63");
+    expect(text).toContain("TECHO-MARCADOR-63");
+  });
+
   it("#52: si falla la carga del logo, el PDF se genera igual (fallback de texto)", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
     resetLogoCache();

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -1071,6 +1071,8 @@ function render22(
       ["B", ubicacion?.zona_b_desc],
       ["C", ubicacion?.zona_c_desc],
       ["D", ubicacion?.zona_d_desc],
+      ["Piso", ubicacion?.piso_desc],
+      ["Techo", ubicacion?.techo_desc],
     ] as const
   )
     .filter(([, desc]) => desc?.trim())

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -2315,8 +2315,10 @@ export type Database = {
           last_modified: string;
           licencia: string | null;
           nombre_servicio: string;
+          piso_desc: string | null;
           sede_id: string;
           sync_status: string;
+          techo_desc: string | null;
           ubicacion_fisica: string | null;
           zona_a_desc: string | null;
           zona_b_desc: string | null;
@@ -2336,8 +2338,10 @@ export type Database = {
           last_modified?: string;
           licencia?: string | null;
           nombre_servicio: string;
+          piso_desc?: string | null;
           sede_id: string;
           sync_status?: string;
+          techo_desc?: string | null;
           ubicacion_fisica?: string | null;
           zona_a_desc?: string | null;
           zona_b_desc?: string | null;
@@ -2357,8 +2361,10 @@ export type Database = {
           last_modified?: string;
           licencia?: string | null;
           nombre_servicio?: string;
+          piso_desc?: string | null;
           sede_id?: string;
           sync_status?: string;
+          techo_desc?: string | null;
           ubicacion_fisica?: string | null;
           zona_a_desc?: string | null;
           zona_b_desc?: string | null;

--- a/supabase/migrations/019_ubicacion_piso_techo.sql
+++ b/supabase/migrations/019_ubicacion_piso_techo.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+--  019 — Piso y techo del blindaje en ubicaciones_rx
+--
+--  Contexto (issue #63, pasada de prueba E2E):
+--  El informe FT-LEC-6c describe las barreras estructurales colindantes
+--  (zonas A–D) pero no tenía dónde registrar el piso ni el techo. Se
+--  capturan igual que las zonas (texto libre) y NO intervienen en el
+--  cálculo del área (ancho × largo).
+--
+--  Idempotente: se puede correr más de una vez sin efecto.
+-- ============================================================
+
+ALTER TABLE public.ubicaciones_rx
+  ADD COLUMN IF NOT EXISTS piso_desc  text,
+  ADD COLUMN IF NOT EXISTS techo_desc text;
+
+COMMENT ON COLUMN public.ubicaciones_rx.piso_desc  IS
+  'Barrera estructural del piso (material, plomo equivalente, colindancia inferior).';
+COMMENT ON COLUMN public.ubicaciones_rx.techo_desc IS
+  'Barrera estructural del techo (material, plomo equivalente, colindancia superior).';


### PR DESCRIPTION
Primera parte del Paquete D (se parte en D1 / D2 / D3 como se hizo con A). D1 es el más chico y no depende de nada.

## El problema
El informe FT-LEC-6c describe las barreras estructurales colindantes de la sala (zonas A–D) pero **no tenía dónde registrar el piso ni el techo**. En una instalación de RX esas dos barreras importan tanto como las laterales (colindancia con pisos superior/inferior, plomo equivalente de la losa, etc.).

## La solución
- **Migración `019_ubicacion_piso_techo.sql`** (la corre el dueño): agrega `piso_desc` y `techo_desc` (`text`) a `ubicaciones_rx`. Idempotente.
- **Captura** — dos `EditableTextArea` nuevos en `info-modulo` → "Sala — Dimensiones y Blindaje" (bloque "Piso y techo"), y dos `textarea` en `ubicacion-form-dialog`. Texto libre, igual que las zonas.
- **Informe** — filas `Piso` / `Techo` agregadas a la tabla "Áreas colindantes y barreras estructurales" (`secciones-convencional.ts`). Solo aparecen si tienen contenido (mismo `.filter` que las zonas).
- **`src/lib/supabase/types.ts`** — las 2 columnas en Row/Insert/Update para que el guard #39 y el push queden consistentes.

**No toca** `saveUbicacionDim` ni el cálculo de `area_m2` (sigue siendo `ancho × largo`, el piso/techo no interviene).

## Verificación
- `npm run verify` — typecheck + lint (0 errores) + format + **575 tests** + build. Verde.
- Tests nuevos:
  - `ubicacion-form-dialog.test.tsx` — piso/techo se capturan y persisten en la fila.
  - `generar-pre-informe.test.ts` — los textos de piso/techo llegan al PDF.

## Cómo probar
Ver el mensaje siguiente en el hilo (se agrega la sección D1 al runbook de QA).

## Issue
#63. El usuario lo cierra manualmente al validarlo con el runbook.