### PR TITLE
feat(informe): Paquete D2a — unificar la identidad del equipo en gen_* + energía MeV (#61)

### DIFF
--- a/src/app/dashboard/clientes/[id]/page.tsx
+++ b/src/app/dashboard/clientes/[id]/page.tsx
@@ -567,10 +567,7 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
                                           <div className="min-w-0 flex-1">
                                             <div className="flex items-center gap-2 min-w-0">
                                               <p className="text-sm font-bold text-slate-800 truncate">
-                                                {[
-                                                  equipo.marca ?? equipo.gen_marca,
-                                                  equipo.modelo ?? equipo.gen_modelo,
-                                                ]
+                                                {[equipo.gen_marca, equipo.gen_modelo]
                                                   .filter(Boolean)
                                                   .join(" ") || "Equipo sin marca"}
                                               </p>
@@ -583,8 +580,8 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
                                                 ? (TIPO_EQUIPO_LABELS[equipo.tipo_equipo] ??
                                                   equipo.tipo_equipo)
                                                 : "Tipo no definido"}
-                                              {(equipo.numero_serie ?? equipo.gen_numero_serie)
-                                                ? ` • S/N: ${equipo.numero_serie ?? equipo.gen_numero_serie}`
+                                              {equipo.gen_numero_serie
+                                                ? ` • S/N: ${equipo.gen_numero_serie}`
                                                 : ""}
                                             </p>
                                           </div>
@@ -593,7 +590,7 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
                                               variant="ghost"
                                               size="sm"
                                               className="rounded-lg text-slate-400 hover:text-primary flex-shrink-0"
-                                              aria-label={`Editar equipo ${equipo.marca ?? equipo.gen_marca ?? ""} ${equipo.modelo ?? equipo.gen_modelo ?? ""}`}
+                                              aria-label={`Editar equipo ${equipo.gen_marca ?? ""} ${equipo.gen_modelo ?? ""}`}
                                               onClick={() => {
                                                 setEquipoUbicacionId(ubicacion.id!);
                                                 setEditEquipo(equipo);

--- a/src/app/dashboard/equipos/page.tsx
+++ b/src/app/dashboard/equipos/page.tsx
@@ -73,9 +73,6 @@ export default function EquiposPage() {
     if (search) {
       const q = search.toLowerCase();
       const haystack = [
-        d.equipo.marca,
-        d.equipo.modelo,
-        d.equipo.numero_serie,
         d.equipo.gen_marca,
         d.equipo.gen_modelo,
         d.equipo.gen_numero_serie,
@@ -196,13 +193,12 @@ export default function EquiposPage() {
                         </div>
                         <div className="min-w-0">
                           <p className="font-black text-slate-900 text-sm sm:text-base truncate">
-                            {equipo.marca ?? equipo.gen_marca ?? "Sin marca"}{" "}
-                            {equipo.modelo ?? equipo.gen_modelo ?? ""}
+                            {equipo.gen_marca ?? "Sin marca"} {equipo.gen_modelo ?? ""}
                           </p>
-                          {(equipo.numero_serie ?? equipo.gen_numero_serie) && (
+                          {equipo.gen_numero_serie && (
                             <p className="text-[11px] text-slate-400 font-medium flex items-center gap-1">
                               <Hash className="w-3 h-3" />
-                              {equipo.numero_serie ?? equipo.gen_numero_serie}
+                              {equipo.gen_numero_serie}
                             </p>
                           )}
                         </div>
@@ -257,7 +253,7 @@ export default function EquiposPage() {
                           variant="ghost"
                           size="sm"
                           className="rounded-lg text-slate-400 hover:text-primary"
-                          aria-label={`Editar equipo ${equipo.marca ?? equipo.gen_marca ?? ""} ${equipo.modelo ?? equipo.gen_modelo ?? ""}`}
+                          aria-label={`Editar equipo ${equipo.gen_marca ?? ""} ${equipo.gen_modelo ?? ""}`}
                           onClick={(e) => {
                             e.preventDefault();
                             e.stopPropagation();

--- a/src/app/verificar/[token]/page.test.tsx
+++ b/src/app/verificar/[token]/page.test.tsx
@@ -60,10 +60,8 @@ beforeEach(() => {
   };
   state.version = { numero_version: 1, pdf_url: "informes/inf-1-v1.pdf" };
   state.equipo = {
-    marca: "Siemens",
-    modelo: "Multix",
-    gen_marca: null,
-    gen_modelo: null,
+    gen_marca: "Siemens",
+    gen_modelo: "Multix",
     tipo_equipo: "CONVENCIONAL",
   };
   state.signedUrl = "https://test.supabase.co/storage/signed/abc";

--- a/src/app/verificar/[token]/page.tsx
+++ b/src/app/verificar/[token]/page.tsx
@@ -32,8 +32,6 @@ interface VersionRow {
 }
 
 interface EquipoRow {
-  marca: string | null;
-  modelo: string | null;
   gen_marca: string | null;
   gen_modelo: string | null;
   tipo_equipo: string | null;
@@ -92,7 +90,7 @@ export default async function VerificarPage({ params }: { params: Promise<{ toke
       .maybeSingle<VersionRow>(),
     supabase
       .from("equipos")
-      .select("marca, modelo, gen_marca, gen_modelo, tipo_equipo")
+      .select("gen_marca, gen_modelo, tipo_equipo")
       .eq("id", informe.equipo_id)
       .maybeSingle<EquipoRow>(),
   ]);
@@ -135,7 +133,7 @@ export default async function VerificarPage({ params }: { params: Promise<{ toke
                 {informe.numero_informe}
               </h2>
               <p className="text-sm text-slate-500 font-medium">
-                {equipo?.marca ?? equipo?.gen_marca} {equipo?.modelo ?? equipo?.gen_modelo}
+                {equipo?.gen_marca} {equipo?.gen_modelo}
                 {equipo?.tipo_equipo ? ` — ${equipo.tipo_equipo.replace(/_/g, " ")}` : ""}
               </p>
             </div>

--- a/src/components/equipo-form-dialog.test.tsx
+++ b/src/components/equipo-form-dialog.test.tsx
@@ -28,7 +28,7 @@ async function seedEquipo(overrides: Partial<Equipo> = {}): Promise<Equipo> {
     id: randomUUID(),
     ubicacion_id: "ubicacion-1",
     planilla_espacial: false,
-    marca: "Siemens",
+    gen_marca: "Siemens",
     ...overrides,
   };
   await db.equipos.add(equipo);
@@ -45,7 +45,7 @@ describe("EquipoFormDialog", () => {
   });
 
   it("repuebla la marca del equipo al reabrir la misma instancia con datos actualizados", async () => {
-    const equipoV1 = await seedEquipo({ marca: "Siemens" });
+    const equipoV1 = await seedEquipo({ gen_marca: "Siemens" });
 
     const { rerender } = render(
       <EquipoFormDialog
@@ -66,7 +66,7 @@ describe("EquipoFormDialog", () => {
     );
     await waitFor(() => expect(screen.getByDisplayValue("Siemens")).toBeTruthy());
 
-    const equipoV2: Equipo = { ...equipoV1, marca: "GE Healthcare" };
+    const equipoV2: Equipo = { ...equipoV1, gen_marca: "GE Healthcare" };
     rerender(
       <EquipoFormDialog
         open={false}
@@ -89,7 +89,7 @@ describe("EquipoFormDialog", () => {
   });
 
   it("actualiza el tubo/colimador/gantry existentes al reeditar el equipo, sin duplicarlos", async () => {
-    const equipo = await seedEquipo({ marca: "Siemens" });
+    const equipo = await seedEquipo({ gen_marca: "Siemens" });
     const tubo: Tubo = {
       id: randomUUID(),
       equipo_id: equipo.id!,
@@ -146,7 +146,7 @@ describe("EquipoFormDialog", () => {
   });
 
   it("#10: soft-borra el tubo cuando el usuario limpia todos sus campos", async () => {
-    const equipo = await seedEquipo({ marca: "Siemens" });
+    const equipo = await seedEquipo({ gen_marca: "Siemens" });
     const tubo: Tubo = {
       id: randomUUID(),
       equipo_id: equipo.id!,
@@ -183,7 +183,7 @@ describe("EquipoFormDialog", () => {
   });
 
   it("#10: si falla un write hijo, el update del equipo también se revierte", async () => {
-    const equipo = await seedEquipo({ marca: "Siemens", modelo: "OLD" });
+    const equipo = await seedEquipo({ gen_marca: "Siemens", gen_modelo: "OLD" });
     const addSpy = vi.spyOn(db.gantry, "add").mockRejectedValueOnce(new Error("boom"));
 
     render(
@@ -210,14 +210,14 @@ describe("EquipoFormDialog", () => {
     await waitFor(() => expect(addSpy).toHaveBeenCalled());
     await waitFor(async () => {
       const fresh = await db.equipos.get(equipo.id!);
-      expect(fresh!.modelo).toBe("OLD");
+      expect(fresh!.gen_modelo).toBe("OLD");
     });
     expect(await db.gantry.where("equipo_id").equals(equipo.id!).count()).toBe(0);
     addSpy.mockRestore();
   });
 
   it("crea el tubo cuando el equipo todavía no tiene uno", async () => {
-    const equipo = await seedEquipo({ marca: "Siemens" });
+    const equipo = await seedEquipo({ gen_marca: "Siemens" });
     const onSaved = vi.fn();
 
     render(

--- a/src/components/equipo-form-dialog.tsx
+++ b/src/components/equipo-form-dialog.tsx
@@ -106,11 +106,8 @@ export function EquipoFormDialog({
     equipo?.distancia_foco_paciente?.toString() ?? ""
   );
   const [bucky, setBucky] = useState(equipo?.bucky ?? "");
-  const [marca, setMarca] = useState(equipo?.marca ?? "");
-  const [modelo, setModelo] = useState(equipo?.modelo ?? "");
-  const [numeroSerie, setNumeroSerie] = useState(equipo?.numero_serie ?? "");
 
-  // Generador
+  // Características del equipo (la plantilla oficial las rotula "del generador")
   const [genMarca, setGenMarca] = useState(equipo?.gen_marca ?? "");
   const [genModelo, setGenModelo] = useState(equipo?.gen_modelo ?? "");
   const [genSerie, setGenSerie] = useState(equipo?.gen_numero_serie ?? "");
@@ -158,9 +155,6 @@ export function EquipoFormDialog({
       setSistemaAdq(equipo?.sistema_adquisicion ?? "");
       setDistanciaFoco(equipo?.distancia_foco_paciente?.toString() ?? "");
       setBucky(equipo?.bucky ?? "");
-      setMarca(equipo?.marca ?? "");
-      setModelo(equipo?.modelo ?? "");
-      setNumeroSerie(equipo?.numero_serie ?? "");
       setGenMarca(equipo?.gen_marca ?? "");
       setGenModelo(equipo?.gen_modelo ?? "");
       setGenSerie(equipo?.gen_numero_serie ?? "");
@@ -221,9 +215,6 @@ export function EquipoFormDialog({
         sistema_adquisicion: sistemaAdq || undefined,
         distancia_foco_paciente: parseDecimal(distanciaFoco),
         bucky: (bucky as Equipo["bucky"]) || undefined,
-        marca: marca || undefined,
-        modelo: modelo || undefined,
-        numero_serie: numeroSerie || undefined,
         gen_marca: genMarca || undefined,
         gen_modelo: genModelo || undefined,
         gen_numero_serie: genSerie || undefined,
@@ -431,43 +422,6 @@ export function EquipoFormDialog({
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-2">
-                <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                  Marca
-                </Label>
-                <Input
-                  className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
-                  placeholder="Marca"
-                  value={marca}
-                  onChange={(e) => setMarca(e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                  Modelo
-                </Label>
-                <Input
-                  className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
-                  placeholder="Modelo"
-                  value={modelo}
-                  onChange={(e) => setModelo(e.target.value)}
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
-                No. Serie
-              </Label>
-              <Input
-                className="rounded-xl border-slate-200 focus:border-primary font-medium h-11"
-                placeholder="Número de serie"
-                value={numeroSerie}
-                onChange={(e) => setNumeroSerie(e.target.value)}
-              />
-            </div>
-
             <div className="space-y-2">
               <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
                 Distancia Foco-Paciente (cm)
@@ -482,8 +436,8 @@ export function EquipoFormDialog({
             </div>
           </CollapsibleSection>
 
-          {/* Generador */}
-          <CollapsibleSection title="Generador">
+          {/* Características del Equipo (la plantilla oficial las rotula "del generador") */}
+          <CollapsibleSection title="Características del Equipo" defaultOpen={true}>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-2">
                 <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -542,6 +542,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
     equipo?.gen_modelo,
     equipo?.gen_fecha_fabricacion,
     equipo?.gen_fase,
+    equipo?.gen_energia_fotones_mev,
   ]);
 
   const progTubo = computeProgress([
@@ -873,10 +874,10 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
         </div>
       </SectionCard>
 
-      {/* 3. Características del Generador */}
+      {/* 3. Características del Equipo (la plantilla las llama "del generador") */}
       <SectionCard
         icon={Radio}
-        title="Características del Generador"
+        title="Características del Equipo"
         subtitle="Datos del equipo de rayos X"
         progress={progGenerador}
       >
@@ -914,6 +915,12 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
               { label: "Alta Frecuencia", value: "alta_frecuencia" },
             ]}
             onSave={(v) => saveEquipo("gen_fase", v)}
+          />
+          <EditableField
+            label="Energía Fotones / Electrones (MeV)"
+            value={toStr(equipo?.gen_energia_fotones_mev)}
+            icon={Zap}
+            onSave={(v) => saveEquipo("gen_energia_fotones_mev", v)}
           />
         </div>
       </SectionCard>

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -92,3 +92,20 @@ describe("InfoModulo — Sistema de Adquisición de Imágenes (#62)", () => {
     expect(screen.getByRole("option", { name: "Monitor análogo" })).toBeInTheDocument();
   });
 });
+
+describe("InfoModulo — Características del Equipo (#61)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+  });
+  afterEach(() => cleanup());
+
+  it("la sección del equipo incluye el campo de energía fotones/electrones (MeV)", async () => {
+    const { visita } = await seedGraph();
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    expect(screen.getByText("Características del Equipo")).toBeInTheDocument();
+    expect(screen.getByText(/Energía Fotones \/ Electrones/i)).toBeInTheDocument();
+  });
+});

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -190,11 +190,8 @@ export interface Equipo extends Partial<SyncFields> {
   sistema_adquisicion?: string;
   distancia_foco_paciente?: number;
   bucky?: "Si" | "No" | "No_aplica";
-  // Identificación del equipo (placa general del aparato)
-  marca?: string;
-  modelo?: string;
-  numero_serie?: string;
-  // Generador
+  // Identificación y características del equipo. La plantilla oficial las
+  // rotula "del generador" (gen_*): en esta app hay UN solo aparato físico.
   gen_marca?: string;
   gen_modelo?: string;
   gen_numero_serie?: string;

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -54,7 +54,7 @@ describe("generarPreInforme — contrato de datos", () => {
     const { visita, cliente, sede, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
     await db.clientes.update(cliente.id!, { nombre_cliente: "CLINICA-MARCADOR-CLI" });
     await db.sedes.update(sede.id!, { nombre_sede: "SEDE-MARCADOR" });
-    await db.equipos.update(equipo.id!, { numero_serie: "SERIE-MARCADOR-999" });
+    await db.equipos.update(equipo.id!, { gen_numero_serie: "SERIE-MARCADOR-999" });
 
     const text = await pdfText((await generarPreInforme(visita!.id!))!);
     expect(text).toContain("CLINICA-MARCADOR-CLI");
@@ -85,6 +85,19 @@ describe("generarPreInforme — contrato de datos", () => {
     const blob = await generarPreInforme(visita!.id!);
     expect(blob).toBeInstanceOf(Blob);
     expect(blob!.type).toBe("application/pdf");
+  });
+
+  it("#61: características del equipo y energía de fotones/electrones llegan al informe", async () => {
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.equipos.update(equipo.id!, {
+      gen_marca: "EQ-MARCA-61",
+      gen_numero_serie: "EQ-SERIE-61",
+      gen_energia_fotones_mev: "ENERGIA-MARCADOR-61",
+    });
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("EQ-MARCA-61");
+    expect(text).toContain("EQ-SERIE-61");
+    expect(text).toContain("ENERGIA-MARCADOR-61");
   });
 
   it("#63: piso y techo del blindaje salen en la tabla de áreas colindantes", async () => {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -491,7 +491,7 @@ export async function generarPreInforme(
   doc.text(`${datos.equipo?.tipo_equipo?.replace(/_/g, " ") ?? "Rayos X"}`, MARGIN + 5, y);
   y += 5;
   doc.text(
-    `Marca: ${datos.equipo?.marca ?? datos.equipo?.gen_marca ?? "—"}    Modelo: ${datos.equipo?.modelo ?? datos.equipo?.gen_modelo ?? "—"}    Serie: ${datos.equipo?.numero_serie ?? datos.equipo?.gen_numero_serie ?? "—"}`,
+    `Marca: ${datos.equipo?.gen_marca ?? "—"}    Modelo: ${datos.equipo?.gen_modelo ?? "—"}    Serie: ${datos.equipo?.gen_numero_serie ?? "—"}`,
     MARGIN + 5,
     y
   );
@@ -635,33 +635,9 @@ export async function generarPreInforme(
 
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
 
-  // Identificación del Equipo
-  checkPage(30);
-  addSubsectionTitle("", "Identificación del Equipo");
-
-  const datosEquipo = [
-    ["Marca", datos.equipo?.marca ?? "—"],
-    ["Modelo", datos.equipo?.modelo ?? "—"],
-    ["No. de Serie", datos.equipo?.numero_serie ?? "—"],
-  ];
-
-  autoTable(doc, {
-    startY: y,
-    margin: { left: MARGIN, right: MARGIN },
-    body: datosEquipo,
-    theme: "grid",
-    bodyStyles: { fontSize: 8, textColor: COLOR_BLACK },
-    columnStyles: {
-      0: { fontStyle: "bold", cellWidth: 60, fillColor: COLOR_HEADER_BG },
-      1: { cellWidth: CONTENT_WIDTH - 60 },
-    },
-  });
-
-  y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
-
-  // Características del Generador
-  checkPage(40);
-  addSubsectionTitle("", "Características del Generador");
+  // Características del Equipo (la plantilla oficial las rotula "del generador")
+  checkPage(48);
+  addSubsectionTitle("", "Características del Equipo");
 
   const datosGenerador = [
     ["Marca", datos.equipo?.gen_marca ?? "—"],
@@ -669,6 +645,7 @@ export async function generarPreInforme(
     ["No. de Serie", datos.equipo?.gen_numero_serie ?? "—"],
     ["Fecha de fabricación", datos.equipo?.gen_fecha_fabricacion ?? "—"],
     ["Fase del generador", datos.equipo?.gen_fase?.replace(/_/g, " ") ?? "—"],
+    ["Energía fotones / electrones (MeV)", textoCampo(datos.equipo?.gen_energia_fotones_mev)],
   ];
 
   autoTable(doc, {
@@ -1814,7 +1791,7 @@ function addHeader(doc: jsPDF, datos: DatosInforme, logoBase64: string) {
   doc.setFontSize(7);
   doc.setTextColor(...COLOR_GRAY);
   doc.text(
-    `Control de Calidad — ${datos.equipo?.marca ?? datos.equipo?.gen_marca ?? ""} ${datos.equipo?.modelo ?? datos.equipo?.gen_modelo ?? ""}`,
+    `Control de Calidad — ${datos.equipo?.gen_marca ?? ""} ${datos.equipo?.gen_modelo ?? ""}`,
     PAGE_WIDTH - MARGIN,
     12,
     { align: "right" }

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1281,9 +1281,6 @@ export type Database = {
           gen_marca: string | null;
           gen_modelo: string | null;
           gen_numero_serie: string | null;
-          marca: string | null;
-          modelo: string | null;
-          numero_serie: string | null;
           id: string;
           last_modified: string;
           planilla_espacial: boolean;
@@ -1304,9 +1301,6 @@ export type Database = {
           gen_marca?: string | null;
           gen_modelo?: string | null;
           gen_numero_serie?: string | null;
-          marca?: string | null;
-          modelo?: string | null;
-          numero_serie?: string | null;
           id?: string;
           last_modified?: string;
           planilla_espacial?: boolean;
@@ -1327,9 +1321,6 @@ export type Database = {
           gen_marca?: string | null;
           gen_modelo?: string | null;
           gen_numero_serie?: string | null;
-          marca?: string | null;
-          modelo?: string | null;
-          numero_serie?: string | null;
           id?: string;
           last_modified?: string;
           planilla_espacial?: boolean;

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -68,9 +68,9 @@ export function makeEquipo(ubicacion_id: string, overrides: Partial<Equipo> = {}
     ubicacion_id,
     tipo_equipo: "CONVENCIONAL" as TipoEquipo,
     planilla_espacial: false,
-    marca: "Siemens",
-    modelo: "Multix",
-    numero_serie: "SN-0001",
+    gen_marca: "Siemens",
+    gen_modelo: "Multix",
+    gen_numero_serie: "SN-0001",
     ...sync(),
     ...overrides,
   };

--- a/supabase/migrations/020_drop_equipo_marca_modelo_serie.sql
+++ b/supabase/migrations/020_drop_equipo_marca_modelo_serie.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+--  020 — Revierte la 014: elimina equipos.marca / modelo / numero_serie
+--
+--  Contexto (issue #61, decisión del dueño):
+--  La 014 agregó marca/modelo/numero_serie como "identificación propia
+--  del equipo", separada de gen_marca/gen_modelo/gen_numero_serie
+--  ("del generador"). En la práctica hay UN solo aparato físico: los
+--  campos gen_* SON los del equipo (la plantilla oficial FT-LEC-6c los
+--  rotula "del generador"). Los campos de la 014 nunca tuvieron captura
+--  propia en el módulo de Información General y quedaron como ruido.
+--
+--  DESTRUCTIVA: descarta los valores de esas 3 columnas. Correr a
+--  conciencia. Si algún equipo tiene datos ahí y no en gen_*, migrarlos
+--  antes con algo como:
+--    UPDATE equipos SET gen_marca = COALESCE(gen_marca, marca),
+--                       gen_modelo = COALESCE(gen_modelo, modelo),
+--                       gen_numero_serie = COALESCE(gen_numero_serie, numero_serie)
+--    WHERE marca IS NOT NULL OR modelo IS NOT NULL OR numero_serie IS NOT NULL;
+-- ============================================================
+
+ALTER TABLE public.equipos
+  DROP COLUMN IF EXISTS marca,
+  DROP COLUMN IF EXISTS modelo,
+  DROP COLUMN IF EXISTS numero_serie;


### PR DESCRIPTION
Primera tajada del D2 (#61 → D2a / D2b / D2c). **Cambió de rumbo respecto al primer push** por la decisión del dueño sobre la confusión equipo/generador.

## El problema (#61)
El usuario reportó: "hay una confusión: la plantilla trata los datos del generador como los datos del equipo… por eso inicialmente no teníamos ninguna captura de información para el equipo" y "el campo de energía de fotones y electrones… su valor siempre es no aplica".

La migración 014 había separado `equipos.marca/modelo/numero_serie` ("identificación propia del equipo") de `gen_marca/gen_modelo/gen_numero_serie` ("del generador, sub-componente interno"). **El dueño confirmó que eso es al revés de la realidad del dominio:** hay UN solo aparato físico; lo que la plantilla oficial FT-LEC-6c llama "Características del Generador" (los `gen_*`) SON los datos del equipo. Los campos de la 014 nunca tuvieron UI de captura en Información General y quedaron como ruido.

## La solución
| Dónde | Cambio |
|---|---|
| `info-modulo` | "Características del Generador" → **"Características del Equipo"** (mismos campos `gen_*`). Campo nuevo **"Energía Fotones / Electrones (MeV)"** (`gen_energia_fotones_mev`, ya en el schema, no se capturaba ni renderizaba). |
| `generar-pre-informe` | Se **elimina** la tabla "Identificación del Equipo" (leía `equipo.marca/*`). "Características del Generador" → "Características del Equipo". Fila de energía MeV con "No aplica" por defecto. El header y el subtítulo dejan de hacer fallback a `equipo.marca`. |
| `equipo-form-dialog` | Se quitan los inputs Marca / Modelo / No. Serie de "General". La sección "Generador" → "Características del Equipo" (`defaultOpen`). |
| `db/types.ts` + `supabase/types.ts` | Se quitan `marca` / `modelo` / `numero_serie` de `Equipo`. |
| Dashboards | `equipos`, `clientes/[id]`, `verificar/[token]`: los `equipo.marca ?? equipo.gen_marca` pasan a `equipo.gen_marca` a secas. |
| Migración | **`020_drop_equipo_marca_modelo_serie.sql`** — revierte la 014. **DESTRUCTIVA**, la corre el dueño; incluye un `UPDATE` de respaldo comentado (`gen_* = COALESCE(gen_*, *)`) por si algún equipo tiene datos solo en los campos viejos. |

## Verificación
- `npm run verify` — typecheck + lint (0 errores) + format + **577 tests** + build. Verde.
- Tests actualizados: `equipo-form-dialog.test.tsx`, `generar-pre-informe.test.ts`, `modulos-smoke.test.tsx`, `verificar/[token]/page.test.tsx`, `factories.ts` (todo lo que sembraba `equipo.marca` ahora siembra `gen_marca`).

## Cómo probar
Ver el mensaje siguiente en el hilo (sección D2a del runbook de QA).

## Lo que queda de D2
- **D2b** — agregar tubo / colimador / gantry **desde** Información General (hoy `saveTubo` solo edita), N tubos.
- **D2c** — tablas nuevas `equipo_imagenes` + `equipo_identificaciones` + migración + RLS + `ImagenConTitulo` + render en el informe.

## Issue
#61 (parcial). El usuario lo cierra manualmente cuando estén D2a + D2b + D2c.