### PR TITLE
feat(informe): Paquete D2b+D2c — N tubos + identificaciones del equipo desde Info (#61)

### DIFF
--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -32,6 +32,8 @@ import {
   Activity,
   Users,
   Eye,
+  Plus,
+  Trash2,
 } from "lucide-react";
 import { irAModulo } from "@/lib/modulo-nav";
 
@@ -325,9 +327,10 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
       : undefined;
 
     const tubos = visita.equipo_id
-      ? await db.tubos.where("equipo_id").equals(visita.equipo_id).toArray()
+      ? (await db.tubos.where("equipo_id").equals(visita.equipo_id).toArray())
+          .filter((t) => !t.deleted_at)
+          .sort((a, b) => (a.creado_en ?? "").localeCompare(b.creado_en ?? ""))
       : [];
-    const tubo = tubos[0];
 
     const contactos = cliente?.id
       ? await db.contactos.where("cliente_id").equals(cliente.id).toArray()
@@ -340,7 +343,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
       sede,
       cliente,
       solicitud,
-      tubo,
+      tubos,
       nroTubos: tubos.length,
       contactos,
     };
@@ -413,12 +416,39 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
     pushSingle("equipos", id);
   }
 
-  async function saveTubo(field: string, value: string, numeric = false) {
-    const id = data?.tubo?.id;
-    if (!id) return;
+  async function saveTubo(tuboId: string, field: string, value: string, numeric = false) {
+    if (!tuboId) return;
     const parsed = numeric ? (value === "" ? undefined : parseDecimal(value)) : value || undefined;
-    await db.tubos.update(id, { [field]: parsed, sync_status: "pending", last_modified: now() });
-    pushSingle("tubos", id);
+    await db.tubos.update(tuboId, {
+      [field]: parsed,
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("tubos", tuboId);
+  }
+
+  async function addTubo() {
+    const equipoId = data?.equipo?.id;
+    if (!equipoId) return;
+    const nuevo = {
+      id: randomUUID(),
+      equipo_id: equipoId,
+      creado_en: now(),
+      sync_status: "pending" as const,
+      last_modified: now(),
+    };
+    await db.tubos.add(nuevo);
+    pushSingle("tubos", nuevo.id);
+  }
+
+  async function deleteTubo(tuboId: string) {
+    if (!tuboId) return;
+    await db.tubos.update(tuboId, {
+      deleted_at: now(),
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("tubos", tuboId);
   }
 
   async function saveVisita(field: string, value: string, numeric = false) {
@@ -493,7 +523,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
     );
   }
 
-  const { visita, equipo, ubicacion, sede, cliente, solicitud, tubo, nroTubos, contactos } = data;
+  const { visita, equipo, ubicacion, sede, cliente, solicitud, tubos, nroTubos, contactos } = data;
 
   const medico = getContacto("medico_responsable");
   const tecnologo = getContacto("tecnologo");
@@ -546,16 +576,16 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
   ]);
 
   const progTubo = computeProgress([
-    tubo?.marca,
-    tubo?.modelo,
-    tubo?.numero_serie,
-    tubo?.tipo,
-    tubo?.mas_max,
-    tubo?.kv_max,
-    tubo?.ma_max,
-    tubo?.tiempo_s,
-    tubo?.foco_fino_mm,
-    tubo?.foco_grueso_mm,
+    tubos[0]?.marca,
+    tubos[0]?.modelo,
+    tubos[0]?.numero_serie,
+    tubos[0]?.tipo,
+    tubos[0]?.mas_max,
+    tubos[0]?.kv_max,
+    tubos[0]?.ma_max,
+    tubos[0]?.tiempo_s,
+    tubos[0]?.foco_fino_mm,
+    tubos[0]?.foco_grueso_mm,
   ]);
 
   const progColimador = computeProgress([
@@ -925,79 +955,107 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
         </div>
       </SectionCard>
 
-      {/* 4. Especificaciones del Tubo */}
+      {/* 4. Especificaciones del Tubo (N tubos) */}
       <SectionCard
         icon={Zap}
         title="Especificaciones del Tubo"
         subtitle={`${nroTubos} tubo${nroTubos !== 1 ? "s" : ""} registrado${nroTubos !== 1 ? "s" : ""}`}
         progress={progTubo}
       >
-        {tubo ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <EditableField
-              label="Marca"
-              value={toStr(tubo.marca)}
-              onSave={(v) => saveTubo("marca", v)}
-            />
-            <EditableField
-              label="Modelo"
-              value={toStr(tubo.modelo)}
-              onSave={(v) => saveTubo("modelo", v)}
-            />
-            <EditableField
-              label="No. de Serie"
-              value={toStr(tubo.numero_serie)}
-              icon={Hash}
-              onSave={(v) => saveTubo("numero_serie", v)}
-            />
-            <EditableField
-              label="Tipo"
-              value={toStr(tubo.tipo)}
-              onSave={(v) => saveTubo("tipo", v)}
-            />
-            <ReadonlyField label="No. de Tubos" value={nroTubos} />
-            <EditableField
-              label="mAs Máximo"
-              value={toStr(tubo.mas_max)}
-              type="number"
-              onSave={(v) => saveTubo("mas_max", v, true)}
-            />
-            <EditableField
-              label="kV Máximo"
-              value={toStr(tubo.kv_max)}
-              type="number"
-              onSave={(v) => saveTubo("kv_max", v, true)}
-            />
-            <EditableField
-              label="mA Máximo"
-              value={toStr(tubo.ma_max)}
-              type="number"
-              onSave={(v) => saveTubo("ma_max", v, true)}
-            />
-            <EditableField
-              label="t (s)"
-              value={toStr(tubo.tiempo_s)}
-              type="number"
-              onSave={(v) => saveTubo("tiempo_s", v, true)}
-            />
-            <EditableField
-              label="Foco Fino (mm)"
-              value={toStr(tubo.foco_fino_mm)}
-              type="number"
-              onSave={(v) => saveTubo("foco_fino_mm", v, true)}
-            />
-            <EditableField
-              label="Foco Grueso (mm)"
-              value={toStr(tubo.foco_grueso_mm)}
-              type="number"
-              onSave={(v) => saveTubo("foco_grueso_mm", v, true)}
-            />
-          </div>
-        ) : (
-          <p className="text-sm text-slate-400 font-medium py-4 text-center">
-            No hay tubo registrado para este equipo
-          </p>
-        )}
+        <div className="space-y-4">
+          {tubos.length === 0 && (
+            <p className="text-sm text-slate-400 font-medium py-2 text-center">
+              No hay tubos registrados para este equipo
+            </p>
+          )}
+
+          {tubos.map((t, i) => (
+            <div key={t.id} className="rounded-xl border border-slate-100 p-3 space-y-3">
+              <div className="flex items-center justify-between">
+                <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                  Tubo {i + 1}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => deleteTubo(t.id!)}
+                  className="text-slate-300 hover:text-red-500 transition-colors"
+                  aria-label={`Eliminar tubo ${i + 1}`}
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                <EditableField
+                  label="Marca"
+                  value={toStr(t.marca)}
+                  onSave={(v) => saveTubo(t.id!, "marca", v)}
+                />
+                <EditableField
+                  label="Modelo"
+                  value={toStr(t.modelo)}
+                  onSave={(v) => saveTubo(t.id!, "modelo", v)}
+                />
+                <EditableField
+                  label="No. de Serie"
+                  value={toStr(t.numero_serie)}
+                  icon={Hash}
+                  onSave={(v) => saveTubo(t.id!, "numero_serie", v)}
+                />
+                <EditableField
+                  label="Tipo"
+                  value={toStr(t.tipo)}
+                  onSave={(v) => saveTubo(t.id!, "tipo", v)}
+                />
+                <EditableField
+                  label="mAs Máximo"
+                  value={toStr(t.mas_max)}
+                  type="number"
+                  onSave={(v) => saveTubo(t.id!, "mas_max", v, true)}
+                />
+                <EditableField
+                  label="kV Máximo"
+                  value={toStr(t.kv_max)}
+                  type="number"
+                  onSave={(v) => saveTubo(t.id!, "kv_max", v, true)}
+                />
+                <EditableField
+                  label="mA Máximo"
+                  value={toStr(t.ma_max)}
+                  type="number"
+                  onSave={(v) => saveTubo(t.id!, "ma_max", v, true)}
+                />
+                <EditableField
+                  label="t (s)"
+                  value={toStr(t.tiempo_s)}
+                  type="number"
+                  onSave={(v) => saveTubo(t.id!, "tiempo_s", v, true)}
+                />
+                <EditableField
+                  label="Foco Fino (mm)"
+                  value={toStr(t.foco_fino_mm)}
+                  type="number"
+                  onSave={(v) => saveTubo(t.id!, "foco_fino_mm", v, true)}
+                />
+                <EditableField
+                  label="Foco Grueso (mm)"
+                  value={toStr(t.foco_grueso_mm)}
+                  type="number"
+                  onSave={(v) => saveTubo(t.id!, "foco_grueso_mm", v, true)}
+                />
+              </div>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={addTubo}
+            disabled={!equipo}
+            className="w-full flex items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 py-2.5 text-sm font-bold text-slate-500 hover:border-primary hover:text-primary transition-colors disabled:opacity-40"
+          >
+            <Plus className="w-4 h-4" />
+            Agregar tubo
+          </button>
+        </div>
       </SectionCard>
 
       {/* 5. Colimador y Sistema de Adquisición */}

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ComponentType } from "react";
+import { db } from "@/lib/db";
 import { resetTestDb } from "@/test/db-reset";
 import { seedGraph } from "@/test/seed";
 
@@ -107,5 +108,37 @@ describe("InfoModulo — Características del Equipo (#61)", () => {
 
     expect(screen.getByText("Características del Equipo")).toBeInTheDocument();
     expect(screen.getByText(/Energía Fotones \/ Electrones/i)).toBeInTheDocument();
+  });
+});
+
+describe("InfoModulo — tubos desde Información General (#61 D2b)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+  });
+  afterEach(() => cleanup());
+
+  it("agrega un tubo al equipo desde el botón 'Agregar tubo'", async () => {
+    const { visita, equipo } = await seedGraph({ conTubo: false });
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    expect(await db.tubos.where("equipo_id").equals(equipo.id!).count()).toBe(0);
+    fireEvent.click(screen.getByRole("button", { name: /agregar tubo/i }));
+    await waitFor(async () =>
+      expect(await db.tubos.where("equipo_id").equals(equipo.id!).count()).toBe(1)
+    );
+  });
+
+  it("soft-borra un tubo desde su botón de eliminar", async () => {
+    const { visita, equipo } = await seedGraph({ conTubo: true });
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    fireEvent.click(await screen.findByRole("button", { name: /eliminar tubo 1/i }));
+    await waitFor(async () => {
+      const t = await db.tubos.where("equipo_id").equals(equipo.id!).first();
+      expect(t?.deleted_at).toBeTruthy();
+    });
   });
 });

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -11,6 +11,7 @@ function okPngFetch() {
 vi.stubGlobal("fetch", okPngFetch());
 
 import { db } from "@/lib/db";
+import { randomUUID } from "@/lib/uuid";
 import { resetTestDb } from "@/test/db-reset";
 import { seedGraph } from "@/test/seed";
 import {
@@ -98,6 +99,35 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(text).toContain("EQ-MARCA-61");
     expect(text).toContain("EQ-SERIE-61");
     expect(text).toContain("ENERGIA-MARCADOR-61");
+  });
+
+  it("#61 (D2b): el informe renderiza todos los tubos del equipo, numerados si hay más de uno", async () => {
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conTubo: false });
+    await db.tubos.bulkAdd([
+      { id: randomUUID(), equipo_id: equipo.id!, marca: "TUBO-UNO-MARCA" },
+      { id: randomUUID(), equipo_id: equipo.id!, marca: "TUBO-DOS-MARCA" },
+    ]);
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("Especificaciones del Tubo 1");
+    expect(text).toContain("Especificaciones del Tubo 2");
+    expect(text).toContain("TUBO-UNO-MARCA");
+    expect(text).toContain("TUBO-DOS-MARCA");
+  });
+
+  it("#61 (D2b): un tubo soft-borrado no sale en el informe", async () => {
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conTubo: false });
+    await db.tubos.bulkAdd([
+      { id: randomUUID(), equipo_id: equipo.id!, marca: "TUBO-VIVO" },
+      {
+        id: randomUUID(),
+        equipo_id: equipo.id!,
+        marca: "TUBO-BORRADO",
+        deleted_at: new Date().toISOString(),
+      },
+    ]);
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("TUBO-VIVO");
+    expect(text).not.toContain("TUBO-BORRADO");
   });
 
   it("#63: piso y techo del blindaje salen en la tabla de áreas colindantes", async () => {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -108,7 +108,7 @@ interface DatosInforme {
   ubicacion?: UbicacionRx;
   sede?: Sede;
   cliente?: Cliente;
-  tubo?: Tubo;
+  tubos: Tubo[];
   sala?: SalaDimensiones;
   tecnico?: Usuario;
   contactos: Contacto[];
@@ -147,9 +147,11 @@ async function recopilarDatos(visitaId: string): Promise<DatosInforme | null> {
   const sede = ubicacion
     ? await db.sedes.get((await db.ubicaciones_rx.get(ubicacion.id!))?.sede_id ?? "")
     : undefined;
-  const tubo = visita.equipo_id
-    ? await db.tubos.where("equipo_id").equals(visita.equipo_id).first()
-    : undefined;
+  const tubos = visita.equipo_id
+    ? (await db.tubos.where("equipo_id").equals(visita.equipo_id).toArray()).filter(
+        (t) => !t.deleted_at
+      )
+    : [];
   const sala = visita.ubicacion_id
     ? await db.sala_dimensiones.where("ubicacion_id").equals(visita.ubicacion_id).first()
     : undefined;
@@ -192,7 +194,7 @@ async function recopilarDatos(visitaId: string): Promise<DatosInforme | null> {
     ubicacion,
     sede,
     cliente,
-    tubo,
+    tubos,
     sala,
     tecnico,
     contactos,
@@ -663,20 +665,22 @@ export async function generarPreInforme(
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
 
   // Especificaciones del Tubo
-  if (datos.tubo) {
+  datos.tubos.forEach((tuboItem, i) => {
     checkPage(40);
-    addSubsectionTitle("", "Especificaciones del Tubo");
+    const titulo =
+      datos.tubos.length > 1 ? `Especificaciones del Tubo ${i + 1}` : "Especificaciones del Tubo";
+    addSubsectionTitle("", titulo);
 
     const datosTubo = [
-      ["Marca", datos.tubo.marca ?? "—"],
-      ["Modelo", datos.tubo.modelo ?? "—"],
-      ["No. Serie", datos.tubo.numero_serie ?? "—"],
-      ["Tipo", datos.tubo.tipo ?? "—"],
-      ["mAs máximo", String(datos.tubo.mas_max ?? "—")],
-      ["kV máx", String(datos.tubo.kv_max ?? "—")],
-      ["mA máx", String(datos.tubo.ma_max ?? "—")],
-      ["Foco fino (mm)", String(datos.tubo.foco_fino_mm ?? "—")],
-      ["Foco grueso (mm)", String(datos.tubo.foco_grueso_mm ?? "—")],
+      ["Marca", tuboItem.marca ?? "—"],
+      ["Modelo", tuboItem.modelo ?? "—"],
+      ["No. Serie", tuboItem.numero_serie ?? "—"],
+      ["Tipo", tuboItem.tipo ?? "—"],
+      ["mAs máximo", String(tuboItem.mas_max ?? "—")],
+      ["kV máx", String(tuboItem.kv_max ?? "—")],
+      ["mA máx", String(tuboItem.ma_max ?? "—")],
+      ["Foco fino (mm)", String(tuboItem.foco_fino_mm ?? "—")],
+      ["Foco grueso (mm)", String(tuboItem.foco_grueso_mm ?? "—")],
     ];
 
     autoTable(doc, {
@@ -692,7 +696,7 @@ export async function generarPreInforme(
     });
 
     y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
-  }
+  });
 
   // Características del Colimador y Sistema de Adquisición
   checkPage(30);


### PR DESCRIPTION
Cierra el grueso de #61 en un solo PR (D2b + D2c). D2a fue #75.

---

## D2b — Agregar y listar N tubos desde Información General

**El problema.** `saveTubo` hacía `if (!data?.tubo?.id) return` → solo editaba un tubo existente; el equipo solo mostraba `tubos[0]`.

**La solución.**
- `info-modulo`: "Especificaciones del Tubo" lista **todos** los tubos vivos (tarjeta numerada por tubo), con **"Agregar tubo"** y botón de **eliminar** por tubo (soft-delete). `saveTubo(tuboId, …)` con id explícito.
- `generar-pre-informe`: `recopilarDatos` devuelve `tubos: Tubo[]` (filtra `deleted_at`); el PDF hace una tabla por tubo, "Especificaciones del Tubo N" si hay más de uno.

---

## D2c — Identificaciones del equipo (nombre + foto)

Cierra la parte de **imágenes** de #61: *"otras identificaciones del equipo con input para cargar el nombre y la imagen… desde la creación del equipo, también en información general y renderizado en el informe"*.

| Pieza | Detalle |
|---|---|
| Tabla `equipo_identificaciones` | `equipo_id`, `nombre`, `orden`, `url_storage`, `blob_local` (local-only). Dexie **v16**, migración **`021_equipo_identificaciones.sql`** (la corre el dueño — RLS permisiva como la 017). Tipos Supabase + `SYNC_TABLES` + `IMAGE_BLOB_TABLES`. `evidenciaPath` → `equipos/{equipo_id}/{id}.jpg`. |
| `<ImagenConTitulo>` | Componente compartido nuevo: título + slot de imagen con **click / archivo / drag & drop** + quitar imagen + eliminar fila. Lo reutiliza el Paquete E (#66). |
| `info-modulo` | Sección **"Identificaciones del Equipo"** — agregar / renombrar / capturar / quitar imagen / eliminar. El blob sube por el pipeline de #67. |
| `generar-pre-informe` | Subsección **"Identificaciones del Equipo"** en el PDF: nombre + imagen (data URL del blob local, best-effort). |

---

## Verificación
- `npm run verify` — typecheck + lint (0 errores) + format + **584 tests** + build. Verde.
- Tests nuevos: PDF con N tubos numerados / tubo borrado ausente; PDF con 2 identificaciones / una borrada ausente; `evidenciaPath` de identificaciones; agregar tubo y agregar identificación desde el smoke de InfoModulo; bump 15→16 en tests de versión de Dexie.

## Migraciones que corre el dueño
- Ninguna para D2b.
- **`021_equipo_identificaciones.sql`** para D2c.

## Pendiente de #61 (fuera de esta tanda)
- Imágenes por subtabla (tubo / colimador / gantry).
- Captura de colimador / gantry desde Información General.
- Las identificaciones también en el diálogo de alta de equipo (hoy solo en Info).

## Issue
#61 (parcial grande). El usuario lo cierra manualmente.