### PR TITLE
feat(informe): Paquete D3 — panel "Datos faltantes" con origen en el pre-informe (#65)

### DIFF
--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -142,3 +142,21 @@ describe("InfoModulo — tubos desde Información General (#61 D2b)", () => {
     });
   });
 });
+
+describe("PreInformeModulo — panel de datos faltantes (#65)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+  });
+  afterEach(() => cleanup());
+
+  it("indica los datos de Info sin completar y su sección al expandir", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    render(<PreInformeModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    const toggle = await screen.findByText(/sin completar en Información General/i);
+    fireEvent.click(toggle);
+    expect(await screen.findByText("Datos de la Instalación")).toBeInTheDocument();
+  });
+});

--- a/src/components/visita-modulos/pre-informe-modulo.tsx
+++ b/src/components/visita-modulos/pre-informe-modulo.tsx
@@ -30,6 +30,7 @@ import {
   Target,
 } from "lucide-react";
 import { irAModulo } from "@/lib/modulo-nav";
+import { getCamposFaltantesInfo, type CampoFaltante } from "@/lib/workflow/module-completeness";
 import { CATALOGO_SECCIONES } from "@/lib/equipos/convencional/informe-secciones";
 import type { ConvInformeSeccion } from "@/lib/equipos/convencional/db/types";
 import {
@@ -310,6 +311,92 @@ function ConceptoBadgeSmall({ concepto }: { concepto?: ConceptoType }) {
   );
 }
 
+/** #65 — panel "Datos faltantes": qué falta y de qué sección de Info viene. */
+function DatosFaltantesPanel({
+  faltantes,
+  visitaId,
+  open,
+  onToggle,
+}: {
+  faltantes: CampoFaltante[];
+  visitaId: string;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  if (faltantes.length === 0) {
+    return (
+      <div className="flex items-center gap-2 py-3 px-4 bg-emerald-50 rounded-2xl border border-emerald-200">
+        <CheckCircle2 className="w-4 h-4 text-emerald-600 flex-shrink-0" />
+        <span className="text-sm font-bold text-emerald-700">
+          Información General completa — todos los datos del informe están cargados.
+        </span>
+      </div>
+    );
+  }
+
+  const porSeccion = new Map<string, CampoFaltante[]>();
+  for (const f of faltantes) {
+    const arr = porSeccion.get(f.seccion) ?? [];
+    arr.push(f);
+    porSeccion.set(f.seccion, arr);
+  }
+
+  return (
+    <div className="bg-amber-50 rounded-2xl border border-amber-200 overflow-hidden">
+      <div className="flex items-center gap-2 p-4">
+        <AlertCircle className="w-4 h-4 text-amber-600 flex-shrink-0" />
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex-1 flex items-center gap-2 text-left"
+          aria-expanded={open}
+        >
+          <span className="text-sm font-bold text-amber-800">
+            {faltantes.length} dato{faltantes.length !== 1 ? "s" : ""} sin completar en Información
+            General
+          </span>
+          {open ? (
+            <ChevronUp className="w-4 h-4 text-amber-600" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-amber-600" />
+          )}
+        </button>
+        <Button
+          size="sm"
+          variant="outline"
+          className="rounded-xl text-[10px] font-bold h-8 border-amber-300 text-amber-800 hover:bg-amber-100"
+          onClick={() => irAModulo(visitaId, "info")}
+        >
+          Ir a completar
+        </Button>
+      </div>
+
+      {open && (
+        <div className="px-4 pb-4 space-y-3">
+          {[...porSeccion.entries()].map(([seccion, campos]) => (
+            <div key={seccion}>
+              <p className="text-[10px] font-black text-amber-700 uppercase tracking-widest">
+                {seccion}
+              </p>
+              <ul className="mt-1 space-y-0.5">
+                {campos.map((c) => (
+                  <li
+                    key={c.campo}
+                    className="text-xs font-medium text-amber-900/80 flex items-center gap-1.5"
+                  >
+                    <span className="w-1 h-1 rounded-full bg-amber-400 flex-shrink-0" />
+                    {c.label}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Main Page ───
 
 export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
@@ -319,6 +406,7 @@ export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [expandedCodigo, setExpandedCodigo] = useState<string | null>(null);
+  const [faltantesOpen, setFaltantesOpen] = useState(false);
 
   // ─── Live data ───
   const data = useLiveQuery(async () => {
@@ -334,7 +422,10 @@ export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
     // Todas las tablas conv_* — el concepto de cada prueba se deriva de aquí
     const datos = await cargarTablasConv(visitaId);
 
-    return { visita, secciones, datos };
+    // #65 — campos de Información General sin llenar, con su origen
+    const camposFaltantes = await getCamposFaltantesInfo(visita);
+
+    return { visita, secciones, datos, camposFaltantes };
   }, [isReady, visitaId]);
 
   const datos = data?.datos;
@@ -497,6 +588,14 @@ export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
           </span>
         </div>
       )}
+
+      {/* #65 — datos faltantes de Información General, con su origen */}
+      <DatosFaltantesPanel
+        faltantes={data.camposFaltantes}
+        visitaId={id}
+        open={faltantesOpen}
+        onToggle={() => setFaltantesOpen((v) => !v)}
+      />
 
       {/* Stats bar */}
       <Card className="border-none shadow-sm rounded-2xl bg-white overflow-hidden">

--- a/src/lib/workflow/module-completeness.test.ts
+++ b/src/lib/workflow/module-completeness.test.ts
@@ -6,6 +6,7 @@ import {
   getModuleStatuses,
   getVisitCompleteness,
   getVisitCompletenessBulk,
+  getCamposFaltantesInfo,
 } from "./module-completeness";
 
 // module-completeness decide si una visita puede avanzar ("enviar a revisión").
@@ -127,5 +128,53 @@ describe("module-completeness — #15 getVisitCompletenessBulk", () => {
 
   it("lista vacía → Map vacío", async () => {
     expect((await getVisitCompletenessBulk([])).size).toBe(0);
+  });
+});
+
+describe("module-completeness — #65 getCamposFaltantesInfo", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+  });
+
+  it("lista los campos de Info vacíos con su etiqueta y sección de origen", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const v = await db.visitas.get(visita!.id!);
+    const faltantes = await getCamposFaltantesInfo(v!);
+    const campos = faltantes.map((f) => f.campo);
+
+    // el seed NO trae estos → deben aparecer
+    expect(campos).toContain("ubicacion.licencia");
+    expect(campos).toContain("equipo.sistema_adquisicion");
+    // el seed SÍ trae estos → NO deben aparecer
+    expect(campos).not.toContain("cliente.nombre_cliente");
+    expect(campos).not.toContain("equipo.gen_marca");
+
+    const lic = faltantes.find((f) => f.campo === "ubicacion.licencia")!;
+    expect(lic.seccion).toBe("Datos de la Instalación");
+    expect(lic.modulo).toBe("info");
+    expect(lic.label.length).toBeGreaterThan(0);
+  });
+
+  it("con toda la Información General cargada → lista vacía", async () => {
+    const { visita, cliente, ubicacion, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.clientes.update(cliente.id!, {
+      telefono: "3001234567",
+      naturaleza: "privado",
+      nombre_representante_legal: "Rep Legal",
+    });
+    await db.ubicaciones_rx.update(ubicacion.id!, { licencia: "L-1", codigo_habilitacion: "H-1" });
+    await db.equipos.update(equipo.id!, {
+      gen_fase: "monofasico",
+      sistema_adquisicion: "Digital",
+      distancia_foco_paciente: 100,
+      filtracion_inherente_mmal: 2,
+      filtracion_anadida_mmal: 1,
+    });
+    const tubo = await db.tubos.where("equipo_id").equals(equipo.id!).first();
+    await db.tubos.update(tubo!.id!, { kv_max: 120, ma_max: 500 });
+    await db.visitas.update(visita!.id!, { fecha_visita: "2026-01-15" });
+
+    const v = await db.visitas.get(visita!.id!);
+    expect(await getCamposFaltantesInfo(v!)).toEqual([]);
   });
 });

--- a/src/lib/workflow/module-completeness.ts
+++ b/src/lib/workflow/module-completeness.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { getPackage, getDefaultModules } from "@/lib/equipos/registry";
 import type { ModuloVisita } from "@/lib/equipos/types";
 import { getEstadoPruebasPorGrupo } from "@/lib/equipos/convencional/evaluacion";
+import type { Cliente, UbicacionRx, Equipo, Tubo } from "@/lib/db/types";
 
 // ============================================================
 //  Motor de completitud de módulos de visita
@@ -65,6 +66,174 @@ async function getModulosForVisita(visitaId: string): Promise<ModuloVisita[]> {
 }
 
 // ─── Info (precarga) — núcleo, compartido por todos los equipos ───
+//
+//  `INFO_CAMPOS` es la fuente única: el % de completitud y el panel
+//  "Datos faltantes" del pre-informe (#65) leen de la MISMA lista, así que
+//  no pueden divergir. Cada entrada dice de qué sección del módulo de
+//  Información General proviene el dato, para que el técnico sepa a dónde ir.
+
+interface InfoCtx {
+  fecha_visita?: string | null;
+  cliente?: Cliente;
+  ubicacion?: UbicacionRx;
+  equipo?: Equipo;
+  tubo?: Tubo;
+}
+
+export interface CampoFaltante {
+  campo: string;
+  label: string;
+  /** Id del módulo donde se completa (hoy siempre "info"). */
+  modulo: string;
+  /** Nombre de la sección dentro de ese módulo. */
+  seccion: string;
+}
+
+const INFO_CAMPOS: {
+  campo: string;
+  label: string;
+  seccion: string;
+  get: (c: InfoCtx) => unknown;
+}[] = [
+  {
+    campo: "fecha_visita",
+    label: "Fecha de la visita",
+    seccion: "Información General",
+    get: (c) => c.fecha_visita,
+  },
+  {
+    campo: "cliente.nombre_cliente",
+    label: "Nombre del cliente",
+    seccion: "Información General",
+    get: (c) => c.cliente?.nombre_cliente,
+  },
+  {
+    campo: "cliente.nit",
+    label: "NIT del cliente",
+    seccion: "Información General",
+    get: (c) => c.cliente?.nit,
+  },
+  {
+    campo: "cliente.telefono",
+    label: "Teléfono del cliente",
+    seccion: "Información General",
+    get: (c) => c.cliente?.telefono,
+  },
+  {
+    campo: "cliente.naturaleza",
+    label: "Naturaleza jurídica",
+    seccion: "Información General",
+    get: (c) => c.cliente?.naturaleza,
+  },
+  {
+    campo: "cliente.nombre_representante_legal",
+    label: "Representante legal",
+    seccion: "Información General",
+    get: (c) => c.cliente?.nombre_representante_legal,
+  },
+  {
+    campo: "ubicacion.nombre_servicio",
+    label: "Nombre del servicio",
+    seccion: "Información General",
+    get: (c) => c.ubicacion?.nombre_servicio,
+  },
+  {
+    campo: "ubicacion.licencia",
+    label: "Licencia de RX",
+    seccion: "Datos de la Instalación",
+    get: (c) => c.ubicacion?.licencia,
+  },
+  {
+    campo: "ubicacion.codigo_habilitacion",
+    label: "Código de habilitación",
+    seccion: "Datos de la Instalación",
+    get: (c) => c.ubicacion?.codigo_habilitacion,
+  },
+  {
+    campo: "equipo.gen_marca",
+    label: "Marca del equipo",
+    seccion: "Características del Equipo",
+    get: (c) => c.equipo?.gen_marca,
+  },
+  {
+    campo: "equipo.gen_numero_serie",
+    label: "N.º de serie del equipo",
+    seccion: "Características del Equipo",
+    get: (c) => c.equipo?.gen_numero_serie,
+  },
+  {
+    campo: "equipo.gen_modelo",
+    label: "Modelo del equipo",
+    seccion: "Características del Equipo",
+    get: (c) => c.equipo?.gen_modelo,
+  },
+  {
+    campo: "equipo.gen_fase",
+    label: "Fase del generador",
+    seccion: "Características del Equipo",
+    get: (c) => c.equipo?.gen_fase,
+  },
+  {
+    campo: "equipo.sistema_adquisicion",
+    label: "Sistema de adquisición",
+    seccion: "Colimador y Sistema de Adquisición",
+    get: (c) => c.equipo?.sistema_adquisicion,
+  },
+  {
+    campo: "equipo.distancia_foco_paciente",
+    label: "Distancia foco-paciente",
+    seccion: "Colimador y Sistema de Adquisición",
+    get: (c) => c.equipo?.distancia_foco_paciente,
+  },
+  {
+    campo: "equipo.filtracion_inherente_mmal",
+    label: "Filtración inherente (mm Al)",
+    seccion: "Colimador y Sistema de Adquisición",
+    get: (c) => c.equipo?.filtracion_inherente_mmal,
+  },
+  {
+    campo: "equipo.filtracion_anadida_mmal",
+    label: "Filtración añadida (mm Al)",
+    seccion: "Colimador y Sistema de Adquisición",
+    get: (c) => c.equipo?.filtracion_anadida_mmal,
+  },
+  {
+    campo: "tubo.marca",
+    label: "Marca del tubo",
+    seccion: "Especificaciones del Tubo",
+    get: (c) => c.tubo?.marca,
+  },
+  {
+    campo: "tubo.kv_max",
+    label: "kV máximo del tubo",
+    seccion: "Especificaciones del Tubo",
+    get: (c) => c.tubo?.kv_max,
+  },
+  {
+    campo: "tubo.ma_max",
+    label: "mA máximo del tubo",
+    seccion: "Especificaciones del Tubo",
+    get: (c) => c.tubo?.ma_max,
+  },
+];
+
+async function loadInfoCtx(visita: {
+  equipo_id?: string | null;
+  ubicacion_id?: string | null;
+  solicitud_id: string;
+  fecha_visita?: string | null;
+}): Promise<InfoCtx> {
+  const equipo = visita.equipo_id ? await db.equipos.get(visita.equipo_id) : undefined;
+  const ubicacion = visita.ubicacion_id
+    ? await db.ubicaciones_rx.get(visita.ubicacion_id)
+    : undefined;
+  const solicitud = await db.solicitudes.get(visita.solicitud_id);
+  const cliente = solicitud ? await db.clientes.get(solicitud.cliente_id) : undefined;
+  const tubo = equipo?.id
+    ? (await db.tubos.where("equipo_id").equals(equipo.id).toArray()).find((t) => !t.deleted_at)
+    : undefined;
+  return { fecha_visita: visita.fecha_visita, cliente, ubicacion, equipo, tubo };
+}
 
 async function getInfoPercentage(visita: {
   equipo_id?: string | null;
@@ -72,36 +241,28 @@ async function getInfoPercentage(visita: {
   solicitud_id: string;
   fecha_visita?: string | null;
 }): Promise<number> {
-  const equipo = visita.equipo_id ? await db.equipos.get(visita.equipo_id) : undefined;
-  const ubicacion = visita.ubicacion_id
-    ? await db.ubicaciones_rx.get(visita.ubicacion_id)
-    : undefined;
-  const solicitud = await db.solicitudes.get(visita.solicitud_id);
-  const cliente = solicitud ? await db.clientes.get(solicitud.cliente_id) : undefined;
-  const tubo = equipo?.id ? await db.tubos.where("equipo_id").equals(equipo.id).first() : undefined;
+  const ctx = await loadInfoCtx(visita);
+  return pct(INFO_CAMPOS.map((k) => k.get(ctx)));
+}
 
-  return pct([
-    visita.fecha_visita,
-    cliente?.nombre_cliente,
-    cliente?.nit,
-    cliente?.telefono,
-    cliente?.naturaleza,
-    cliente?.nombre_representante_legal,
-    ubicacion?.nombre_servicio,
-    ubicacion?.licencia,
-    ubicacion?.codigo_habilitacion,
-    equipo?.gen_marca,
-    equipo?.gen_numero_serie,
-    equipo?.gen_modelo,
-    equipo?.gen_fase,
-    equipo?.sistema_adquisicion,
-    equipo?.distancia_foco_paciente,
-    equipo?.filtracion_inherente_mmal,
-    equipo?.filtracion_anadida_mmal,
-    tubo?.marca,
-    tubo?.kv_max,
-    tubo?.ma_max,
-  ]);
+/**
+ * Campos de Información General que están vacíos, con la sección de origen
+ * de cada uno (#65). El pre-informe muestra esta lista para que el técnico
+ * sepa exactamente a dónde ir a completar.
+ */
+export async function getCamposFaltantesInfo(visita: {
+  equipo_id?: string | null;
+  ubicacion_id?: string | null;
+  solicitud_id: string;
+  fecha_visita?: string | null;
+}): Promise<CampoFaltante[]> {
+  const ctx = await loadInfoCtx(visita);
+  return INFO_CAMPOS.filter((k) => !notEmpty(k.get(ctx))).map((k) => ({
+    campo: k.campo,
+    label: k.label,
+    modulo: "info",
+    seccion: k.seccion,
+  }));
 }
 
 // ─── Convencional — completitud por grupo basada en pruebas resueltas ───


### PR DESCRIPTION
Última parte del Paquete D. Cierra #65.

## El pedido
*"En el pre informe, los datos que no se han llenado, ponme un indicador de dónde proviene el dato para tener claro a dónde debo ir a actualizar la información."*

## La solución
En el editor del pre-informe, un **panel colapsable "Datos faltantes"** — arriba de todo, junto a la barra de stats:
- Colapsado: "N datos sin completar en Información General" + botón **"Ir a completar"** (salta a Información General con `irAModulo`).
- Expandido: los campos vacíos **agrupados por su sección de origen** (Información General / Datos de la Instalación / Características del Equipo / Colimador y Sistema de Adquisición / Especificaciones del Tubo).
- Si no falta nada: estado verde "Información General completa".

## Implementación
- **`module-completeness.ts`** — `INFO_CAMPOS` pasa a ser la **fuente única**: el `%` de completitud del módulo Info (`getInfoPercentage`) y el panel nuevo leen exactamente la misma lista, así que no pueden divergir. Cada entrada lleva `label` + `seccion`. Nuevo export `getCamposFaltantesInfo(visita) → CampoFaltante[]`.
- **`pre-informe-modulo.tsx`** — `<DatosFaltantesPanel>`, alimentado desde el `useLiveQuery` (se recomputa al vuelo cuando cambian los datos).

## Verificación
- `npm run verify` — typecheck + lint (0 errores) + format + **584 tests** + build. Verde.
- Tests nuevos:
  - `module-completeness.test.ts` — `getCamposFaltantesInfo` lista los vacíos con su sección; con todo cargado devuelve `[]`.
  - `modulos-smoke.test.tsx` — el panel aparece en `PreInformeModulo` y al expandir muestra la sección de origen.

## Cómo probar
1. Abrir el pre-informe de una visita con Información General incompleta.
2. Arriba aparece el panel ámbar "N datos sin completar en Información General".
3. Expandirlo → lista agrupada por sección (ej. "Datos de la Instalación → Licencia de RX").
4. "Ir a completar" → lleva al módulo de Información General.
5. Completar los campos → volver al pre-informe → el panel baja el conteo o pasa a verde.

## Issue
Cierra #65. El usuario lo cierra manualmente al validarlo con el runbook.