### PR TITLE
feat(informe): Paquete D2c — identificaciones del equipo (nombre + foto) (#61)

### DIFF
--- a/src/components/imagen-con-titulo.tsx
+++ b/src/components/imagen-con-titulo.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Camera, Trash2, X } from "lucide-react";
+
+// ============================================================
+//  <ImagenConTitulo> — fila reutilizable de "título + imagen"
+//
+//  Usada por las identificaciones del equipo (#61) y por los avisos
+//  de protección como lista dinámica (#66). Es controlada: el padre
+//  pasa `nombre` y `src` (URL ya resuelta) y recibe los cambios.
+//  Soporta captura por click, selección de archivo y drag & drop.
+// ============================================================
+
+export function ImagenConTitulo({
+  nombre,
+  src,
+  placeholder = "Título de la imagen",
+  onNombreChange,
+  onCapture,
+  onRemoveImagen,
+  onDelete,
+}: {
+  nombre: string;
+  src: string | null;
+  placeholder?: string;
+  onNombreChange: (value: string) => void;
+  onCapture: (file: File) => void;
+  onRemoveImagen?: () => void;
+  onDelete?: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+
+  function pick(file?: File | null) {
+    if (file && file.type.startsWith("image/")) onCapture(file);
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-100 p-3 space-y-2">
+      <div className="flex items-center gap-2">
+        <input
+          className="flex-1 rounded-lg border border-slate-200 h-9 px-3 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          placeholder={placeholder}
+          value={nombre}
+          onChange={(e) => onNombreChange(e.target.value)}
+        />
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label={`Eliminar ${nombre || "identificación"}`}
+            className="text-slate-300 hover:text-red-500 transition-colors"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {src ? (
+        <div className="relative rounded-lg overflow-hidden border border-slate-200">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={src} alt={nombre || "Identificación"} className="w-full h-40 object-cover" />
+          {onRemoveImagen && (
+            <button
+              type="button"
+              onClick={onRemoveImagen}
+              aria-label="Quitar imagen"
+              className="absolute top-2 right-2 bg-red-500 text-white p-1.5 rounded-lg hover:bg-red-600"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragOver(false);
+            pick(e.dataTransfer.files?.[0]);
+          }}
+          className={`w-full h-28 border-2 border-dashed rounded-lg flex flex-col items-center justify-center gap-1.5 transition-colors ${
+            dragOver
+              ? "border-primary text-primary bg-primary/5"
+              : "border-slate-300 text-slate-400 hover:border-primary hover:text-primary"
+          }`}
+        >
+          <Camera className="w-5 h-5" />
+          <span className="text-xs font-bold">Tomar foto, elegir o arrastrar</span>
+        </button>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          pick(e.target.files?.[0]);
+          e.target.value = "";
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -6,6 +6,9 @@ import { parseDecimal, decimalInputValue } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
 import { SISTEMAS_ADQUISICION } from "@/lib/db/types";
+import type { EquipoIdentificacion } from "@/lib/db/types";
+import { useImagenSrc } from "@/hooks/use-imagen-src";
+import { ImagenConTitulo } from "@/components/imagen-con-titulo";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { pushSingle } from "@/lib/supabase/sync-engine";
@@ -239,6 +242,34 @@ function ReadonlyField({
   );
 }
 
+/** Una fila de identificación del equipo (#61): resuelve su imagen y delega en <ImagenConTitulo>. */
+function IdentificacionRow({
+  iden,
+  onNombre,
+  onCapture,
+  onRemoveImagen,
+  onDelete,
+}: {
+  iden: EquipoIdentificacion;
+  onNombre: (value: string) => void;
+  onCapture: (file: File) => void;
+  onRemoveImagen: () => void;
+  onDelete: () => void;
+}) {
+  const src = useImagenSrc(iden);
+  return (
+    <ImagenConTitulo
+      nombre={iden.nombre ?? ""}
+      src={src}
+      placeholder="Ej: Placa del fabricante / N.º de inventario"
+      onNombreChange={onNombre}
+      onCapture={onCapture}
+      onRemoveImagen={onRemoveImagen}
+      onDelete={onDelete}
+    />
+  );
+}
+
 // ─── Progress bar ───
 
 function ProgressBar({ percent, label }: { percent: number; label: string }) {
@@ -332,6 +363,16 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
           .sort((a, b) => (a.creado_en ?? "").localeCompare(b.creado_en ?? ""))
       : [];
 
+    const identificaciones = visita.equipo_id
+      ? (await db.equipo_identificaciones.where("equipo_id").equals(visita.equipo_id).toArray())
+          .filter((r) => !r.deleted_at)
+          .sort(
+            (a, b) =>
+              (a.orden ?? 0) - (b.orden ?? 0) ||
+              (a.creado_en ?? "").localeCompare(b.creado_en ?? "")
+          )
+      : [];
+
     const contactos = cliente?.id
       ? await db.contactos.where("cliente_id").equals(cliente.id).toArray()
       : [];
@@ -345,6 +386,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
       solicitud,
       tubos,
       nroTubos: tubos.length,
+      identificaciones,
       contactos,
     };
   }, [isReady, visitaId]);
@@ -451,6 +493,43 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
     pushSingle("tubos", tuboId);
   }
 
+  // ─── Identificaciones del equipo (#61: nombre + foto) ───
+
+  async function addIdentificacion() {
+    const equipoId = data?.equipo?.id;
+    if (!equipoId) return;
+    const nueva = {
+      id: randomUUID(),
+      equipo_id: equipoId,
+      orden: (data?.identificaciones?.length ?? 0) + 1,
+      creado_en: now(),
+      sync_status: "pending" as const,
+      last_modified: now(),
+    };
+    await db.equipo_identificaciones.add(nueva);
+    pushSingle("equipo_identificaciones", nueva.id);
+  }
+
+  async function saveIdentificacion(idenId: string, patch: Partial<EquipoIdentificacion>) {
+    if (!idenId) return;
+    await db.equipo_identificaciones.update(idenId, {
+      ...patch,
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("equipo_identificaciones", idenId);
+  }
+
+  async function deleteIdentificacion(idenId: string) {
+    if (!idenId) return;
+    await db.equipo_identificaciones.update(idenId, {
+      deleted_at: now(),
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("equipo_identificaciones", idenId);
+  }
+
   async function saveVisita(field: string, value: string, numeric = false) {
     if (!visitaId) return;
     const parsed = numeric ? (value === "" ? undefined : parseDecimal(value)) : value || undefined;
@@ -524,6 +603,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   const { visita, equipo, ubicacion, sede, cliente, solicitud, tubos, nroTubos, contactos } = data;
+  const identificaciones = data.identificaciones;
 
   const medico = getContacto("medico_responsable");
   const tecnologo = getContacto("tecnologo");
@@ -952,6 +1032,45 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             icon={Zap}
             onSave={(v) => saveEquipo("gen_energia_fotones_mev", v)}
           />
+        </div>
+      </SectionCard>
+
+      {/* 3b. Identificaciones del Equipo (placas, inventario, calibración…) */}
+      <SectionCard
+        icon={FileText}
+        title="Identificaciones del Equipo"
+        subtitle="Placas / inventario / calibración — foto rotulada"
+        progress={identificaciones.length > 0 ? 100 : 0}
+      >
+        <div className="space-y-3">
+          {identificaciones.length === 0 && (
+            <p className="text-sm text-slate-400 font-medium py-2 text-center">
+              Sin identificaciones cargadas
+            </p>
+          )}
+          {identificaciones.map((iden) => (
+            <IdentificacionRow
+              key={iden.id}
+              iden={iden}
+              onNombre={(v) => saveIdentificacion(iden.id!, { nombre: v || undefined })}
+              onCapture={(file) =>
+                saveIdentificacion(iden.id!, { blob_local: file, url_storage: null })
+              }
+              onRemoveImagen={() =>
+                saveIdentificacion(iden.id!, { blob_local: null, url_storage: null })
+              }
+              onDelete={() => deleteIdentificacion(iden.id!)}
+            />
+          ))}
+          <button
+            type="button"
+            onClick={addIdentificacion}
+            disabled={!equipo}
+            className="w-full flex items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 py-2.5 text-sm font-bold text-slate-500 hover:border-primary hover:text-primary transition-colors disabled:opacity-40"
+          >
+            <Plus className="w-4 h-4" />
+            Agregar identificación
+          </button>
         </div>
       </SectionCard>
 

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -141,4 +141,16 @@ describe("InfoModulo — tubos desde Información General (#61 D2b)", () => {
       expect(t?.deleted_at).toBeTruthy();
     });
   });
+
+  it("#61 (D2c): agrega una identificación del equipo desde su botón", async () => {
+    const { visita, equipo } = await seedGraph();
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    expect(await db.equipo_identificaciones.where("equipo_id").equals(equipo.id!).count()).toBe(0);
+    fireEvent.click(screen.getByRole("button", { name: /agregar identificación/i }));
+    await waitFor(async () =>
+      expect(await db.equipo_identificaciones.where("equipo_id").equals(equipo.id!).count()).toBe(1)
+    );
+  });
 });

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -11,6 +11,7 @@ import type {
   Tubo,
   Colimador,
   Gantry,
+  EquipoIdentificacion,
   SalaDimensiones,
   ParteEquipo,
   ValoresReferencia,
@@ -66,6 +67,7 @@ class EyCDatabase extends Dexie {
   tubos!: EntityTable<Tubo, "id">;
   colimadores!: EntityTable<Colimador, "id">;
   gantry!: EntityTable<Gantry, "id">;
+  equipo_identificaciones!: EntityTable<EquipoIdentificacion, "id">;
   sala_dimensiones!: EntityTable<SalaDimensiones, "id">;
   partes_equipo!: EntityTable<ParteEquipo, "id">;
   valores_referencia!: EntityTable<ValoresReferencia, "id">;
@@ -322,6 +324,15 @@ class EyCDatabase extends Dexie {
     // ─────────────────────────────────────────────────────────────
     this.version(15).stores({
       sync_retry: "&[table_name+record_id], table_name, next_attempt_at",
+    });
+
+    // ─────────────────────────────────────────────────────────────
+    //  v16 — "otras identificaciones" del equipo (#61). Tabla nueva,
+    //  aditiva. Foto rotulada por equipo; sincroniza bidireccional y
+    //  su blob va al bucket `evidencias` como las demás imágenes.
+    // ─────────────────────────────────────────────────────────────
+    this.version(16).stores({
+      equipo_identificaciones: "id, equipo_id, sync_status",
     });
   }
 }

--- a/src/lib/db/migrations.test.ts
+++ b/src/lib/db/migrations.test.ts
@@ -19,8 +19,8 @@ describe("esquema — instalación nueva", () => {
     await resetTestDb();
   });
 
-  it("abre en la versión 15", () => {
-    expect(db.verno).toBe(15);
+  it("abre en la versión 16", () => {
+    expect(db.verno).toBe(16);
   });
 
   it("las tablas de dominio tienen PK string 'id' (migración v13 a UUID)", () => {

--- a/src/lib/db/recovery.test.ts
+++ b/src/lib/db/recovery.test.ts
@@ -64,7 +64,7 @@ describe("resetAndReopen", () => {
     await resetAndReopen();
 
     expect(db.isOpen()).toBe(true);
-    expect(db.verno).toBe(15);
+    expect(db.verno).toBe(16);
     expect(await db.clientes.count()).toBe(0);
   });
 });

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -250,6 +250,22 @@ export interface Gantry extends Partial<SyncFields> {
   creado_en?: string;
 }
 
+/**
+ * "Otras identificaciones" del equipo (#61): una foto rotulada — placa del
+ * fabricante, número de inventario de la institución, etiqueta de calibración,
+ * etc. `blob_local` es la imagen local; se sube al bucket y su path queda en
+ * `url_storage` (mismo pipeline que las evidencias, #67).
+ */
+export interface EquipoIdentificacion extends Partial<SyncFields> {
+  id?: string;
+  equipo_id: string;
+  nombre?: string;
+  orden?: number;
+  blob_local?: Blob | null;
+  url_storage?: string | null;
+  creado_en?: string;
+}
+
 export interface SalaDimensiones {
   id?: string;
   ubicacion_id: string;

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -130,6 +130,26 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(text).not.toContain("TUBO-BORRADO");
   });
 
+  it("#61 (D2c): las identificaciones del equipo salen en el informe; una borrada no", async () => {
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.equipo_identificaciones.bulkAdd([
+      { id: randomUUID(), equipo_id: equipo.id!, nombre: "IDEN-PLACA-FABRICANTE", orden: 1 },
+      { id: randomUUID(), equipo_id: equipo.id!, nombre: "IDEN-INVENTARIO", orden: 2 },
+      {
+        id: randomUUID(),
+        equipo_id: equipo.id!,
+        nombre: "IDEN-BORRADA",
+        orden: 3,
+        deleted_at: new Date().toISOString(),
+      },
+    ]);
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("Identificaciones del Equipo");
+    expect(text).toContain("IDEN-PLACA-FABRICANTE");
+    expect(text).toContain("IDEN-INVENTARIO");
+    expect(text).not.toContain("IDEN-BORRADA");
+  });
+
   it("#63: piso y techo del blindaje salen en la tabla de áreas colindantes", async () => {
     const { visita, ubicacion } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
     await db.ubicaciones_rx.update(ubicacion.id!, {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -78,6 +78,16 @@ export async function getLogoBase64(): Promise<string> {
 
 // ─── Formateo de campos del informe ───
 
+/** Blob → data URL (para incrustar imágenes locales en el PDF). */
+function blobADataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error("FileReader"));
+    reader.readAsDataURL(blob);
+  });
+}
+
 /** "No aplica" para null / undefined / "" ; el valor tal cual si tiene contenido. */
 export function textoCampo(v: string | null | undefined, fallback = "No aplica"): string {
   const s = (v ?? "").trim();
@@ -109,6 +119,7 @@ interface DatosInforme {
   sede?: Sede;
   cliente?: Cliente;
   tubos: Tubo[];
+  identificaciones: { nombre: string; dataUrl?: string }[];
   sala?: SalaDimensiones;
   tecnico?: Usuario;
   contactos: Contacto[];
@@ -152,6 +163,20 @@ async function recopilarDatos(visitaId: string): Promise<DatosInforme | null> {
         (t) => !t.deleted_at
       )
     : [];
+
+  const idenRows = visita.equipo_id
+    ? (
+        await db.equipo_identificaciones.where("equipo_id").equals(visita.equipo_id).toArray()
+      ).filter((r) => !r.deleted_at)
+    : [];
+  const identificaciones = await Promise.all(
+    idenRows
+      .sort((a, b) => (a.orden ?? 0) - (b.orden ?? 0))
+      .map(async (r) => ({
+        nombre: r.nombre?.trim() || "Identificación",
+        dataUrl: r.blob_local ? await blobADataUrl(r.blob_local).catch(() => undefined) : undefined,
+      }))
+  );
   const sala = visita.ubicacion_id
     ? await db.sala_dimensiones.where("ubicacion_id").equals(visita.ubicacion_id).first()
     : undefined;
@@ -195,6 +220,7 @@ async function recopilarDatos(visitaId: string): Promise<DatosInforme | null> {
     sede,
     cliente,
     tubos,
+    identificaciones,
     sala,
     tecnico,
     contactos,
@@ -697,6 +723,29 @@ export async function generarPreInforme(
 
     y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
   });
+
+  // Identificaciones del equipo (placas / inventario / calibración) — #61
+  if (datos.identificaciones.length > 0) {
+    checkPage(20);
+    addSubsectionTitle("", "Identificaciones del Equipo");
+    datos.identificaciones.forEach((iden) => {
+      checkPage(iden.dataUrl ? 60 : 10);
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(8);
+      doc.setTextColor(...COLOR_GRAY);
+      doc.text(iden.nombre, MARGIN, y);
+      y += 4;
+      if (iden.dataUrl) {
+        try {
+          doc.addImage(iden.dataUrl, MARGIN, y, 50, 40);
+          y += 44;
+        } catch {
+          y += 2;
+        }
+      }
+    });
+    y += 2;
+  }
 
   // Características del Colimador y Sistema de Adquisición
   checkPage(30);

--- a/src/lib/supabase/storage.test.ts
+++ b/src/lib/supabase/storage.test.ts
@@ -34,6 +34,15 @@ describe("storage — evidenciaPath", () => {
   it("sin visita_id usa 'sin-visita'", () => {
     expect(evidenciaPath("conv_evidencias", { id: "x", slot: "s" })).toBe("sin-visita/gen/s.jpg");
   });
+
+  it("equipo_identificaciones → equipos/{equipo_id}/{id}.jpg", () => {
+    expect(evidenciaPath("equipo_identificaciones", { id: "iden-1", equipo_id: "eq-9" })).toBe(
+      "equipos/eq-9/iden-1.jpg"
+    );
+    expect(evidenciaPath("equipo_identificaciones", { id: "iden-2" })).toBe(
+      "equipos/sin-equipo/iden-2.jpg"
+    );
+  });
 });
 
 describe("storage — compressImage", () => {

--- a/src/lib/supabase/storage.ts
+++ b/src/lib/supabase/storage.ts
@@ -19,6 +19,7 @@ export const EVIDENCIAS_BUCKET = "evidencias";
 export interface RegistroConImagen {
   id?: string;
   visita_id?: string;
+  equipo_id?: string;
   prueba_codigo?: string;
   slot?: string;
   tipo?: string;
@@ -29,8 +30,9 @@ export interface RegistroConImagen {
 /**
  * Ruta de una evidencia dentro del bucket. Una carpeta por visita para
  * que sea navegable en el panel de Storage; el índice real es la fila.
- *   conv_evidencias → {visita_id}/{prueba_codigo}/{slot}.jpg
- *   evidencias      → {visita_id}/{tipo|id}.jpg
+ *   conv_evidencias         → {visita_id}/{prueba_codigo}/{slot}.jpg
+ *   equipo_identificaciones → equipos/{equipo_id}/{id}.jpg
+ *   evidencias              → {visita_id}/{tipo|id}.jpg
  */
 export function evidenciaPath(localTable: string, rec: RegistroConImagen): string {
   const visita = rec.visita_id ?? "sin-visita";
@@ -39,6 +41,10 @@ export function evidenciaPath(localTable: string, rec: RegistroConImagen): strin
     const prueba = (rec.prueba_codigo ?? "gen").replace(/[^\w.-]/g, "_");
     const slot = (rec.slot ?? id).replace(/[^\w.-]/g, "_");
     return `${visita}/${prueba}/${slot}.jpg`;
+  }
+  if (localTable === "equipo_identificaciones") {
+    const equipo = (rec.equipo_id ?? "sin-equipo").replace(/[^\w.-]/g, "_");
+    return `equipos/${equipo}/${id}.jpg`;
   }
   const nombre = (rec.tipo ?? rec.slot ?? id).replace(/[^\w.-]/g, "_");
   return `${visita}/${nombre}.jpg`;

--- a/src/lib/supabase/sync-engine.ts
+++ b/src/lib/supabase/sync-engine.ts
@@ -175,7 +175,7 @@ function mergeLocalBinaries(
 }
 
 // Tablas cuyo `blob_local` es una imagen que va al bucket `evidencias` (#67).
-const IMAGE_BLOB_TABLES = new Set(["conv_evidencias", "evidencias"]);
+const IMAGE_BLOB_TABLES = new Set(["conv_evidencias", "evidencias", "equipo_identificaciones"]);
 
 /**
  * Antes de pushear una fila de imagen: si tiene `blob_local` y todavía no
@@ -237,6 +237,7 @@ export const SYNC_TABLES = [
   { local: "tubos", remote: "tubos" },
   { local: "colimadores", remote: "colimadores" },
   { local: "gantry", remote: "gantry" },
+  { local: "equipo_identificaciones", remote: "equipo_identificaciones" },
   { local: "solicitudes", remote: "solicitudes" },
   // ─── Datos de campo ───
   { local: "visitas", remote: "visitas" },

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1200,6 +1200,47 @@ export type Database = {
           },
         ];
       };
+      equipo_identificaciones: {
+        Row: {
+          creado_en: string;
+          equipo_id: string;
+          id: string;
+          last_modified: string;
+          nombre: string | null;
+          orden: number | null;
+          sync_status: string;
+          url_storage: string | null;
+        };
+        Insert: {
+          creado_en?: string;
+          equipo_id: string;
+          id?: string;
+          last_modified?: string;
+          nombre?: string | null;
+          orden?: number | null;
+          sync_status?: string;
+          url_storage?: string | null;
+        };
+        Update: {
+          creado_en?: string;
+          equipo_id?: string;
+          id?: string;
+          last_modified?: string;
+          nombre?: string | null;
+          orden?: number | null;
+          sync_status?: string;
+          url_storage?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "equipo_identificaciones_equipo_id_fkey";
+            columns: ["equipo_id"];
+            isOneToOne: false;
+            referencedRelation: "equipos";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       equipo_movimientos: {
         Row: {
           creado_en: string;

--- a/supabase/migrations/021_equipo_identificaciones.sql
+++ b/supabase/migrations/021_equipo_identificaciones.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+--  021 — "Otras identificaciones" del equipo (#61)
+--
+--  Una foto rotulada por equipo: placa del fabricante, número de
+--  inventario de la institución, etiqueta de calibración, etc. Se
+--  captura desde Información General y se renderiza en el informe.
+--  El binario va al bucket `evidencias` (ruta equipos/{equipo_id}/{id}.jpg);
+--  la fila guarda el PATH en `url_storage`.
+--
+--  Sincroniza bidireccional como el resto de tablas de campo. RLS con
+--  el mismo modelo permisivo para `authenticated` que la 017.
+--  Idempotente.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.equipo_identificaciones (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  equipo_id     uuid NOT NULL REFERENCES public.equipos (id) ON DELETE CASCADE,
+  nombre        text,
+  orden         integer,
+  url_storage   text,
+  deleted_at    timestamptz,
+  sync_status   text DEFAULT 'synced',
+  last_modified timestamptz NOT NULL DEFAULT now(),
+  creado_en     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS equipo_identificaciones_equipo_id_idx
+  ON public.equipo_identificaciones (equipo_id);
+
+ALTER TABLE public.equipo_identificaciones ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS equipo_identificaciones_auth_select ON public.equipo_identificaciones;
+DROP POLICY IF EXISTS equipo_identificaciones_auth_insert ON public.equipo_identificaciones;
+DROP POLICY IF EXISTS equipo_identificaciones_auth_update ON public.equipo_identificaciones;
+DROP POLICY IF EXISTS equipo_identificaciones_auth_delete ON public.equipo_identificaciones;
+
+CREATE POLICY equipo_identificaciones_auth_select ON public.equipo_identificaciones
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY equipo_identificaciones_auth_insert ON public.equipo_identificaciones
+  FOR INSERT TO authenticated WITH CHECK (true);
+CREATE POLICY equipo_identificaciones_auth_update ON public.equipo_identificaciones
+  FOR UPDATE TO authenticated USING (true) WITH CHECK (true);
+CREATE POLICY equipo_identificaciones_auth_delete ON public.equipo_identificaciones
+  FOR DELETE TO authenticated USING (true);


### PR DESCRIPTION
**Nota:** este commit ya se había hecho sobre la rama de D2b, pero la PR #76 se mergeó **solo con el commit de D2b**. Este PR recupera D2c como cambio propio (cherry-pick, cero conflictos, `npm run verify` verde sobre `main` actual).

---

Cierra la parte de **imágenes** de #61: *"otras identificaciones del equipo con input para cargar el nombre y la imagen… desde la creación del equipo, también en información general, renderizado en el informe"*.

| Pieza | Detalle |
|---|---|
| Tabla `equipo_identificaciones` | `equipo_id`, `nombre`, `orden`, `url_storage`, `blob_local` (local-only). Dexie **v16**, migración **`021_equipo_identificaciones.sql`** (la corre el dueño — RLS permisiva como la 017). Tipos Supabase + `SYNC_TABLES` + `IMAGE_BLOB_TABLES`. `evidenciaPath` → `equipos/{equipo_id}/{id}.jpg`. |
| `<ImagenConTitulo>` | Componente compartido nuevo (`src/components/imagen-con-titulo.tsx`): título + slot de imagen con **click / archivo / drag & drop** + quitar imagen + eliminar fila. Lo reutiliza el Paquete E (#66). |
| `info-modulo` | Sección **"Identificaciones del Equipo"** — agregar / renombrar / capturar / quitar imagen / eliminar (soft-delete). El blob sube por el pipeline de #67. |
| `generar-pre-informe` | Subsección **"Identificaciones del Equipo"** en el PDF: nombre + imagen (data URL del blob local, best-effort). |

## Verificación
- `npm run verify` — typecheck + lint (0 errores) + format + **584 tests** + build. Verde.
- Tests: dos identificaciones en el PDF (una borrada no); `evidenciaPath` de identificaciones; "Agregar identificación" desde el smoke de InfoModulo; bump 15→16 en los tests de versión de Dexie.

## Migración que corre el dueño
**`021_equipo_identificaciones.sql`** (aditiva, no destructiva).

## Pendiente de #61 (issue de seguimiento)
Imágenes por subtabla (tubo / colimador / gantry), captura de colimador / gantry desde Info, identificaciones en el diálogo de alta de equipo.

## Issue
#61 (parcial). El usuario lo cierra manualmente.