### PR TITLE
fix(contactos): etiqueta legible de 'responsable_visita' + robustez de imports

### DIFF
--- a/src/app/dashboard/clientes/[id]/page.tsx
+++ b/src/app/dashboard/clientes/[id]/page.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { ClienteFormDialog } from "@/components/cliente-form-dialog";
-import { ContactoFormDialog } from "@/components/contacto-form-dialog";
+import { ContactoFormDialog, CARGO_LABELS } from "@/components/contacto-form-dialog";
 import { SedeFormDialog } from "@/components/sede-form-dialog";
 import { UbicacionFormDialog } from "@/components/ubicacion-form-dialog";
 import { EquipoFormDialog } from "@/components/equipo-form-dialog";
@@ -33,14 +33,6 @@ import type { Sede, UbicacionRx, Equipo, Contacto } from "@/lib/db/types";
 // ============================================================
 //  Detalle de cliente con tabs: Info, Contactos, Sedes
 // ============================================================
-
-const CARGO_LABELS: Record<string, string> = {
-  medico_responsable: "Médico Responsable",
-  tecnologo: "Tecnólogo",
-  opr: "OPR",
-  representante: "Representante",
-  otro: "Otro",
-};
 
 const TIPO_EQUIPO_LABELS: Record<string, string> = {
   CONVENCIONAL: "Convencional",

--- a/src/components/contacto-form-dialog.test.tsx
+++ b/src/components/contacto-form-dialog.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@/lib/supabase/sync-engine", () => ({
   pushSingle: vi.fn(),
 }));
 
-import { ContactoFormDialog, CARGO_OPTIONS } from "./contacto-form-dialog";
+import { ContactoFormDialog, CARGO_OPTIONS, CARGO_LABELS } from "./contacto-form-dialog";
 
 async function seedContacto(overrides: Partial<Contacto> = {}): Promise<Contacto> {
   const contacto: Contacto = {
@@ -136,6 +136,13 @@ describe("ContactoFormDialog", () => {
         "otro",
       ])
     );
+  });
+
+  it("CARGO_LABELS mapea cada valor a su etiqueta (incl. responsable_visita)", () => {
+    expect(CARGO_LABELS.responsable_visita).toBe("Responsable de la Visita");
+    for (const opt of CARGO_OPTIONS) {
+      expect(CARGO_LABELS[opt.value]).toBe(opt.label);
+    }
   });
 
   it("al editar un contacto responsable_visita muestra su etiqueta, no 'Seleccionar cargo'", async () => {

--- a/src/components/contacto-form-dialog.tsx
+++ b/src/components/contacto-form-dialog.tsx
@@ -52,6 +52,11 @@ export const CARGO_OPTIONS = [
   { value: "otro", label: "Otro" },
 ];
 
+/** { valor de cargo → etiqueta legible } — derivado de CARGO_OPTIONS. */
+export const CARGO_LABELS: Record<string, string> = Object.fromEntries(
+  CARGO_OPTIONS.map((o) => [o.value, o.label])
+);
+
 export function ContactoFormDialog({
   open,
   onOpenChange,

--- a/src/components/equipo-form-dialog.tsx
+++ b/src/components/equipo-form-dialog.tsx
@@ -3,11 +3,18 @@
 import { useState } from "react";
 import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { db } from "@/lib/db";
-import type { Equipo, Tubo, Colimador, Gantry } from "@/lib/db/types";
+import {
+  TIPOS_EQUIPO,
+  SISTEMAS_ADQUISICION,
+  type Equipo,
+  type Tubo,
+  type Colimador,
+  type Gantry,
+  type TipoEquipo,
+} from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
 import { parseDecimal } from "@/lib/decimal";
 import { pushSingle } from "@/lib/supabase/sync-engine";
-import { TIPOS_EQUIPO, SISTEMAS_ADQUISICION, type TipoEquipo } from "@/lib/db/types";
 import {
   Dialog,
   DialogContent,


### PR DESCRIPTION
Recupera el commit que quedó fuera de la PR #79 (se mergeó antes de tiempo) + un endurecimiento chico.

## Cambios
1. **`responsable_visita` legible en el listado de contactos.** La tarjeta en `clientes/[id]` mostraba el cargo crudo (`responsable_visita` con guion) porque su `CARGO_LABELS` local no incluía el valor. Se elimina el dict local y se usa un `CARGO_LABELS` **derivado de `CARGO_OPTIONS`** (exportado desde `contacto-form-dialog.tsx`) — una sola fuente para el diálogo y el listado.
2. **`equipo-form-dialog.tsx`: un solo `import` de `@/lib/db/types`** en vez de dos statements separados. Turbopack HMR a veces desincroniza imports partidos del mismo módulo en dev y deja uno `undefined` → `Cannot read properties of undefined (reading 'map')` sobre `SISTEMAS_ADQUISICION`. No es bug de código (el build y `equipo-form-dialog.test.tsx` pasan); esto lo previene.

## Verificación
- `npm run verify` — typecheck + lint (0 errores) + format + **590 tests** + build. Verde.

## Nota
La migración **022** (`contactos.cargo` CHECK) ya está en `main` (vino con #79). Sigue pendiente que el dueño la corra en Supabase.