### PR TITLE
fix(informe): cierre de #61 (fotos por subtabla + tarjeta) + regresiones de pruebas locales A–D

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -27,7 +27,9 @@ const nextConfig: NextConfig = {
               // Next.js requiere unsafe-inline para hidratación y RSC
               "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
               "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: blob:",
+              // Las evidencias del bucket privado se muestran con signed URLs
+              // servidas desde el host de Supabase Storage.
+              `img-src 'self' data: blob: https://${supabaseHost}`,
               `connect-src 'self' https://${supabaseHost} wss://${supabaseHost}`,
               "font-src 'self'",
               "worker-src 'self' blob:",

--- a/src/components/equipo-form-dialog.tsx
+++ b/src/components/equipo-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { db } from "@/lib/db";
 import {
@@ -11,10 +11,13 @@ import {
   type Colimador,
   type Gantry,
   type TipoEquipo,
+  type SubtablaIdentificacion,
 } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
 import { parseDecimal } from "@/lib/decimal";
 import { pushSingle } from "@/lib/supabase/sync-engine";
+import { useImagenSrc } from "@/hooks/use-imagen-src";
+import { ImagenConTitulo } from "@/components/imagen-con-titulo";
 import {
   Dialog,
   DialogContent,
@@ -33,7 +36,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Loader2, ChevronDown, ChevronUp } from "lucide-react";
+import { Loader2, ChevronDown, ChevronUp, Plus } from "lucide-react";
 
 // ============================================================
 //  Dialog para crear / editar un equipo (multi-sección)
@@ -97,6 +100,65 @@ function CollapsibleSection({
   );
 }
 
+// ─── Identificaciones del equipo (fotos de referencia + "otras") ───
+
+type IdenStage = {
+  id: string;
+  subtabla: SubtablaIdentificacion;
+  /** Para subtabla="tubo": id del tubo al que pertenece la foto. */
+  ref_id?: string;
+  nombre: string;
+  /** Imagen nueva sin subir. */
+  file?: File;
+  /** Estado ya persistido (al editar). */
+  blob_local?: Blob | null;
+  url_storage?: string | null;
+  isNew: boolean;
+};
+
+/** Slot de imagen del diálogo: resuelve el preview de un `File` nuevo o de una fila existente. */
+function StageImagenRow({
+  iden,
+  conTitulo,
+  onNombre,
+  onCapture,
+  onRemove,
+}: {
+  iden: IdenStage | undefined;
+  conTitulo: boolean;
+  onNombre?: (v: string) => void;
+  onCapture: (file: File) => void;
+  onRemove: () => void;
+}) {
+  const file = iden?.file;
+  const [objUrl, setObjUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (!file) {
+      setObjUrl(null);
+      return;
+    }
+    const u = URL.createObjectURL(file);
+    setObjUrl(u);
+    return () => URL.revokeObjectURL(u);
+  }, [file]);
+  const fromRow = useImagenSrc(
+    file ? {} : { blob_local: iden?.blob_local, url_storage: iden?.url_storage }
+  );
+  const src = objUrl ?? fromRow;
+
+  return (
+    <ImagenConTitulo
+      nombre={iden?.nombre ?? ""}
+      src={src}
+      placeholder="Ej: Placa del fabricante / N.º de inventario"
+      onNombreChange={conTitulo ? onNombre : undefined}
+      onCapture={onCapture}
+      onRemoveImagen={src ? onRemove : undefined}
+      onDelete={conTitulo ? onRemove : undefined}
+    />
+  );
+}
+
 export function EquipoFormDialog({
   open,
   onOpenChange,
@@ -154,6 +216,42 @@ export function EquipoFormDialog({
 
   const [saving, setSaving] = useState(false);
 
+  // Identificaciones del equipo: fotos de referencia (generador/tubo/colimador)
+  // + lista "otras". Se acumulan en el form y se persisten en handleSave.
+  const [identificaciones, setIdentificaciones] = useState<IdenStage[]>([]);
+  const [idenBorradas, setIdenBorradas] = useState<string[]>([]);
+
+  const getRefIden = (sub: SubtablaIdentificacion) =>
+    identificaciones.find((i) => i.subtabla === sub);
+  const otrasIden = identificaciones.filter((i) => i.subtabla === "otra");
+
+  function setRefImagen(sub: SubtablaIdentificacion, file: File) {
+    setIdentificaciones((prev) => {
+      const ex = prev.find((i) => i.subtabla === sub);
+      if (ex) return prev.map((i) => (i.subtabla === sub ? { ...i, file } : i));
+      return [...prev, { id: randomUUID(), subtabla: sub, nombre: "", file, isNew: true }];
+    });
+  }
+  function quitarIden(id: string) {
+    setIdentificaciones((prev) => {
+      const ex = prev.find((i) => i.id === id);
+      if (ex && !ex.isNew) setIdenBorradas((b) => [...b, id]);
+      return prev.filter((i) => i.id !== id);
+    });
+  }
+  function addOtraIden() {
+    setIdentificaciones((prev) => [
+      ...prev,
+      { id: randomUUID(), subtabla: "otra", nombre: "", isNew: true },
+    ]);
+  }
+  function setOtraNombre(id: string, nombre: string) {
+    setIdentificaciones((prev) => prev.map((i) => (i.id === id ? { ...i, nombre } : i)));
+  }
+  function setOtraFile(id: string, file: File) {
+    setIdentificaciones((prev) => prev.map((i) => (i.id === id ? { ...i, file } : i)));
+  }
+
   // Repoblar el form al reabrir (el padre controla `open` directo). Solo en
   // la transición de apertura — ver useReseedOnOpen (#11).
   useReseedOnOpen(open, () => {
@@ -208,6 +306,29 @@ export function EquipoFormDialog({
       setGantryModelo(gantryReg?.modelo ?? "");
       setGantrySerie(gantryReg?.numero_serie ?? "");
       setGantryDetector(gantryReg?.tipo_detector ?? "");
+
+      const idenRows = equipo?.id
+        ? (await db.equipo_identificaciones.where("equipo_id").equals(equipo.id).toArray()).filter(
+            (r) => !r.deleted_at
+          )
+        : [];
+      setIdentificaciones(
+        idenRows
+          // El diálogo gestiona un solo tubo; solo se trae la foto de ESE tubo.
+          // Las fotos de otros tubos (creados desde Info) se dejan intactas.
+          .filter((r) => (r.subtabla ?? "otra") !== "tubo" || r.ref_id === tubo?.id)
+          .sort((a, b) => (a.orden ?? 0) - (b.orden ?? 0))
+          .map((r) => ({
+            id: r.id!,
+            subtabla: (r.subtabla ?? "otra") as SubtablaIdentificacion,
+            ref_id: r.ref_id,
+            nombre: r.nombre ?? "",
+            blob_local: r.blob_local ?? null,
+            url_storage: r.url_storage ?? null,
+            isNew: false,
+          }))
+      );
+      setIdenBorradas([]);
     })();
   });
 
@@ -278,70 +399,129 @@ export function EquipoFormDialog({
       // revés). Los ids a pushear se acumulan y se envían tras el commit.
       const toPush: Array<[Parameters<typeof pushSingle>[0], string]> = [];
 
-      await db.transaction("rw", [db.equipos, db.tubos, db.colimadores, db.gantry], async () => {
-        let equipoId: string;
-        if (isEdit && equipo?.id) {
-          await db.equipos.update(equipo.id, equipoData);
-          equipoId = equipo.id;
-        } else {
-          equipoId = (await db.equipos.add({ ...equipoData, id: randomUUID() })) as string;
-        }
-        toPush.push(["equipos", equipoId]);
+      await db.transaction(
+        "rw",
+        [db.equipos, db.tubos, db.colimadores, db.gantry, db.equipo_identificaciones],
+        async () => {
+          let equipoId: string;
+          if (isEdit && equipo?.id) {
+            await db.equipos.update(equipo.id, equipoData);
+            equipoId = equipo.id;
+          } else {
+            equipoId = (await db.equipos.add({ ...equipoData, id: randomUUID() })) as string;
+          }
+          toPush.push(["equipos", equipoId]);
 
-        // Hijo: si hay datos, crear/actualizar; si el usuario limpió todos los
-        // campos y existía una fila, soft-delete (no dejar la fila huérfana).
-        type HijoTable = {
-          update: (id: string, changes: Record<string, unknown>) => PromiseLike<unknown>;
-          add: (obj: Record<string, unknown>) => PromiseLike<unknown>;
-        };
-        const guardarHijo = async <T extends { equipo_id: string }>(
-          nombre: Parameters<typeof pushSingle>[0],
-          tabla: HijoTable,
-          data: T,
-          existingId: string | undefined,
-          tieneDatos: boolean
-        ) => {
-          if (tieneDatos) {
-            const payload = { ...data, equipo_id: equipoId };
-            if (existingId) {
-              await tabla.update(existingId, payload);
-              toPush.push([nombre, existingId]);
-            } else {
+          // Hijo: si hay datos, crear/actualizar; si el usuario limpió todos los
+          // campos y existía una fila, soft-delete (no dejar la fila huérfana).
+          type HijoTable = {
+            update: (id: string, changes: Record<string, unknown>) => PromiseLike<unknown>;
+            add: (obj: Record<string, unknown>) => PromiseLike<unknown>;
+          };
+          const guardarHijo = async <T extends { equipo_id: string }>(
+            nombre: Parameters<typeof pushSingle>[0],
+            tabla: HijoTable,
+            data: T,
+            existingId: string | undefined,
+            tieneDatos: boolean
+          ): Promise<string | undefined> => {
+            if (tieneDatos) {
+              const payload = { ...data, equipo_id: equipoId };
+              if (existingId) {
+                await tabla.update(existingId, payload);
+                toPush.push([nombre, existingId]);
+                return existingId;
+              }
               const nuevoId = (await tabla.add({ ...payload, id: randomUUID() })) as string;
               toPush.push([nombre, nuevoId]);
+              return nuevoId;
             }
-          } else if (existingId) {
-            await tabla.update(existingId, {
+            if (existingId) {
+              await tabla.update(existingId, {
+                deleted_at: now,
+                sync_status: "pending",
+                last_modified: now,
+              });
+              toPush.push([nombre, existingId]);
+            }
+            return undefined;
+          };
+
+          const tuboIdFinal = await guardarHijo(
+            "tubos",
+            db.tubos as unknown as HijoTable,
+            tuboData,
+            tuboId,
+            tuboTieneDatos
+          );
+          await guardarHijo(
+            "colimadores",
+            db.colimadores as unknown as HijoTable,
+            colData,
+            colId,
+            colTieneDatos
+          );
+          await guardarHijo(
+            "gantry",
+            db.gantry as unknown as HijoTable,
+            gantryData,
+            gantryId,
+            gantryTieneDatos
+          );
+
+          // Identificaciones del equipo (fotos de referencia + "otras")
+          for (const iden of identificaciones) {
+            const esOtra = iden.subtabla === "otra";
+            // "otras" sin título ni imagen → no vale la pena guardarlas
+            if (
+              esOtra &&
+              !iden.nombre.trim() &&
+              !iden.file &&
+              !iden.blob_local &&
+              !iden.url_storage
+            ) {
+              continue;
+            }
+            // La foto del tubo se ancla al tubo que se acaba de guardar; sin
+            // tubo no hay a qué asociarla (y no saldría en el informe).
+            const refId = iden.subtabla === "tubo" ? (tuboIdFinal ?? iden.ref_id) : undefined;
+            if (iden.subtabla === "tubo" && !refId) continue;
+            if (iden.isNew) {
+              await db.equipo_identificaciones.add({
+                id: iden.id,
+                equipo_id: equipoId,
+                subtabla: iden.subtabla,
+                ref_id: refId,
+                nombre: esOtra ? iden.nombre.trim() || undefined : undefined,
+                blob_local: iden.file ?? undefined,
+                url_storage: null,
+                orden: esOtra ? otrasIden.findIndex((o) => o.id === iden.id) + 1 : undefined,
+                creado_en: now,
+                sync_status: "pending",
+                last_modified: now,
+              });
+            } else {
+              await db.equipo_identificaciones.update(iden.id, {
+                subtabla: iden.subtabla,
+                ref_id: refId,
+                nombre: esOtra ? iden.nombre.trim() || undefined : undefined,
+                ...(iden.file ? { blob_local: iden.file, url_storage: null } : {}),
+                sync_status: "pending",
+                last_modified: now,
+              });
+            }
+            toPush.push(["equipo_identificaciones", iden.id]);
+          }
+          for (const id of idenBorradas) {
+            await db.equipo_identificaciones.update(id, {
               deleted_at: now,
               sync_status: "pending",
               last_modified: now,
             });
-            toPush.push([nombre, existingId]);
+            toPush.push(["equipo_identificaciones", id]);
           }
-        };
-
-        await guardarHijo(
-          "tubos",
-          db.tubos as unknown as HijoTable,
-          tuboData,
-          tuboId,
-          tuboTieneDatos
-        );
-        await guardarHijo(
-          "colimadores",
-          db.colimadores as unknown as HijoTable,
-          colData,
-          colId,
-          colTieneDatos
-        );
-        await guardarHijo(
-          "gantry",
-          db.gantry as unknown as HijoTable,
-          gantryData,
-          gantryId,
-          gantryTieneDatos
-        );
-      });
+        }
+      );
 
       onOpenChange(false);
       onSaved?.();
@@ -516,6 +696,21 @@ export function EquipoFormDialog({
                 </SelectContent>
               </Select>
             </div>
+
+            <div className="space-y-1.5 pt-2 border-t border-slate-100">
+              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                Foto de la placa / referencia del generador
+              </Label>
+              <StageImagenRow
+                iden={getRefIden("generador")}
+                conTitulo={false}
+                onCapture={(f) => setRefImagen("generador", f)}
+                onRemove={() => {
+                  const r = getRefIden("generador");
+                  if (r) quitarIden(r.id);
+                }}
+              />
+            </div>
           </CollapsibleSection>
 
           {/* Filtración */}
@@ -658,6 +853,21 @@ export function EquipoFormDialog({
                 />
               </div>
             </div>
+
+            <div className="space-y-1.5 pt-2 border-t border-slate-100">
+              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                Foto de la placa / referencia del tubo
+              </Label>
+              <StageImagenRow
+                iden={getRefIden("tubo")}
+                conTitulo={false}
+                onCapture={(f) => setRefImagen("tubo", f)}
+                onRemove={() => {
+                  const r = getRefIden("tubo");
+                  if (r) quitarIden(r.id);
+                }}
+              />
+            </div>
           </CollapsibleSection>
 
           {/* Colimador */}
@@ -693,6 +903,21 @@ export function EquipoFormDialog({
                   onChange={(e) => setColSerie(e.target.value)}
                 />
               </div>
+            </div>
+
+            <div className="space-y-1.5 pt-2 border-t border-slate-100">
+              <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">
+                Foto de la placa / referencia del colimador
+              </Label>
+              <StageImagenRow
+                iden={getRefIden("colimador")}
+                conTitulo={false}
+                onCapture={(f) => setRefImagen("colimador", f)}
+                onRemove={() => {
+                  const r = getRefIden("colimador");
+                  if (r) quitarIden(r.id);
+                }}
+              />
             </div>
           </CollapsibleSection>
 
@@ -742,6 +967,35 @@ export function EquipoFormDialog({
                   onChange={(e) => setGantryDetector(e.target.value)}
                 />
               </div>
+            </div>
+          </CollapsibleSection>
+
+          {/* Otras identificaciones del equipo de rayos X — lista título + imagen */}
+          <CollapsibleSection title="Otras identificaciones del equipo de rayos X">
+            <div className="space-y-3">
+              {otrasIden.length === 0 && (
+                <p className="text-sm text-slate-400 font-medium py-1 text-center">
+                  Sin identificaciones cargadas
+                </p>
+              )}
+              {otrasIden.map((iden) => (
+                <StageImagenRow
+                  key={iden.id}
+                  iden={iden}
+                  conTitulo
+                  onNombre={(v) => setOtraNombre(iden.id, v)}
+                  onCapture={(f) => setOtraFile(iden.id, f)}
+                  onRemove={() => quitarIden(iden.id)}
+                />
+              ))}
+              <button
+                type="button"
+                onClick={addOtraIden}
+                className="w-full flex items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 py-2.5 text-sm font-bold text-slate-500 hover:border-primary hover:text-primary transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                Agregar identificación
+              </button>
             </div>
           </CollapsibleSection>
         </div>

--- a/src/components/equipo-form-dialog.tsx
+++ b/src/components/equipo-form-dialog.tsx
@@ -114,7 +114,7 @@ export function EquipoFormDialog({
   );
   const [bucky, setBucky] = useState(equipo?.bucky ?? "");
 
-  // Características del equipo (la plantilla oficial las rotula "del generador")
+  // Generador (en la práctica son los datos del equipo — un solo aparato físico)
   const [genMarca, setGenMarca] = useState(equipo?.gen_marca ?? "");
   const [genModelo, setGenModelo] = useState(equipo?.gen_modelo ?? "");
   const [genSerie, setGenSerie] = useState(equipo?.gen_numero_serie ?? "");
@@ -443,8 +443,8 @@ export function EquipoFormDialog({
             </div>
           </CollapsibleSection>
 
-          {/* Características del Equipo (la plantilla oficial las rotula "del generador") */}
-          <CollapsibleSection title="Características del Equipo" defaultOpen={true}>
+          {/* Generador */}
+          <CollapsibleSection title="Generador" defaultOpen={true}>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-2">
                 <Label className="text-xs font-black text-slate-600 uppercase tracking-wider">

--- a/src/components/imagen-con-titulo.tsx
+++ b/src/components/imagen-con-titulo.tsx
@@ -13,7 +13,7 @@ import { Camera, Trash2, X } from "lucide-react";
 // ============================================================
 
 export function ImagenConTitulo({
-  nombre,
+  nombre = "",
   src,
   placeholder = "Título de la imagen",
   onNombreChange,
@@ -21,10 +21,11 @@ export function ImagenConTitulo({
   onRemoveImagen,
   onDelete,
 }: {
-  nombre: string;
+  nombre?: string;
   src: string | null;
   placeholder?: string;
-  onNombreChange: (value: string) => void;
+  /** Si se omite, no se muestra el input de título (solo la imagen). */
+  onNombreChange?: (value: string) => void;
   onCapture: (file: File) => void;
   onRemoveImagen?: () => void;
   onDelete?: () => void;
@@ -36,26 +37,32 @@ export function ImagenConTitulo({
     if (file && file.type.startsWith("image/")) onCapture(file);
   }
 
+  const conTitulo = typeof onNombreChange === "function";
+
   return (
     <div className="rounded-xl border border-slate-100 p-3 space-y-2">
-      <div className="flex items-center gap-2">
-        <input
-          className="flex-1 rounded-lg border border-slate-200 h-9 px-3 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-          placeholder={placeholder}
-          value={nombre}
-          onChange={(e) => onNombreChange(e.target.value)}
-        />
-        {onDelete && (
-          <button
-            type="button"
-            onClick={onDelete}
-            aria-label={`Eliminar ${nombre || "identificación"}`}
-            className="text-slate-300 hover:text-red-500 transition-colors"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
-        )}
-      </div>
+      {(conTitulo || onDelete) && (
+        <div className="flex items-center gap-2">
+          {conTitulo && (
+            <input
+              className="flex-1 rounded-lg border border-slate-200 h-9 px-3 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              placeholder={placeholder}
+              value={nombre}
+              onChange={(e) => onNombreChange!(e.target.value)}
+            />
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              aria-label={`Eliminar ${nombre || "identificación"}`}
+              className={`text-slate-300 hover:text-red-500 transition-colors ${conTitulo ? "" : "ml-auto"}`}
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      )}
 
       {src ? (
         <div className="relative rounded-lg overflow-hidden border border-slate-200">

--- a/src/components/visita-modulos/grupo-a-modulo.tsx
+++ b/src/components/visita-modulos/grupo-a-modulo.tsx
@@ -489,23 +489,34 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
+    const now = new Date().toISOString();
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
-      await db.conv_evidencias.update(existing.id, { blob_local: blob });
+      // Reemplazo: re-marcar pending y limpiar url_storage para que el push
+      // vuelva a subir el binario nuevo al bucket (#67).
+      await db.conv_evidencias.update(existing.id, {
+        blob_local: blob,
+        url_storage: null,
+        sync_status: "pending",
+        last_modified: now,
+      });
+      pushSingle("conv_evidencias", existing.id);
     } else {
+      const nuevoId = randomUUID();
       await db.conv_evidencias.add({
-        id: randomUUID(),
+        id: nuevoId,
         visita_id: visitaId,
         prueba_codigo: pruebaCodigo,
         slot,
         blob_local: blob,
-        fecha_captura: new Date().toISOString(),
-        creado_en: new Date().toISOString(),
+        fecha_captura: now,
+        creado_en: now,
         sync_status: "pending" as const,
-        last_modified: new Date().toISOString(),
+        last_modified: now,
       });
+      pushSingle("conv_evidencias", nuevoId);
     }
   }
 

--- a/src/components/visita-modulos/grupo-b-modulo.tsx
+++ b/src/components/visita-modulos/grupo-b-modulo.tsx
@@ -542,23 +542,34 @@ export function GrupoBModulo({ visitaId: id }: { visitaId: string }) {
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
+    const now = new Date().toISOString();
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
-      await db.conv_evidencias.update(existing.id, { blob_local: blob });
+      // Reemplazo: re-marcar pending y limpiar url_storage para que el push
+      // vuelva a subir el binario nuevo al bucket (#67).
+      await db.conv_evidencias.update(existing.id, {
+        blob_local: blob,
+        url_storage: null,
+        sync_status: "pending",
+        last_modified: now,
+      });
+      pushSingle("conv_evidencias", existing.id);
     } else {
+      const nuevoId = randomUUID();
       await db.conv_evidencias.add({
-        id: randomUUID(),
+        id: nuevoId,
         visita_id: visitaId,
         prueba_codigo: pruebaCodigo,
         slot,
         blob_local: blob,
-        fecha_captura: new Date().toISOString(),
-        creado_en: new Date().toISOString(),
+        fecha_captura: now,
+        creado_en: now,
         sync_status: "pending" as const,
-        last_modified: new Date().toISOString(),
+        last_modified: now,
       });
+      pushSingle("conv_evidencias", nuevoId);
     }
   }
 

--- a/src/components/visita-modulos/grupo-c-modulo.tsx
+++ b/src/components/visita-modulos/grupo-c-modulo.tsx
@@ -327,23 +327,34 @@ export function GrupoCModulo({ visitaId: id }: { visitaId: string }) {
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
+    const now = new Date().toISOString();
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
-      await db.conv_evidencias.update(existing.id, { blob_local: blob });
+      // Reemplazo: re-marcar pending y limpiar url_storage para que el push
+      // vuelva a subir el binario nuevo al bucket (#67).
+      await db.conv_evidencias.update(existing.id, {
+        blob_local: blob,
+        url_storage: null,
+        sync_status: "pending",
+        last_modified: now,
+      });
+      pushSingle("conv_evidencias", existing.id);
     } else {
+      const nuevoId = randomUUID();
       await db.conv_evidencias.add({
-        id: randomUUID(),
+        id: nuevoId,
         visita_id: visitaId,
         prueba_codigo: pruebaCodigo,
         slot,
         blob_local: blob,
-        fecha_captura: new Date().toISOString(),
-        creado_en: new Date().toISOString(),
+        fecha_captura: now,
+        creado_en: now,
         sync_status: "pending" as const,
-        last_modified: new Date().toISOString(),
+        last_modified: now,
       });
+      pushSingle("conv_evidencias", nuevoId);
     }
   }
 

--- a/src/components/visita-modulos/grupo-d-modulo.tsx
+++ b/src/components/visita-modulos/grupo-d-modulo.tsx
@@ -392,23 +392,34 @@ export function GrupoDModulo({ visitaId: id }: { visitaId: string }) {
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
+    const now = new Date().toISOString();
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
-      await db.conv_evidencias.update(existing.id, { blob_local: blob });
+      // Reemplazo: re-marcar pending y limpiar url_storage para que el push
+      // vuelva a subir el binario nuevo al bucket (#67).
+      await db.conv_evidencias.update(existing.id, {
+        blob_local: blob,
+        url_storage: null,
+        sync_status: "pending",
+        last_modified: now,
+      });
+      pushSingle("conv_evidencias", existing.id);
     } else {
+      const nuevoId = randomUUID();
       await db.conv_evidencias.add({
-        id: randomUUID(),
+        id: nuevoId,
         visita_id: visitaId,
         prueba_codigo: pruebaCodigo,
         slot,
         blob_local: blob,
-        fecha_captura: new Date().toISOString(),
-        creado_en: new Date().toISOString(),
+        fecha_captura: now,
+        creado_en: now,
         sync_status: "pending" as const,
-        last_modified: new Date().toISOString(),
+        last_modified: now,
       });
+      pushSingle("conv_evidencias", nuevoId);
     }
   }
 

--- a/src/components/visita-modulos/grupo-e-modulo.tsx
+++ b/src/components/visita-modulos/grupo-e-modulo.tsx
@@ -370,23 +370,34 @@ export function GrupoEModulo({ visitaId: id }: { visitaId: string }) {
 
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
+    const now = new Date().toISOString();
     const existing = data?.evidencias?.find(
       (e) => e.prueba_codigo === pruebaCodigo && e.slot === slot
     );
     if (existing?.id) {
-      await db.conv_evidencias.update(existing.id, { blob_local: blob });
+      // Reemplazo: re-marcar pending y limpiar url_storage para que el push
+      // vuelva a subir el binario nuevo al bucket (#67).
+      await db.conv_evidencias.update(existing.id, {
+        blob_local: blob,
+        url_storage: null,
+        sync_status: "pending",
+        last_modified: now,
+      });
+      pushSingle("conv_evidencias", existing.id);
     } else {
+      const nuevoId = randomUUID();
       await db.conv_evidencias.add({
-        id: randomUUID(),
+        id: nuevoId,
         visita_id: visitaId,
         prueba_codigo: pruebaCodigo,
         slot,
         blob_local: blob,
-        fecha_captura: new Date().toISOString(),
-        creado_en: new Date().toISOString(),
+        fecha_captura: now,
+        creado_en: now,
         sync_status: "pending" as const,
-        last_modified: new Date().toISOString(),
+        last_modified: now,
       });
+      pushSingle("conv_evidencias", nuevoId);
     }
   }
 

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -562,10 +562,19 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
   }
 
   /** Foto de referencia de una subtabla (generador/tubo/colimador): crea o reemplaza. */
-  async function captureRefImagen(subtabla: EquipoIdentificacion["subtabla"], file: File) {
+  const findRef = (subtabla: EquipoIdentificacion["subtabla"], refId?: string) =>
+    (data?.identificaciones ?? []).find(
+      (i) => i.subtabla === subtabla && (i.ref_id ?? undefined) === refId
+    );
+
+  async function captureRefImagen(
+    subtabla: EquipoIdentificacion["subtabla"],
+    file: File,
+    refId?: string
+  ) {
     const equipoId = data?.equipo?.id;
     if (!equipoId) return;
-    const existente = (data?.identificaciones ?? []).find((i) => i.subtabla === subtabla);
+    const existente = findRef(subtabla, refId);
     if (existente?.id) {
       await saveIdentificacion(existente.id, { blob_local: file, url_storage: null });
       return;
@@ -574,6 +583,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
       id: randomUUID(),
       equipo_id: equipoId,
       subtabla,
+      ref_id: refId,
       blob_local: file,
       url_storage: null,
       creado_en: now(),
@@ -584,8 +594,8 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
     pushSingle("equipo_identificaciones", nueva.id);
   }
 
-  async function removeRefImagen(subtabla: EquipoIdentificacion["subtabla"]) {
-    const existente = (data?.identificaciones ?? []).find((i) => i.subtabla === subtabla);
+  async function removeRefImagen(subtabla: EquipoIdentificacion["subtabla"], refId?: string) {
+    const existente = findRef(subtabla, refId);
     if (existente?.id) await deleteIdentificacion(existente.id);
   }
 
@@ -663,8 +673,8 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
 
   const { visita, equipo, ubicacion, sede, cliente, solicitud, tubos, nroTubos, contactos } = data;
   const identificaciones = data.identificaciones;
-  const refImagen = (sub: EquipoIdentificacion["subtabla"]) =>
-    identificaciones.find((i) => i.subtabla === sub);
+  const refImagen = (sub: EquipoIdentificacion["subtabla"], refId?: string) =>
+    identificaciones.find((i) => i.subtabla === sub && (i.ref_id ?? undefined) === refId);
   const otrasIdentificaciones = identificaciones.filter((i) => (i.subtabla ?? "otra") === "otra");
 
   const medico = getContacto("medico_responsable");
@@ -1193,6 +1203,15 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
                   onSave={(v) => saveTubo(t.id!, "foco_grueso_mm", v, true)}
                 />
               </div>
+
+              <div className="pt-2 border-t border-slate-100">
+                <RefImagenSlot
+                  label={`Foto de la placa / referencia del tubo ${i + 1}`}
+                  iden={refImagen("tubo", t.id)}
+                  onCapture={(file) => captureRefImagen("tubo", file, t.id)}
+                  onRemove={() => removeRefImagen("tubo", t.id)}
+                />
+              </div>
             </div>
           ))}
 
@@ -1205,15 +1224,6 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             <Plus className="w-4 h-4" />
             Agregar tubo
           </button>
-
-          <div className="pt-2 border-t border-slate-100">
-            <RefImagenSlot
-              label="Foto de la placa / referencia del tubo"
-              iden={refImagen("tubo")}
-              onCapture={(file) => captureRefImagen("tubo", file)}
-              onRemove={() => removeRefImagen("tubo")}
-            />
-          </div>
         </div>
       </SectionCard>
 

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -984,10 +984,10 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
         </div>
       </SectionCard>
 
-      {/* 3. Características del Equipo (la plantilla las llama "del generador") */}
+      {/* 3. Características del Generador */}
       <SectionCard
         icon={Radio}
-        title="Características del Equipo"
+        title="Características del Generador"
         subtitle="Datos del equipo de rayos X"
         progress={progGenerador}
       >

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -251,10 +251,11 @@ function IdentificacionRow({
   onDelete,
 }: {
   iden: EquipoIdentificacion;
-  onNombre: (value: string) => void;
+  /** Si se omite, la fila es solo imagen (foto de referencia de una sección). */
+  onNombre?: (value: string) => void;
   onCapture: (file: File) => void;
-  onRemoveImagen: () => void;
-  onDelete: () => void;
+  onRemoveImagen?: () => void;
+  onDelete?: () => void;
 }) {
   const src = useImagenSrc(iden);
   return (
@@ -267,6 +268,31 @@ function IdentificacionRow({
       onRemoveImagen={onRemoveImagen}
       onDelete={onDelete}
     />
+  );
+}
+
+/** Foto de referencia (placa) de una sección del equipo: generador / tubo / colimador. */
+function RefImagenSlot({
+  label,
+  iden,
+  onCapture,
+  onRemove,
+}: {
+  label: string;
+  iden: EquipoIdentificacion | undefined;
+  onCapture: (file: File) => void;
+  onRemove: () => void;
+}) {
+  const src = useImagenSrc(iden ?? {});
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">{label}</p>
+      <ImagenConTitulo
+        src={src}
+        onCapture={onCapture}
+        onRemoveImagen={src ? onRemove : undefined}
+      />
+    </div>
   );
 }
 
@@ -493,15 +519,20 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
     pushSingle("tubos", tuboId);
   }
 
-  // ─── Identificaciones del equipo (#61: nombre + foto) ───
+  // ─── Identificaciones del equipo (#61) ───
+  //  Tabla equipo_identificaciones con `subtabla`:
+  //   - generador / tubo / colimador → foto de referencia de esa sección (1 sola)
+  //   - otra → entrada libre de la lista "Otras identificaciones"
 
   async function addIdentificacion() {
     const equipoId = data?.equipo?.id;
     if (!equipoId) return;
+    const otras = (data?.identificaciones ?? []).filter((i) => (i.subtabla ?? "otra") === "otra");
     const nueva = {
       id: randomUUID(),
       equipo_id: equipoId,
-      orden: (data?.identificaciones?.length ?? 0) + 1,
+      subtabla: "otra" as const,
+      orden: otras.length + 1,
       creado_en: now(),
       sync_status: "pending" as const,
       last_modified: now(),
@@ -528,6 +559,34 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
       last_modified: now(),
     });
     pushSingle("equipo_identificaciones", idenId);
+  }
+
+  /** Foto de referencia de una subtabla (generador/tubo/colimador): crea o reemplaza. */
+  async function captureRefImagen(subtabla: EquipoIdentificacion["subtabla"], file: File) {
+    const equipoId = data?.equipo?.id;
+    if (!equipoId) return;
+    const existente = (data?.identificaciones ?? []).find((i) => i.subtabla === subtabla);
+    if (existente?.id) {
+      await saveIdentificacion(existente.id, { blob_local: file, url_storage: null });
+      return;
+    }
+    const nueva = {
+      id: randomUUID(),
+      equipo_id: equipoId,
+      subtabla,
+      blob_local: file,
+      url_storage: null,
+      creado_en: now(),
+      sync_status: "pending" as const,
+      last_modified: now(),
+    };
+    await db.equipo_identificaciones.add(nueva);
+    pushSingle("equipo_identificaciones", nueva.id);
+  }
+
+  async function removeRefImagen(subtabla: EquipoIdentificacion["subtabla"]) {
+    const existente = (data?.identificaciones ?? []).find((i) => i.subtabla === subtabla);
+    if (existente?.id) await deleteIdentificacion(existente.id);
   }
 
   async function saveVisita(field: string, value: string, numeric = false) {
@@ -604,6 +663,9 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
 
   const { visita, equipo, ubicacion, sede, cliente, solicitud, tubos, nroTubos, contactos } = data;
   const identificaciones = data.identificaciones;
+  const refImagen = (sub: EquipoIdentificacion["subtabla"]) =>
+    identificaciones.find((i) => i.subtabla === sub);
+  const otrasIdentificaciones = identificaciones.filter((i) => (i.subtabla ?? "otra") === "otra");
 
   const medico = getContacto("medico_responsable");
   const tecnologo = getContacto("tecnologo");
@@ -1033,44 +1095,13 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             onSave={(v) => saveEquipo("gen_energia_fotones_mev", v)}
           />
         </div>
-      </SectionCard>
-
-      {/* 3b. Identificaciones del Equipo (placas, inventario, calibración…) */}
-      <SectionCard
-        icon={FileText}
-        title="Identificaciones del Equipo"
-        subtitle="Placas / inventario / calibración — foto rotulada"
-        progress={identificaciones.length > 0 ? 100 : 0}
-      >
-        <div className="space-y-3">
-          {identificaciones.length === 0 && (
-            <p className="text-sm text-slate-400 font-medium py-2 text-center">
-              Sin identificaciones cargadas
-            </p>
-          )}
-          {identificaciones.map((iden) => (
-            <IdentificacionRow
-              key={iden.id}
-              iden={iden}
-              onNombre={(v) => saveIdentificacion(iden.id!, { nombre: v || undefined })}
-              onCapture={(file) =>
-                saveIdentificacion(iden.id!, { blob_local: file, url_storage: null })
-              }
-              onRemoveImagen={() =>
-                saveIdentificacion(iden.id!, { blob_local: null, url_storage: null })
-              }
-              onDelete={() => deleteIdentificacion(iden.id!)}
-            />
-          ))}
-          <button
-            type="button"
-            onClick={addIdentificacion}
-            disabled={!equipo}
-            className="w-full flex items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 py-2.5 text-sm font-bold text-slate-500 hover:border-primary hover:text-primary transition-colors disabled:opacity-40"
-          >
-            <Plus className="w-4 h-4" />
-            Agregar identificación
-          </button>
+        <div className="pt-3 border-t border-slate-100">
+          <RefImagenSlot
+            label="Foto de la placa / referencia del generador"
+            iden={refImagen("generador")}
+            onCapture={(file) => captureRefImagen("generador", file)}
+            onRemove={() => removeRefImagen("generador")}
+          />
         </div>
       </SectionCard>
 
@@ -1174,6 +1205,15 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             <Plus className="w-4 h-4" />
             Agregar tubo
           </button>
+
+          <div className="pt-2 border-t border-slate-100">
+            <RefImagenSlot
+              label="Foto de la placa / referencia del tubo"
+              iden={refImagen("tubo")}
+              onCapture={(file) => captureRefImagen("tubo", file)}
+              onRemove={() => removeRefImagen("tubo")}
+            />
+          </div>
         </div>
       </SectionCard>
 
@@ -1221,6 +1261,14 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             onSave={(v) => saveEquipo("filtracion_anadida_mmal", v, true)}
           />
         </div>
+        <div className="pt-3 border-t border-slate-100">
+          <RefImagenSlot
+            label="Foto de la placa / referencia del colimador"
+            iden={refImagen("colimador")}
+            onCapture={(file) => captureRefImagen("colimador", file)}
+            onRemove={() => removeRefImagen("colimador")}
+          />
+        </div>
       </SectionCard>
 
       {/* 6. Condiciones Ambientales */}
@@ -1265,6 +1313,45 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
               onSave={(v) => saveVisita("observaciones", v)}
             />
           </div>
+        </div>
+      </SectionCard>
+
+      {/* 6b. Otras identificaciones del equipo de rayos X (lista título + imagen) */}
+      <SectionCard
+        icon={FileText}
+        title="Otras identificaciones del equipo de rayos X"
+        subtitle="Placas, inventario, calibración… — título + foto, las que hagan falta"
+        progress={otrasIdentificaciones.length > 0 ? 100 : 0}
+      >
+        <div className="space-y-3">
+          {otrasIdentificaciones.length === 0 && (
+            <p className="text-sm text-slate-400 font-medium py-2 text-center">
+              Sin identificaciones cargadas
+            </p>
+          )}
+          {otrasIdentificaciones.map((iden) => (
+            <IdentificacionRow
+              key={iden.id}
+              iden={iden}
+              onNombre={(v) => saveIdentificacion(iden.id!, { nombre: v || undefined })}
+              onCapture={(file) =>
+                saveIdentificacion(iden.id!, { blob_local: file, url_storage: null })
+              }
+              onRemoveImagen={() =>
+                saveIdentificacion(iden.id!, { blob_local: null, url_storage: null })
+              }
+              onDelete={() => deleteIdentificacion(iden.id!)}
+            />
+          ))}
+          <button
+            type="button"
+            onClick={addIdentificacion}
+            disabled={!equipo}
+            className="w-full flex items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 py-2.5 text-sm font-bold text-slate-500 hover:border-primary hover:text-primary transition-colors disabled:opacity-40"
+          >
+            <Plus className="w-4 h-4" />
+            Agregar identificación
+          </button>
         </div>
       </SectionCard>
 

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -29,6 +29,7 @@ vi.mock("@/lib/supabase/sync-engine", () => ({
   deleteAndSync: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { pushSingle } from "@/lib/supabase/sync-engine";
 import { GrupoAModulo } from "./grupo-a-modulo";
 import { GrupoBModulo } from "./grupo-b-modulo";
 import { GrupoCModulo } from "./grupo-c-modulo";
@@ -72,6 +73,35 @@ describe("visita-modulos — smoke", () => {
       render(<Modulo visitaId={visita!.id!} />);
       expect(await screen.findByText(/Volver al workspace/i)).toBeInTheDocument();
     });
+  });
+});
+
+describe("GrupoAModulo — capturar una foto dispara el push (#67)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+    vi.mocked(pushSingle).mockClear();
+  });
+  afterEach(() => cleanup());
+
+  it("crea la evidencia pending con blob y llama pushSingle('conv_evidencias')", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const { container } = render(<GrupoAModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    // Primer slot de imagen del módulo = plano / croquis radiométrico (prueba 2.1).
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    const file = new File([new Uint8Array([1, 2, 3])], "plano.jpg", { type: "image/jpeg" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(async () => {
+      const filas = await db.conv_evidencias.where("visita_id").equals(visita!.id!).toArray();
+      expect(filas.length).toBe(1);
+      expect(filas[0].sync_status).toBe("pending");
+      expect(filas[0].blob_local).not.toBeNull();
+    });
+    expect(vi.mocked(pushSingle)).toHaveBeenCalledWith("conv_evidencias", expect.any(String));
   });
 });
 

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -124,19 +124,19 @@ describe("InfoModulo — Sistema de Adquisición de Imágenes (#62)", () => {
   });
 });
 
-describe("InfoModulo — Características del Equipo (#61)", () => {
+describe("InfoModulo — Características del Generador (#61)", () => {
   beforeEach(async () => {
     await resetTestDb();
     useDb.mockReturnValue({ isReady: true });
   });
   afterEach(() => cleanup());
 
-  it("la sección del equipo incluye el campo de energía fotones/electrones (MeV)", async () => {
+  it("la sección del generador incluye el campo de energía fotones/electrones (MeV)", async () => {
     const { visita } = await seedGraph();
     render(<InfoModulo visitaId={visita!.id!} />);
     await screen.findByText(/Volver al workspace/i);
 
-    expect(screen.getByText("Características del Equipo")).toBeInTheDocument();
+    expect(screen.getByText("Características del Generador")).toBeInTheDocument();
     expect(screen.getByText(/Energía Fotones \/ Electrones/i)).toBeInTheDocument();
   });
 });

--- a/src/components/visita-modulos/pre-informe-modulo.tsx
+++ b/src/components/visita-modulos/pre-informe-modulo.tsx
@@ -681,72 +681,6 @@ export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
         ))}
       </div>
 
-      {/* Secciones de pruebas */}
-      <div className={`space-y-2 ${readOnly ? "pointer-events-none opacity-60" : ""}`}>
-        <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1">
-          Pruebas de control de calidad
-        </p>
-
-        {secciones.map((seccion) => {
-          const cat = catalogoMap.get(seccion.prueba_codigo);
-          if (!cat) return null;
-
-          return (
-            <SeccionCard
-              key={seccion.id}
-              seccion={seccion}
-              catalogo={cat}
-              conceptoEfectivo={conceptoDe(seccion)}
-              expanded={expandedCodigo === seccion.prueba_codigo}
-              onToggleExpand={() =>
-                setExpandedCodigo(
-                  expandedCodigo === seccion.prueba_codigo ? null : seccion.prueba_codigo
-                )
-              }
-              onToggleIncluida={() =>
-                seccion.id && updateSeccion(seccion.id, { incluida: !seccion.incluida })
-              }
-              onUpdateAcciones={(v) =>
-                seccion.id && updateSeccion(seccion.id, { acciones_correctivas: v || undefined })
-              }
-              onUpdateObservaciones={(v) =>
-                seccion.id && updateSeccion(seccion.id, { observaciones: v || undefined })
-              }
-            />
-          );
-        })}
-      </div>
-
-      {/* Secciones finales fijas */}
-      <div className="space-y-2">
-        <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1">
-          Secciones finales
-        </p>
-        {[
-          { label: "Resumen de resultados", desc: "Tabla resumen auto-generada" },
-          { label: "Concepto general", desc: "Favorable / No favorable" },
-          { label: "Acciones correctivas", desc: "Consolidado de acciones" },
-          { label: "Observaciones generales", desc: "Notas del fisico" },
-          { label: "Firmas", desc: "Director tecnico y responsable de visita" },
-        ].map((s) => (
-          <div
-            key={s.label}
-            className="flex items-center gap-3 p-3 bg-slate-50 rounded-xl border border-slate-100"
-          >
-            <div className="bg-slate-200 p-1.5 rounded-lg">
-              <FileText className="w-3.5 h-3.5 text-slate-500" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-xs font-bold text-slate-600">{s.label}</p>
-              <p className="text-[10px] text-slate-400">{s.desc}</p>
-            </div>
-            <span className="text-[9px] font-bold text-slate-400 bg-slate-100 px-2 py-0.5 rounded">
-              Fija
-            </span>
-          </div>
-        ))}
-      </div>
-
       {/* Botones de acción */}
       <div className="flex flex-col sm:flex-row gap-3">
         <Button
@@ -813,6 +747,72 @@ export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
           </CardContent>
         </Card>
       )}
+
+      {/* Secciones de pruebas */}
+      <div className={`space-y-2 ${readOnly ? "pointer-events-none opacity-60" : ""}`}>
+        <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1">
+          Pruebas de control de calidad
+        </p>
+
+        {secciones.map((seccion) => {
+          const cat = catalogoMap.get(seccion.prueba_codigo);
+          if (!cat) return null;
+
+          return (
+            <SeccionCard
+              key={seccion.id}
+              seccion={seccion}
+              catalogo={cat}
+              conceptoEfectivo={conceptoDe(seccion)}
+              expanded={expandedCodigo === seccion.prueba_codigo}
+              onToggleExpand={() =>
+                setExpandedCodigo(
+                  expandedCodigo === seccion.prueba_codigo ? null : seccion.prueba_codigo
+                )
+              }
+              onToggleIncluida={() =>
+                seccion.id && updateSeccion(seccion.id, { incluida: !seccion.incluida })
+              }
+              onUpdateAcciones={(v) =>
+                seccion.id && updateSeccion(seccion.id, { acciones_correctivas: v || undefined })
+              }
+              onUpdateObservaciones={(v) =>
+                seccion.id && updateSeccion(seccion.id, { observaciones: v || undefined })
+              }
+            />
+          );
+        })}
+      </div>
+
+      {/* Secciones finales fijas */}
+      <div className="space-y-2">
+        <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1">
+          Secciones finales
+        </p>
+        {[
+          { label: "Resumen de resultados", desc: "Tabla resumen auto-generada" },
+          { label: "Concepto general", desc: "Favorable / No favorable" },
+          { label: "Acciones correctivas", desc: "Consolidado de acciones" },
+          { label: "Observaciones generales", desc: "Notas del fisico" },
+          { label: "Firmas", desc: "Director tecnico y responsable de visita" },
+        ].map((s) => (
+          <div
+            key={s.label}
+            className="flex items-center gap-3 p-3 bg-slate-50 rounded-xl border border-slate-100"
+          >
+            <div className="bg-slate-200 p-1.5 rounded-lg">
+              <FileText className="w-3.5 h-3.5 text-slate-500" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-bold text-slate-600">{s.label}</p>
+              <p className="text-[10px] text-slate-400">{s.desc}</p>
+            </div>
+            <span className="text-[9px] font-bold text-slate-400 bg-slate-100 px-2 py-0.5 rounded">
+              Fija
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/visita-modulos/pre-informe-modulo.tsx
+++ b/src/components/visita-modulos/pre-informe-modulo.tsx
@@ -650,37 +650,6 @@ export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
         </CardContent>
       </Card>
 
-      {/* Secciones fijas — Portada, Información, Introducción */}
-      <div className="space-y-2">
-        <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1">
-          Secciones fijas
-        </p>
-        {[
-          { label: "Portada", desc: "Identificacion del equipo e instalacion" },
-          {
-            label: "Informacion de la practica",
-            desc: "Datos generales, generador, tubo, colimador",
-          },
-          { label: "Introduccion", desc: "Texto TECDOC normativo" },
-        ].map((s) => (
-          <div
-            key={s.label}
-            className="flex items-center gap-3 p-3 bg-slate-50 rounded-xl border border-slate-100"
-          >
-            <div className="bg-slate-200 p-1.5 rounded-lg">
-              <FileText className="w-3.5 h-3.5 text-slate-500" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-xs font-bold text-slate-600">{s.label}</p>
-              <p className="text-[10px] text-slate-400">{s.desc}</p>
-            </div>
-            <span className="text-[9px] font-bold text-slate-400 bg-slate-100 px-2 py-0.5 rounded">
-              Fija
-            </span>
-          </div>
-        ))}
-      </div>
-
       {/* Botones de acción */}
       <div className="flex flex-col sm:flex-row gap-3">
         <Button
@@ -747,6 +716,37 @@ export function PreInformeModulo({ visitaId: id }: { visitaId: string }) {
           </CardContent>
         </Card>
       )}
+
+      {/* Secciones fijas — Portada, Información, Introducción */}
+      <div className="space-y-2">
+        <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1">
+          Secciones fijas
+        </p>
+        {[
+          { label: "Portada", desc: "Identificacion del equipo e instalacion" },
+          {
+            label: "Informacion de la practica",
+            desc: "Datos generales, generador, tubo, colimador",
+          },
+          { label: "Introduccion", desc: "Texto TECDOC normativo" },
+        ].map((s) => (
+          <div
+            key={s.label}
+            className="flex items-center gap-3 p-3 bg-slate-50 rounded-xl border border-slate-100"
+          >
+            <div className="bg-slate-200 p-1.5 rounded-lg">
+              <FileText className="w-3.5 h-3.5 text-slate-500" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-bold text-slate-600">{s.label}</p>
+              <p className="text-[10px] text-slate-400">{s.desc}</p>
+            </div>
+            <span className="text-[9px] font-bold text-slate-400 bg-slate-100 px-2 py-0.5 rounded">
+              Fija
+            </span>
+          </div>
+        ))}
+      </div>
 
       {/* Secciones de pruebas */}
       <div className={`space-y-2 ${readOnly ? "pointer-events-none opacity-60" : ""}`}>

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -262,9 +262,11 @@ export type SubtablaIdentificacion = "generador" | "tubo" | "colimador" | "otra"
 export interface EquipoIdentificacion extends Partial<SyncFields> {
   id?: string;
   equipo_id: string;
-  /** "generador" / "tubo" / "colimador" = foto de referencia de esa sección (1 sola).
+  /** "generador" / "tubo" / "colimador" = foto de referencia de esa sección.
    *  "otra" = entrada libre de la lista "Otras identificaciones". Default: "otra". */
   subtabla?: SubtablaIdentificacion;
+  /** Para subtabla="tubo": id del tubo al que pertenece la foto (hay N tubos). */
+  ref_id?: string;
   nombre?: string;
   orden?: number;
   blob_local?: Blob | null;

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -256,9 +256,15 @@ export interface Gantry extends Partial<SyncFields> {
  * etc. `blob_local` es la imagen local; se sube al bucket y su path queda en
  * `url_storage` (mismo pipeline que las evidencias, #67).
  */
+/** Dónde vive la identificación: la placa de una subtabla del equipo, o una "otra" suelta. */
+export type SubtablaIdentificacion = "generador" | "tubo" | "colimador" | "otra";
+
 export interface EquipoIdentificacion extends Partial<SyncFields> {
   id?: string;
   equipo_id: string;
+  /** "generador" / "tubo" / "colimador" = foto de referencia de esa sección (1 sola).
+   *  "otra" = entrada libre de la lista "Otras identificaciones". Default: "otra". */
+  subtabla?: SubtablaIdentificacion;
   nombre?: string;
   orden?: number;
   blob_local?: Blob | null;

--- a/src/lib/decimal.test.ts
+++ b/src/lib/decimal.test.ts
@@ -42,6 +42,13 @@ describe("formatDecimal (es-CO, coma)", () => {
   it("no agrupa miles", () => {
     expect(formatDecimal(1234.5)).toBe("1234,5");
   });
+  it("sin `decimals`: hasta 3 decimales, sin ceros de relleno (columna T del informe)", () => {
+    // Regresión: el factor de ocupación 1 salía como "1," en la tabla 2.1.2.
+    expect(formatDecimal(1)).toBe("1");
+    expect(formatDecimal(0.5)).toBe("0,5");
+    expect(formatDecimal(0.05)).toBe("0,05");
+    expect(formatDecimal(0.2)).toBe("0,2");
+  });
   it("null / undefined / NaN → fallback", () => {
     expect(formatDecimal(null)).toBe("—");
     expect(formatDecimal(undefined)).toBe("—");

--- a/src/lib/equipos/convencional/db/types.ts
+++ b/src/lib/equipos/convencional/db/types.ts
@@ -443,9 +443,9 @@ export interface ConvEvidencia extends Partial<SyncFields> {
   slot: string;
   descripcion?: string;
   /** Blob almacenado en IndexedDB — solo local, no se sincroniza */
-  blob_local?: Blob;
-  /** URL en storage remoto (post-sync) */
-  url_storage?: string;
+  blob_local?: Blob | null;
+  /** Path en el bucket (post-sync). `null` fuerza re-subida al reemplazar la imagen. */
+  url_storage?: string | null;
   fecha_captura?: string;
   creado_en?: string;
   /** Soft-delete: borrado viaja como cambio (UPSERT) para que el pull lo propague */

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -152,24 +152,42 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(text).not.toContain("TUBO-BORRADO");
   });
 
-  it("#61 (D2c): las identificaciones del equipo salen en el informe; una borrada no", async () => {
+  it("#61: 'Otras identificaciones' salen en el informe; una borrada no", async () => {
     const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
     await db.equipo_identificaciones.bulkAdd([
-      { id: randomUUID(), equipo_id: equipo.id!, nombre: "IDEN-PLACA-FABRICANTE", orden: 1 },
-      { id: randomUUID(), equipo_id: equipo.id!, nombre: "IDEN-INVENTARIO", orden: 2 },
+      { id: randomUUID(), equipo_id: equipo.id!, subtabla: "otra", nombre: "IDEN-PLACA", orden: 1 },
       {
         id: randomUUID(),
         equipo_id: equipo.id!,
+        subtabla: "otra",
+        nombre: "IDEN-INVENTARIO",
+        orden: 2,
+      },
+      {
+        id: randomUUID(),
+        equipo_id: equipo.id!,
+        subtabla: "otra",
         nombre: "IDEN-BORRADA",
         orden: 3,
         deleted_at: new Date().toISOString(),
       },
     ]);
     const text = await pdfText((await generarPreInforme(visita!.id!))!);
-    expect(text).toContain("Identificaciones del Equipo");
-    expect(text).toContain("IDEN-PLACA-FABRICANTE");
+    expect(text).toContain("Otras identificaciones del equipo de rayos X");
+    expect(text).toContain("IDEN-PLACA");
     expect(text).toContain("IDEN-INVENTARIO");
     expect(text).not.toContain("IDEN-BORRADA");
+  });
+
+  it("#61: las identificaciones de subtabla generador/tubo/colimador NO van a la lista 'Otras'", async () => {
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    await db.equipo_identificaciones.bulkAdd([
+      { id: randomUUID(), equipo_id: equipo.id!, subtabla: "generador", nombre: "REF-GENERADOR" },
+      { id: randomUUID(), equipo_id: equipo.id!, subtabla: "otra", nombre: "IDEN-SUELTA" },
+    ]);
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("IDEN-SUELTA");
+    expect(text).not.toContain("REF-GENERADOR");
   });
 
   it("#63: piso y techo del blindaje salen en la tabla de áreas colindantes", async () => {

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -114,6 +114,28 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(text).toContain("TUBO-DOS-MARCA");
   });
 
+  it("#61: el informe indica la cantidad de tubos del equipo en texto", async () => {
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conTubo: false });
+    await db.tubos.bulkAdd([
+      { id: randomUUID(), equipo_id: equipo.id! },
+      { id: randomUUID(), equipo_id: equipo.id! },
+    ]);
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("El equipo cuenta con 2 tubos.");
+  });
+
+  it("#61: un solo tubo → singular; sin tubos → 'no tiene tubos registrados'", async () => {
+    const g1 = await seedGraph({ tipoEquipo: "CONVENCIONAL", conTubo: true });
+    expect(await pdfText((await generarPreInforme(g1.visita!.id!))!)).toContain(
+      "El equipo cuenta con 1 tubo."
+    );
+
+    const g0 = await seedGraph({ tipoEquipo: "CONVENCIONAL", conTubo: false });
+    expect(await pdfText((await generarPreInforme(g0.visita!.id!))!)).toContain(
+      "El equipo no tiene tubos registrados."
+    );
+  });
+
   it("#61 (D2b): un tubo soft-borrado no sale en el informe", async () => {
     const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conTubo: false });
     await db.tubos.bulkAdd([

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -190,6 +190,29 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(text).not.toContain("REF-GENERADOR");
   });
 
+  it("#61: con foto de referencia del generador, el informe se genera y mantiene la tabla", async () => {
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    // PNG 1x1 válido → getImageProperties devuelve dimensiones reales.
+    const png = Uint8Array.from(
+      atob(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+      ),
+      (c) => c.charCodeAt(0)
+    );
+    await db.equipos.update(equipo.id!, { gen_marca: "MARCA-CARD-61" });
+    await db.equipo_identificaciones.add({
+      id: randomUUID(),
+      equipo_id: equipo.id!,
+      subtabla: "generador",
+      blob_local: new Blob([png], { type: "image/png" }),
+    });
+    const blob = await generarPreInforme(visita!.id!);
+    expect(blob).not.toBeNull();
+    const text = await pdfText(blob!);
+    expect(text).toContain("Características del Generador");
+    expect(text).toContain("MARCA-CARD-61");
+  });
+
   it("#63: piso y techo del blindaje salen en la tabla de áreas colindantes", async () => {
     const { visita, ubicacion } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
     await db.ubicaciones_rx.update(ubicacion.id!, {

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -32,6 +32,18 @@ async function pdfText(blob: Blob): Promise<string> {
   return s;
 }
 
+// PNG 1x1 válido → doc.getImageProperties devuelve dimensiones reales y
+// doc.addImage no lanza (ejercita el camino de tarjeta con foto).
+function tinyPngBlob(): Blob {
+  const bytes = Uint8Array.from(
+    atob(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    ),
+    (c) => c.charCodeAt(0)
+  );
+  return new Blob([bytes], { type: "image/png" });
+}
+
 beforeEach(async () => {
   await resetTestDb();
   resetLogoCache();
@@ -155,7 +167,13 @@ describe("generarPreInforme — contrato de datos", () => {
   it("#61: 'Otras identificaciones' salen en el informe; una borrada no", async () => {
     const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
     await db.equipo_identificaciones.bulkAdd([
-      { id: randomUUID(), equipo_id: equipo.id!, subtabla: "otra", nombre: "IDEN-PLACA", orden: 1 },
+      {
+        id: randomUUID(),
+        equipo_id: equipo.id!,
+        subtabla: "otra",
+        nombre: "IDEN-PLACA",
+        orden: 1,
+      },
       {
         id: randomUUID(),
         equipo_id: equipo.id!,
@@ -190,27 +208,55 @@ describe("generarPreInforme — contrato de datos", () => {
     expect(text).not.toContain("REF-GENERADOR");
   });
 
-  it("#61: con foto de referencia del generador, el informe se genera y mantiene la tabla", async () => {
+  // Nota: el render de la imagen en sí (tarjeta foto/tabla, drawImagenCard) no se
+  // puede ejercitar bajo happy-dom + fake-indexeddb — el Blob no sobrevive el
+  // round-trip por IndexedDB (vuelve como objeto plano y FileReader lo rechaza),
+  // así que `dataUrl` queda undefined y se toma la rama sin foto. Estos tests
+  // cubren la carga de identificaciones, el ref_id por tubo y que la presencia de
+  // filas con blob no rompe la generación (rama `.catch` de blobADataUrl).
+  it("#61: una identificación de generador con blob no rompe el informe", async () => {
     const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
-    // PNG 1x1 válido → getImageProperties devuelve dimensiones reales.
-    const png = Uint8Array.from(
-      atob(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-      ),
-      (c) => c.charCodeAt(0)
-    );
     await db.equipos.update(equipo.id!, { gen_marca: "MARCA-CARD-61" });
     await db.equipo_identificaciones.add({
       id: randomUUID(),
       equipo_id: equipo.id!,
       subtabla: "generador",
-      blob_local: new Blob([png], { type: "image/png" }),
+      blob_local: tinyPngBlob(),
     });
     const blob = await generarPreInforme(visita!.id!);
     expect(blob).not.toBeNull();
     const text = await pdfText(blob!);
     expect(text).toContain("Características del Generador");
     expect(text).toContain("MARCA-CARD-61");
+  });
+
+  it("#61: identificaciones de tubo (ref_id) y colimador se cargan sin romper el informe", async () => {
+    const { visita, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conTubo: false });
+    const tuboA = randomUUID();
+    const tuboB = randomUUID();
+    await db.tubos.bulkAdd([
+      { id: tuboA, equipo_id: equipo.id!, marca: "TUBO-A-CARD" },
+      { id: tuboB, equipo_id: equipo.id!, marca: "TUBO-B-CARD" },
+    ]);
+    await db.equipo_identificaciones.bulkAdd([
+      {
+        id: randomUUID(),
+        equipo_id: equipo.id!,
+        subtabla: "tubo",
+        ref_id: tuboB,
+        blob_local: tinyPngBlob(),
+      },
+      {
+        id: randomUUID(),
+        equipo_id: equipo.id!,
+        subtabla: "colimador",
+        blob_local: tinyPngBlob(),
+      },
+    ]);
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("Especificaciones del Tubo 2");
+    expect(text).toContain("TUBO-B-CARD");
+    expect(text).toContain("Características del Colimador");
   });
 
   it("#63: piso y techo del blindaje salen en la tabla de áreas colindantes", async () => {

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -663,9 +663,9 @@ export async function generarPreInforme(
 
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
 
-  // Características del Equipo (la plantilla oficial las rotula "del generador")
+  // Características del Generador
   checkPage(48);
-  addSubsectionTitle("", "Características del Equipo");
+  addSubsectionTitle("", "Características del Generador");
 
   const datosGenerador = [
     ["Marca", datos.equipo?.gen_marca ?? "—"],

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -627,9 +627,9 @@ export async function generarPreInforme(
 
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
 
-  // Datos de la Instalación e Identificación del Equipo
+  // Datos de la Instalación
   checkPage(50);
-  addSubsectionTitle("", "Datos de la Instalación e Identificación del Equipo");
+  addSubsectionTitle("", "Datos de la Instalación");
 
   const datosInstalacion = [
     [

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -690,7 +690,23 @@ export async function generarPreInforme(
 
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
 
-  // Especificaciones del Tubo
+  // Especificaciones del Tubo — cantidad de tubos del equipo, en texto
+  {
+    const n = datos.tubos.length;
+    checkPage(8);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    doc.setTextColor(...COLOR_BLACK);
+    doc.text(
+      n === 0
+        ? "El equipo no tiene tubos registrados."
+        : `El equipo cuenta con ${n} tubo${n > 1 ? "s" : ""}.`,
+      MARGIN,
+      y
+    );
+    y += 6;
+  }
+
   datos.tubos.forEach((tuboItem, i) => {
     checkPage(40);
     const titulo =

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -510,16 +510,34 @@ export async function generarPreInforme(
       return;
     }
 
-    // Tarjeta: foto a la izquierda, tabla a la derecha.
-    const pad = 4;
-    const imgW = 48;
-    const imgH = 38;
-    const gap = 6;
-    const tableLeft = MARGIN + pad + imgW + gap;
-    const tableWidth = CONTENT_WIDTH - pad * 2 - imgW - gap;
-    const labelW = 44;
+    // Tarjeta: foto (grande, para que la placa se lea) a la izquierda, tabla
+    // clave/valor a la derecha.
+    const pad = 5;
+    const gap = 8;
+    const imgBoxW = 70;
+    const imgBoxH = 90;
+    const tableLeft = MARGIN + pad + imgBoxW + gap;
+    const tableWidth = CONTENT_WIDTH - pad * 2 - imgBoxW - gap;
+    const labelW = 42;
 
-    checkPage(Math.max(filas.length * 8 + pad * 2, imgH + pad * 2) + 4);
+    // Tamaño real de la foto respetando su relación de aspecto dentro del box.
+    let imgW = imgBoxW;
+    let imgH = imgBoxW * 0.75;
+    try {
+      const props = doc.getImageProperties(dataUrl);
+      if (props?.width && props?.height) {
+        const ratio = props.height / props.width;
+        imgH = imgW * ratio;
+        if (imgH > imgBoxH) {
+          imgH = imgBoxH;
+          imgW = imgH / ratio;
+        }
+      }
+    } catch {
+      // sin metadata: se usa el fallback 4:3
+    }
+
+    checkPage(Math.max(filas.length * 9, imgH) + pad * 2 + 6);
     const startY = y;
 
     autoTable(doc, {
@@ -544,8 +562,8 @@ export async function generarPreInforme(
     doc.setLineWidth(0.3);
     doc.roundedRect(MARGIN, startY, CONTENT_WIDTH, cardH, 2, 2, "S");
 
-    // Foto centrada verticalmente respecto al alto de la tabla
-    const imgX = MARGIN + pad;
+    // Foto centrada dentro de su box (vertical respecto al alto de la tarjeta)
+    const imgX = MARGIN + pad + (imgBoxW - imgW) / 2;
     const imgY = startY + pad + (bodyH - imgH) / 2;
     try {
       doc.addImage(dataUrl, imgX, imgY, imgW, imgH);

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -119,7 +119,7 @@ interface DatosInforme {
   sede?: Sede;
   cliente?: Cliente;
   tubos: Tubo[];
-  identificaciones: { nombre: string; dataUrl?: string }[];
+  identificaciones: { subtabla: string; nombre: string; dataUrl?: string }[];
   sala?: SalaDimensiones;
   tecnico?: Usuario;
   contactos: Contacto[];
@@ -173,6 +173,7 @@ async function recopilarDatos(visitaId: string): Promise<DatosInforme | null> {
     idenRows
       .sort((a, b) => (a.orden ?? 0) - (b.orden ?? 0))
       .map(async (r) => ({
+        subtabla: r.subtabla ?? "otra",
         nombre: r.nombre?.trim() || "Identificación",
         dataUrl: r.blob_local ? await blobADataUrl(r.blob_local).catch(() => undefined) : undefined,
       }))
@@ -418,6 +419,24 @@ export async function generarPreInforme(
     doc.setTextColor(...COLOR_BLACK);
     doc.text(`${number} ${title}`, MARGIN, y);
     y += 5;
+  }
+
+  /** Foto de referencia (placa) de una subtabla del equipo, si se capturó (#61). */
+  function renderRefImagen(subtabla: string, caption: string) {
+    const iden = datos.identificaciones.find((i) => i.subtabla === subtabla);
+    if (!iden?.dataUrl) return;
+    checkPage(52);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(8);
+    doc.setTextColor(...COLOR_GRAY);
+    doc.text(caption, MARGIN, y);
+    y += 4;
+    try {
+      doc.addImage(iden.dataUrl, MARGIN, y, 50, 40);
+      y += 44;
+    } catch {
+      y += 2;
+    }
   }
 
   // Contactos helper
@@ -689,6 +708,7 @@ export async function generarPreInforme(
   });
 
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
+  renderRefImagen("generador", "Placa / referencia del generador");
 
   // Especificaciones del Tubo — cantidad de tubos del equipo, en texto
   {
@@ -739,29 +759,7 @@ export async function generarPreInforme(
 
     y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
   });
-
-  // Identificaciones del equipo (placas / inventario / calibración) — #61
-  if (datos.identificaciones.length > 0) {
-    checkPage(20);
-    addSubsectionTitle("", "Identificaciones del Equipo");
-    datos.identificaciones.forEach((iden) => {
-      checkPage(iden.dataUrl ? 60 : 10);
-      doc.setFont("helvetica", "bold");
-      doc.setFontSize(8);
-      doc.setTextColor(...COLOR_GRAY);
-      doc.text(iden.nombre, MARGIN, y);
-      y += 4;
-      if (iden.dataUrl) {
-        try {
-          doc.addImage(iden.dataUrl, MARGIN, y, 50, 40);
-          y += 44;
-        } catch {
-          y += 2;
-        }
-      }
-    });
-    y += 2;
-  }
+  renderRefImagen("tubo", "Placa / referencia del tubo");
 
   // Características del Colimador y Sistema de Adquisición
   checkPage(30);
@@ -791,6 +789,7 @@ export async function generarPreInforme(
   });
 
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
+  renderRefImagen("colimador", "Placa / referencia del colimador");
 
   // Condiciones ambientales
   checkPage(15);
@@ -801,6 +800,32 @@ export async function generarPreInforme(
   y += 5;
   doc.text(`Presión (hPa): ${datos.visita.presion_hpa ?? "—"}`, MARGIN, y);
   y += 8;
+
+  // Otras identificaciones del equipo de rayos X — lista título + imagen (#61)
+  {
+    const otras = datos.identificaciones.filter((i) => (i.subtabla ?? "otra") === "otra");
+    if (otras.length > 0) {
+      checkPage(20);
+      addSubsectionTitle("", "Otras identificaciones del equipo de rayos X");
+      otras.forEach((iden) => {
+        checkPage(iden.dataUrl ? 60 : 10);
+        doc.setFont("helvetica", "bold");
+        doc.setFontSize(8);
+        doc.setTextColor(...COLOR_GRAY);
+        doc.text(iden.nombre, MARGIN, y);
+        y += 4;
+        if (iden.dataUrl) {
+          try {
+            doc.addImage(iden.dataUrl, MARGIN, y, 50, 40);
+            y += 44;
+          } catch {
+            y += 2;
+          }
+        }
+      });
+      y += 2;
+    }
+  }
 
   // ═══════════════════════════════════════════════════════════
   //  PÁGINA — INTRODUCCIÓN

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -119,7 +119,7 @@ interface DatosInforme {
   sede?: Sede;
   cliente?: Cliente;
   tubos: Tubo[];
-  identificaciones: { subtabla: string; nombre: string; dataUrl?: string }[];
+  identificaciones: { subtabla: string; ref_id?: string; nombre: string; dataUrl?: string }[];
   sala?: SalaDimensiones;
   tecnico?: Usuario;
   contactos: Contacto[];
@@ -136,6 +136,7 @@ const COLOR_HEADER_BG: [number, number, number] = [241, 245, 249];
 const COLOR_GRAY: [number, number, number] = [100, 116, 139];
 const COLOR_BLACK: [number, number, number] = [30, 30, 30];
 const COLOR_ALT_ROW: [number, number, number] = [248, 250, 252];
+const COLOR_BORDER: [number, number, number] = [203, 213, 225];
 const MARGIN = 20;
 const PAGE_WIDTH = 210;
 const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
@@ -174,6 +175,7 @@ async function recopilarDatos(visitaId: string): Promise<DatosInforme | null> {
       .sort((a, b) => (a.orden ?? 0) - (b.orden ?? 0))
       .map(async (r) => ({
         subtabla: r.subtabla ?? "otra",
+        ref_id: r.ref_id,
         nombre: r.nombre?.trim() || "Identificación",
         dataUrl: r.blob_local ? await blobADataUrl(r.blob_local).catch(() => undefined) : undefined,
       }))
@@ -421,22 +423,61 @@ export async function generarPreInforme(
     y += 5;
   }
 
-  /** Foto de referencia (placa) de una subtabla del equipo, si se capturó (#61). */
-  function renderRefImagen(subtabla: string, caption: string) {
-    const iden = datos.identificaciones.find((i) => i.subtabla === subtabla);
-    if (!iden?.dataUrl) return;
-    checkPage(52);
+  /**
+   * Tarjeta con rótulo en cabecera + imagen enmarcada. Formato común para las
+   * fotos de referencia por sección y para "otras identificaciones" (#61).
+   * Devuelve `false` si `dataUrl` no es utilizable (el llamador decide el fallback).
+   */
+  function drawImagenCard(caption: string, dataUrl: string): boolean {
+    const imgW = 58;
+    const imgH = 44;
+    const pad = 5;
+    const headerH = 8;
+    const cardW = imgW + pad * 2;
+    const cardH = headerH + pad + imgH + pad;
+
+    checkPage(cardH + 6);
+
+    // Cuerpo de la tarjeta
+    doc.setFillColor(255, 255, 255);
+    doc.setDrawColor(...COLOR_BORDER);
+    doc.setLineWidth(0.3);
+    doc.roundedRect(MARGIN, y, cardW, cardH, 2, 2, "FD");
+
+    // Cabecera
+    doc.setFillColor(...COLOR_HEADER_BG);
+    doc.rect(MARGIN + 0.4, y + 0.4, cardW - 0.8, headerH - 0.4, "F");
     doc.setFont("helvetica", "bold");
-    doc.setFontSize(8);
-    doc.setTextColor(...COLOR_GRAY);
-    doc.text(caption, MARGIN, y);
-    y += 4;
+    doc.setFontSize(6.5);
+    doc.setTextColor(...COLOR_PRIMARY);
+    doc.text(caption.toUpperCase(), MARGIN + pad, y + headerH - 3);
+    doc.setDrawColor(...COLOR_BORDER);
+    doc.setLineWidth(0.2);
+    doc.line(MARGIN, y + headerH, MARGIN + cardW, y + headerH);
+
+    // Imagen enmarcada
     try {
-      doc.addImage(iden.dataUrl, MARGIN, y, 50, 40);
-      y += 44;
+      const imgX = MARGIN + pad;
+      const imgY = y + headerH + pad;
+      doc.addImage(dataUrl, imgX, imgY, imgW, imgH);
+      doc.setDrawColor(...COLOR_BORDER);
+      doc.setLineWidth(0.2);
+      doc.rect(imgX, imgY, imgW, imgH, "S");
+      y += cardH + 6;
+      return true;
     } catch {
-      y += 2;
+      y += headerH + 4;
+      return false;
     }
+  }
+
+  /** Foto de referencia (placa) de una subtabla del equipo, si se capturó (#61). */
+  function renderRefImagen(subtabla: string, caption: string, refId?: string) {
+    const iden = datos.identificaciones.find(
+      (i) => i.subtabla === subtabla && (i.ref_id ?? undefined) === refId
+    );
+    if (!iden?.dataUrl) return;
+    drawImagenCard(caption, iden.dataUrl);
   }
 
   // Contactos helper
@@ -758,8 +799,12 @@ export async function generarPreInforme(
     });
 
     y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
+    const captionRef =
+      datos.tubos.length > 1
+        ? `Placa / referencia del tubo ${i + 1}`
+        : "Placa / referencia del tubo";
+    renderRefImagen("tubo", captionRef, tuboItem.id);
   });
-  renderRefImagen("tubo", "Placa / referencia del tubo");
 
   // Características del Colimador y Sistema de Adquisición
   checkPage(30);
@@ -808,19 +853,15 @@ export async function generarPreInforme(
       checkPage(20);
       addSubsectionTitle("", "Otras identificaciones del equipo de rayos X");
       otras.forEach((iden) => {
-        checkPage(iden.dataUrl ? 60 : 10);
-        doc.setFont("helvetica", "bold");
-        doc.setFontSize(8);
-        doc.setTextColor(...COLOR_GRAY);
-        doc.text(iden.nombre, MARGIN, y);
-        y += 4;
         if (iden.dataUrl) {
-          try {
-            doc.addImage(iden.dataUrl, MARGIN, y, 50, 40);
-            y += 44;
-          } catch {
-            y += 2;
-          }
+          drawImagenCard(iden.nombre, iden.dataUrl);
+        } else {
+          checkPage(10);
+          doc.setFont("helvetica", "bold");
+          doc.setFontSize(8);
+          doc.setTextColor(...COLOR_GRAY);
+          doc.text(iden.nombre, MARGIN, y);
+          y += 6;
         }
       });
       y += 2;

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -471,13 +471,92 @@ export async function generarPreInforme(
     }
   }
 
-  /** Foto de referencia (placa) de una subtabla del equipo, si se capturó (#61). */
-  function renderRefImagen(subtabla: string, caption: string, refId?: string) {
-    const iden = datos.identificaciones.find(
-      (i) => i.subtabla === subtabla && (i.ref_id ?? undefined) === refId
-    );
-    if (!iden?.dataUrl) return;
-    drawImagenCard(caption, iden.dataUrl);
+  const lastAutoTableFinalY = () =>
+    (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY;
+
+  /**
+   * Subsección de características del equipo (generador / tubo / colimador).
+   * Si hay foto de referencia (#61) la tabla se muestra como tarjeta: foto a la
+   * izquierda, tabla clave/valor a la derecha. Sin foto → tabla a todo el ancho,
+   * igual que el resto del informe.
+   */
+  function renderTablaEquipo(
+    titulo: string,
+    filas: string[][],
+    ref?: { subtabla: string; refId?: string }
+  ) {
+    checkPage(14);
+    addSubsectionTitle("", titulo);
+
+    const dataUrl = ref
+      ? datos.identificaciones.find(
+          (i) => i.subtabla === ref.subtabla && (i.ref_id ?? undefined) === ref.refId
+        )?.dataUrl
+      : undefined;
+
+    if (!dataUrl) {
+      autoTable(doc, {
+        startY: y,
+        margin: { left: MARGIN, right: MARGIN },
+        body: filas,
+        theme: "grid",
+        bodyStyles: { fontSize: 8, textColor: COLOR_BLACK },
+        columnStyles: {
+          0: { fontStyle: "bold", cellWidth: 60, fillColor: COLOR_HEADER_BG },
+          1: { cellWidth: CONTENT_WIDTH - 60 },
+        },
+      });
+      y = lastAutoTableFinalY() + 6;
+      return;
+    }
+
+    // Tarjeta: foto a la izquierda, tabla a la derecha.
+    const pad = 4;
+    const imgW = 48;
+    const imgH = 38;
+    const gap = 6;
+    const tableLeft = MARGIN + pad + imgW + gap;
+    const tableWidth = CONTENT_WIDTH - pad * 2 - imgW - gap;
+    const labelW = 44;
+
+    checkPage(Math.max(filas.length * 8 + pad * 2, imgH + pad * 2) + 4);
+    const startY = y;
+
+    autoTable(doc, {
+      startY: startY + pad,
+      margin: { left: tableLeft, right: MARGIN + pad },
+      tableWidth,
+      body: filas,
+      theme: "grid",
+      bodyStyles: { fontSize: 8, textColor: COLOR_BLACK },
+      columnStyles: {
+        0: { fontStyle: "bold", cellWidth: labelW, fillColor: COLOR_HEADER_BG },
+        1: { cellWidth: tableWidth - labelW },
+      },
+    });
+
+    const tableH = lastAutoTableFinalY() - (startY + pad);
+    const bodyH = Math.max(tableH, imgH);
+    const cardH = bodyH + pad * 2;
+
+    // Marco de la tarjeta (solo trazo, minimalista)
+    doc.setDrawColor(...COLOR_BORDER);
+    doc.setLineWidth(0.3);
+    doc.roundedRect(MARGIN, startY, CONTENT_WIDTH, cardH, 2, 2, "S");
+
+    // Foto centrada verticalmente respecto al alto de la tabla
+    const imgX = MARGIN + pad;
+    const imgY = startY + pad + (bodyH - imgH) / 2;
+    try {
+      doc.addImage(dataUrl, imgX, imgY, imgW, imgH);
+      doc.setDrawColor(...COLOR_BORDER);
+      doc.setLineWidth(0.2);
+      doc.rect(imgX, imgY, imgW, imgH, "S");
+    } catch {
+      // sin imagen utilizable: la tarjeta queda solo con la tabla
+    }
+
+    y = startY + cardH + 6;
   }
 
   // Contactos helper
@@ -724,9 +803,6 @@ export async function generarPreInforme(
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
 
   // Características del Generador
-  checkPage(48);
-  addSubsectionTitle("", "Características del Generador");
-
   const datosGenerador = [
     ["Marca", datos.equipo?.gen_marca ?? "—"],
     ["Modelo", datos.equipo?.gen_modelo ?? "—"],
@@ -736,20 +812,7 @@ export async function generarPreInforme(
     ["Energía fotones / electrones (MeV)", textoCampo(datos.equipo?.gen_energia_fotones_mev)],
   ];
 
-  autoTable(doc, {
-    startY: y,
-    margin: { left: MARGIN, right: MARGIN },
-    body: datosGenerador,
-    theme: "grid",
-    bodyStyles: { fontSize: 8, textColor: COLOR_BLACK },
-    columnStyles: {
-      0: { fontStyle: "bold", cellWidth: 60, fillColor: COLOR_HEADER_BG },
-      1: { cellWidth: CONTENT_WIDTH - 60 },
-    },
-  });
-
-  y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
-  renderRefImagen("generador", "Placa / referencia del generador");
+  renderTablaEquipo("Características del Generador", datosGenerador, { subtabla: "generador" });
 
   // Especificaciones del Tubo — cantidad de tubos del equipo, en texto
   {
@@ -769,10 +832,8 @@ export async function generarPreInforme(
   }
 
   datos.tubos.forEach((tuboItem, i) => {
-    checkPage(40);
     const titulo =
       datos.tubos.length > 1 ? `Especificaciones del Tubo ${i + 1}` : "Especificaciones del Tubo";
-    addSubsectionTitle("", titulo);
 
     const datosTubo = [
       ["Marca", tuboItem.marca ?? "—"],
@@ -786,30 +847,10 @@ export async function generarPreInforme(
       ["Foco grueso (mm)", String(tuboItem.foco_grueso_mm ?? "—")],
     ];
 
-    autoTable(doc, {
-      startY: y,
-      margin: { left: MARGIN, right: MARGIN },
-      body: datosTubo,
-      theme: "grid",
-      bodyStyles: { fontSize: 8, textColor: COLOR_BLACK },
-      columnStyles: {
-        0: { fontStyle: "bold", cellWidth: 60, fillColor: COLOR_HEADER_BG },
-        1: { cellWidth: CONTENT_WIDTH - 60 },
-      },
-    });
-
-    y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
-    const captionRef =
-      datos.tubos.length > 1
-        ? `Placa / referencia del tubo ${i + 1}`
-        : "Placa / referencia del tubo";
-    renderRefImagen("tubo", captionRef, tuboItem.id);
+    renderTablaEquipo(titulo, datosTubo, { subtabla: "tubo", refId: tuboItem.id });
   });
 
   // Características del Colimador y Sistema de Adquisición
-  checkPage(30);
-  addSubsectionTitle("", "Características del Colimador y del Sistema de Adquisición de Imágenes");
-
   const datosColimador = [
     ["Distancia Foco / Paciente (cm)", String(datos.equipo?.distancia_foco_paciente ?? "—")],
     ["Bucky", datos.equipo?.bucky?.replace(/_/g, " ") ?? "—"],
@@ -821,20 +862,11 @@ export async function generarPreInforme(
     ["Filtración Añadida (mm Al)", String(datos.equipo?.filtracion_anadida_mmal ?? "No reporta")],
   ];
 
-  autoTable(doc, {
-    startY: y,
-    margin: { left: MARGIN, right: MARGIN },
-    body: datosColimador,
-    theme: "grid",
-    bodyStyles: { fontSize: 8, textColor: COLOR_BLACK },
-    columnStyles: {
-      0: { fontStyle: "bold", cellWidth: 60, fillColor: COLOR_HEADER_BG },
-      1: { cellWidth: CONTENT_WIDTH - 60 },
-    },
-  });
-
-  y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 6;
-  renderRefImagen("colimador", "Placa / referencia del colimador");
+  renderTablaEquipo(
+    "Características del Colimador y del Sistema de Adquisición de Imágenes",
+    datosColimador,
+    { subtabla: "colimador" }
+  );
 
   // Condiciones ambientales
   checkPage(15);

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -605,7 +605,11 @@ function render21(ctx: InformeCtx, visita: VisitaEjecucion, conv: DatosConvencio
       body: conv.mediciones.map((m) => [
         String(m.punto_numero),
         m.ubicacion_descripcion || "—",
-        fmt(m.factor_ocupacion_t, 3).replace(/\.?0+$/, "") || "—",
+        // T con hasta 3 decimales y sin ceros de relleno. `formatDecimal` sin
+        // `decimals` ya lo hace (maximumFractionDigits 3, minimum 0); el
+        // `.replace(/\.?0+$/)` anterior asumía punto decimal y dejaba "1," con
+        // valores enteros ahora que se formatea con coma (es-CO).
+        formatDecimal(m.factor_ocupacion_t) || "—",
         fmt(m.factor_uso_u, 1),
         m.dosis_anual_msv != null ? formatDecimal(m.dosis_anual_msv, 6) : "—",
         capitalizar(m.tipo_area),

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1209,6 +1209,7 @@ export type Database = {
           last_modified: string;
           nombre: string | null;
           orden: number | null;
+          ref_id: string | null;
           subtabla: string;
           sync_status: string;
           url_storage: string | null;
@@ -1221,6 +1222,7 @@ export type Database = {
           last_modified?: string;
           nombre?: string | null;
           orden?: number | null;
+          ref_id?: string | null;
           subtabla?: string;
           sync_status?: string;
           url_storage?: string | null;
@@ -1233,6 +1235,7 @@ export type Database = {
           last_modified?: string;
           nombre?: string | null;
           orden?: number | null;
+          ref_id?: string | null;
           subtabla?: string;
           sync_status?: string;
           url_storage?: string | null;

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1203,31 +1203,37 @@ export type Database = {
       equipo_identificaciones: {
         Row: {
           creado_en: string;
+          deleted_at: string | null;
           equipo_id: string;
           id: string;
           last_modified: string;
           nombre: string | null;
           orden: number | null;
+          subtabla: string;
           sync_status: string;
           url_storage: string | null;
         };
         Insert: {
           creado_en?: string;
+          deleted_at?: string | null;
           equipo_id: string;
           id?: string;
           last_modified?: string;
           nombre?: string | null;
           orden?: number | null;
+          subtabla?: string;
           sync_status?: string;
           url_storage?: string | null;
         };
         Update: {
           creado_en?: string;
+          deleted_at?: string | null;
           equipo_id?: string;
           id?: string;
           last_modified?: string;
           nombre?: string | null;
           orden?: number | null;
+          subtabla?: string;
           sync_status?: string;
           url_storage?: string | null;
         };

--- a/src/lib/workflow/module-completeness.ts
+++ b/src/lib/workflow/module-completeness.ts
@@ -152,25 +152,25 @@ const INFO_CAMPOS: {
   {
     campo: "equipo.gen_marca",
     label: "Marca del equipo",
-    seccion: "Características del Equipo",
+    seccion: "Características del Generador",
     get: (c) => c.equipo?.gen_marca,
   },
   {
     campo: "equipo.gen_numero_serie",
     label: "N.º de serie del equipo",
-    seccion: "Características del Equipo",
+    seccion: "Características del Generador",
     get: (c) => c.equipo?.gen_numero_serie,
   },
   {
     campo: "equipo.gen_modelo",
     label: "Modelo del equipo",
-    seccion: "Características del Equipo",
+    seccion: "Características del Generador",
     get: (c) => c.equipo?.gen_modelo,
   },
   {
     campo: "equipo.gen_fase",
     label: "Fase del generador",
-    seccion: "Características del Equipo",
+    seccion: "Características del Generador",
     get: (c) => c.equipo?.gen_fase,
   },
   {

--- a/supabase/migrations/023_deleted_at_todas_las_tablas_sync.sql
+++ b/supabase/migrations/023_deleted_at_todas_las_tablas_sync.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+--  023 — `deleted_at` en TODAS las tablas de sync
+--
+--  Contexto (pasada de prueba E2E): al eliminar un tubo desde Información
+--  General, el borrado NO llega a Supabase. `deleteTubo` marca
+--  `deleted_at` en Dexie y el push hace un UPSERT que incluye esa columna,
+--  pero `tubos` (y `colimadores` / `gantry` / varias más) no la tienen en
+--  la base → PGRST204 / 42703 y la fila queda `pending`/`failed`.
+--
+--  La migración 015 agregó `deleted_at` solo a 6 tablas conv_*. El
+--  soft-delete (invariante `SyncFields.deleted_at`) aplica a TODAS las
+--  tablas bidireccionales. Esto lo empareja.
+--
+--  Aditiva e idempotente (`ADD COLUMN IF NOT EXISTS`). Correr en Supabase
+--  → SQL Editor.
+-- ============================================================
+
+DO $$
+DECLARE
+  t text;
+  sync_tables text[] := ARRAY[
+    'clientes','contactos','sedes','ubicaciones_rx','equipos','equipo_movimientos',
+    'tubos','colimadores','gantry','equipo_identificaciones','solicitudes',
+    'visitas','grupo_resultados','prueba_resultados','mediciones_radiometricas','evidencias',
+    'conv_levantamiento_setup','conv_mediciones','conv_inspeccion_items','conv_elementos_proteccion',
+    'conv_raysafe_setup','conv_raysafe_mediciones','conv_cae_setup','conv_cae_mediciones',
+    'conv_ddi_mediciones','conv_cassette_inspeccion','conv_uniformidad_cr','conv_colimacion',
+    'conv_uniformidad_detector','conv_resolucion','conv_bajo_contraste','conv_mtf',
+    'conv_informe_secciones','conv_resultados_prueba','conv_evidencias'
+  ];
+BEGIN
+  FOREACH t IN ARRAY sync_tables LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = t
+    ) THEN
+      RAISE NOTICE 'tabla % no existe — se omite', t;
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.%I ADD COLUMN IF NOT EXISTS deleted_at timestamptz', t);
+  END LOOP;
+END $$;

--- a/supabase/migrations/024_equipo_identificaciones_subtabla.sql
+++ b/supabase/migrations/024_equipo_identificaciones_subtabla.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+--  024 — `subtabla` en equipo_identificaciones (#61)
+--
+--  La tabla ahora guarda dos cosas:
+--   - la foto de referencia (placa) de las secciones generador / tubo /
+--     colimador — una sola por sección;
+--   - las "otras identificaciones" sueltas (título + imagen) de la lista
+--     que va después de Condiciones Ambientales.
+--
+--  `subtabla` discrimina. Default 'otra' → las filas creadas por la 021
+--  (antes de este cambio) quedan como "otras", que es su comportamiento
+--  previo. Aditiva e idempotente.
+-- ============================================================
+
+ALTER TABLE public.equipo_identificaciones
+  ADD COLUMN IF NOT EXISTS subtabla text NOT NULL DEFAULT 'otra';
+
+ALTER TABLE public.equipo_identificaciones
+  DROP CONSTRAINT IF EXISTS equipo_identificaciones_subtabla_check;
+
+ALTER TABLE public.equipo_identificaciones
+  ADD CONSTRAINT equipo_identificaciones_subtabla_check
+  CHECK (subtabla IN ('generador', 'tubo', 'colimador', 'otra'));

--- a/supabase/migrations/025_equipo_identificaciones_ref_id.sql
+++ b/supabase/migrations/025_equipo_identificaciones_ref_id.sql
@@ -1,0 +1,12 @@
+-- ============================================================
+--  025 — `ref_id` en equipo_identificaciones (#61)
+--
+--  La foto de referencia de la subtabla "tubo" es POR TUBO (un equipo
+--  puede tener N tubos). `ref_id` apunta al `tubos.id` correspondiente.
+--  Para generador / colimador / otra queda NULL (hay una sola por equipo).
+--
+--  Aditiva e idempotente.
+-- ============================================================
+
+ALTER TABLE public.equipo_identificaciones
+  ADD COLUMN IF NOT EXISTS ref_id uuid;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,8 +62,12 @@ export default defineConfig({
         "src/lib/db/index.ts": { lines: 63 },
         // Tier 5 — PDF. Tests de contrato (smoke end-to-end + recopilarDatosConv);
         // no snapshots de píxeles. Cobertura alta para un smoke porque
-        // generarPreInforme recorre casi toda la tubería de render.
-        "src/lib/pdf/generar-pre-informe.ts": { lines: 65, functions: 40, branches: 58 },
+        // generarPreInforme recorre casi toda la tubería de render. El render de
+        // imágenes del equipo (#61: tarjeta foto/tabla, drawImagenCard) no se
+        // ejercita: happy-dom + fake-indexeddb no conservan el Blob en el
+        // round-trip por IndexedDB, así que `dataUrl` queda undefined y esas
+        // ~90 líneas caen fuera del smoke.
+        "src/lib/pdf/generar-pre-informe.ts": { lines: 64, functions: 40, branches: 58 },
         "src/lib/pdf/secciones-convencional.ts": { lines: 43, functions: 28, branches: 20 },
         // Tier 6 — Módulo 17 (form-dialogs) + piezas compartidas del Módulo 18.
         // #10 (writes multi-tabla del equipo ahora transaccionales + soft-delete


### PR DESCRIPTION
Cierra **#61** y endurece **#67**, **#68** y **#51** con las regresiones detectadas en la ronda de pruebas locales sobre los paquetes A–D (ya mergeados en `main` por los PRs #70–#78).

## #61 — fotos por subtabla + "otras identificaciones" (lo que #78 dejó como seguimiento)

| Pieza | Detalle |
|---|---|
| `equipo_identificaciones.subtabla` | `generador` / `tubo` / `colimador` = foto de referencia (placa) de esa sección; `otra` = entrada libre de la lista "Otras identificaciones". Migración **`024_equipo_identificaciones_subtabla.sql`** (`ADD COLUMN` + CHECK, aditiva). |
| `equipo_identificaciones.ref_id` | La foto de la subtabla `tubo` es **por tubo** (`ref_id` → `tubos.id`). Migración **`025_equipo_identificaciones_ref_id.sql`** (aditiva). |
| `info-modulo` | Slot de foto de placa en Generador, en **cada tarjeta de Tubo**, y en Colimador. Sección **"Otras identificaciones del equipo de rayos X"** movida a después de "Condiciones ambientales". |
| `equipo-form-dialog` | Los mismos slots de foto (generador / tubo / colimador) + lista "Otras identificaciones" disponibles desde el alta/edición del equipo. La foto del tubo se ancla al tubo que se guarda. |
| `generar-pre-informe` | Cuando hay foto, las secciones Generador / Tubo / Colimador se renderizan como **tarjeta minimalista**: placa a la izquierda (respeta aspect ratio, box 70 mm), tabla clave/valor a la derecha. Sin foto → tabla a todo el ancho como antes. La foto del tubo va dentro del bloque de su tubo. |
| Cantidad de tubos | Línea de texto "El equipo cuenta con N tubos." antes de las especificaciones. |
| Revert visual | La sección vuelve a llamarse **"Características del Generador"** (se quitó "Identificación del Equipo" del título del informe). |

## Regresiones de la ronda local

| Commit | Issue | Qué |
|---|---|---|
| `fcba730` | #67 | La captura de foto en los grupos A–E disparaba `pending` pero **nunca llamaba a `pushSingle`** — la imagen esperaba al ciclo de reintento de 5 min. El path de reemplazo tampoco seteaba `sync_status`/`last_modified`. |
| `d6a1d94` | #67 | CSP `img-src` no incluía el host de Supabase Storage → las imágenes firmadas del pull no renderizaban (`next.config.ts`). |
| `dbba030` | #51 | `tubos`, `colimadores`, `gantry` y demás tablas de sync no tenían columna `deleted_at` en Supabase (la mig. 015 solo cubrió `conv_*`) → borrar un tubo no propagaba. Migración **`023_deleted_at_todas_las_tablas_sync.sql`** (DO-block `ADD COLUMN IF NOT EXISTS` sobre todas las tablas de sync). |
| `9a97789` | #68 | Factor de ocupación entero salía como `"1,"` en la tabla 2.1.2 (`fmt(v,3)` → `"1,000"` + regex de recorte que asume punto). Ahora usa `formatDecimal`. |
| `bdcb479` `8e64ce5` | #65 | El bloque "Generar Pre-Informe / Vista previa" se movió arriba de "Secciones fijas" en el módulo de pre-informe. |

## Migraciones que corre el dueño (aditivas, en orden)

1. `023_deleted_at_todas_las_tablas_sync.sql`
2. `024_equipo_identificaciones_subtabla.sql`
3. `025_equipo_identificaciones_ref_id.sql`

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **596 tests** + build. Verde.

Nuevos tests: foto de referencia por subtabla en el informe (generador/tubo/colimador no van a "Otras"); "Otras identificaciones" con una borrada; camino de tarjeta con PNG válido; captura de foto dispara `pushSingle` en el smoke de grupo A; factor de ocupación `formatDecimal`.

Closes #61
