### PR TITLE
fix(informe): incrustar imágenes del bucket cuando no hay blob local (#67)

### DIFF
--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -19,6 +19,7 @@ import type {
 } from "@/lib/db/types";
 import { hasPackage } from "@/lib/equipos/registry";
 import { logger } from "@/lib/logger";
+import { descargarEvidencia } from "@/lib/supabase/storage";
 import { getCatalogoSeccion } from "@/lib/equipos/convencional/informe-secciones";
 import { evaluarConceptoPrueba, tieneCriterio } from "@/lib/equipos/convencional/evaluacion";
 import {
@@ -86,6 +87,21 @@ function blobADataUrl(blob: Blob): Promise<string> {
     reader.onerror = () => reject(reader.error ?? new Error("FileReader"));
     reader.readAsDataURL(blob);
   });
+}
+
+/**
+ * data URL de una imagen para el PDF: usa el blob local si está; si no, baja los
+ * bytes del bucket con `url_storage`. Devuelve undefined si no hay ninguno o si
+ * la conversión/descarga falla (el informe sigue sin esa imagen).
+ */
+async function imagenDataUrl(
+  blobLocal: Blob | null | undefined,
+  urlStorage: string | null | undefined
+): Promise<string | undefined> {
+  if (blobLocal) return blobADataUrl(blobLocal).catch(() => undefined);
+  if (!urlStorage) return undefined;
+  const bajado = await descargarEvidencia(urlStorage);
+  return bajado ? blobADataUrl(bajado).catch(() => undefined) : undefined;
 }
 
 /** "No aplica" para null / undefined / "" ; el valor tal cual si tiene contenido. */
@@ -177,7 +193,10 @@ async function recopilarDatos(visitaId: string): Promise<DatosInforme | null> {
         subtabla: r.subtabla ?? "otra",
         ref_id: r.ref_id,
         nombre: r.nombre?.trim() || "Identificación",
-        dataUrl: r.blob_local ? await blobADataUrl(r.blob_local).catch(() => undefined) : undefined,
+        // El blob local solo existe en el dispositivo que capturó la foto; en
+        // cualquier otro hay que bajarla del bucket con el `url_storage` que
+        // llegó por el sync.
+        dataUrl: await imagenDataUrl(r.blob_local, r.url_storage),
       }))
   );
   const sala = visita.ubicacion_id

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -30,6 +30,7 @@ import {
 } from "@/lib/equipos/convencional/inspeccion-items";
 import { CATALOGO_SECCIONES } from "@/lib/equipos/convencional/informe-secciones";
 import { detalle213 } from "@/lib/equipos/convencional/evaluacion";
+import { descargarEvidencia } from "@/lib/supabase/storage";
 
 // ============================================================
 //  Secciones del pre-informe para el equipo CONVENCIONAL
@@ -146,10 +147,17 @@ async function blobADataUrl(blob: Blob): Promise<string> {
 async function cargarImagen(
   evidencia: ConvEvidencia | undefined
 ): Promise<DatosConvencional["planoRadiometrico"]> {
-  if (!evidencia?.blob_local) return undefined;
+  if (!evidencia) return undefined;
+  // El blob local solo existe en el dispositivo que capturó la foto; en
+  // cualquier otro hay que bajarla del bucket con el `url_storage` del sync.
+  const blob =
+    evidencia.blob_local instanceof Blob
+      ? evidencia.blob_local
+      : await descargarEvidencia(evidencia.url_storage);
+  if (!blob) return undefined;
   try {
-    const bitmap = await createImageBitmap(evidencia.blob_local);
-    const dataUrl = await blobADataUrl(evidencia.blob_local);
+    const bitmap = await createImageBitmap(blob);
+    const dataUrl = await blobADataUrl(blob);
     return { dataUrl, width: bitmap.width, height: bitmap.height };
   } catch {
     return undefined;

--- a/src/lib/supabase/storage.test.ts
+++ b/src/lib/supabase/storage.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
-import { evidenciaPath, compressImage, resolverImagenSrc, subirEvidencia } from "./storage";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  evidenciaPath,
+  compressImage,
+  resolverImagenSrc,
+  subirEvidencia,
+  descargarEvidencia,
+} from "./storage";
+
+const download = vi.fn();
+vi.mock("./client", () => ({
+  createClient: () => ({ storage: { from: () => ({ download }) } }),
+}));
 
 describe("storage — evidenciaPath", () => {
   it("conv_evidencias → {visita}/{prueba}/{slot}.jpg", () => {
@@ -96,5 +107,36 @@ describe("storage — resolverImagenSrc", () => {
 
   it("si url_storage ya es una URL completa, la devuelve tal cual", async () => {
     expect(await resolverImagenSrc({ url_storage: "https://cdn/x.jpg" })).toBe("https://cdn/x.jpg");
+  });
+});
+
+describe("storage — descargarEvidencia", () => {
+  afterEach(() => {
+    download.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("sin path → null", async () => {
+    expect(await descargarEvidencia(null)).toBeNull();
+    expect(await descargarEvidencia(undefined)).toBeNull();
+    expect(await descargarEvidencia("")).toBeNull();
+  });
+
+  it("path del bucket → baja el blob por el cliente de Supabase", async () => {
+    const blob = new Blob([new Uint8Array(8)], { type: "image/jpeg" });
+    download.mockResolvedValue({ data: blob, error: null });
+    expect(await descargarEvidencia("equipos/eq-1/iden-1.jpg")).toBe(blob);
+    expect(download).toHaveBeenCalledWith("equipos/eq-1/iden-1.jpg");
+  });
+
+  it("si Supabase devuelve error → null (el informe sigue sin la imagen)", async () => {
+    download.mockResolvedValue({ data: null, error: { message: "no existe" } });
+    expect(await descargarEvidencia("equipos/eq-1/x.jpg")).toBeNull();
+  });
+
+  it("url completa (datos viejos) → fetch directo", async () => {
+    const blob = new Blob([new Uint8Array(4)], { type: "image/png" });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, blob: async () => blob }));
+    expect(await descargarEvidencia("https://cdn/x.png")).toBe(blob);
   });
 });

--- a/src/lib/supabase/storage.ts
+++ b/src/lib/supabase/storage.ts
@@ -146,3 +146,32 @@ export async function resolverImagenSrc(img: {
     return null;
   }
 }
+
+/**
+ * Bytes de una imagen del bucket privado, para incrustarla en el PDF. Se usa
+ * cuando el dispositivo que genera el informe no capturó la foto y por lo tanto
+ * no tiene `blob_local` — solo el `url_storage` (path) que llegó por el sync.
+ * Devuelve null si no hay path o si la descarga falla (el informe sigue sin la
+ * imagen, no se rompe).
+ */
+export async function descargarEvidencia(path: string | null | undefined): Promise<Blob | null> {
+  if (!path) return null;
+  // Compatibilidad: `url_storage` que ya es una URL completa (datos viejos).
+  if (/^https?:\/\//.test(path)) {
+    try {
+      const r = await fetch(path);
+      return r.ok ? await r.blob() : null;
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const { createClient } = await import("./client");
+    const supabase = createClient();
+    const { data, error } = await supabase.storage.from(EVIDENCIAS_BUCKET).download(path);
+    if (error || !data) return null;
+    return data as Blob;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Seguimiento de #67. El pipeline de subida a Storage (PR #71) funciona, pero la **generación del PDF** solo incrustaba `blob_local` — que existe únicamente en el dispositivo que capturó la foto. Al generar el informe en otro equipo (o tras limpiar IndexedDB) las placas del equipo y las fotos de los grupos salían vacías aunque estuvieran en el bucket.

Reportado en producción: "no me están cargando las imágenes de las placas del equipo".

## Cambios

| Archivo | Qué |
|---|---|
| `src/lib/supabase/storage.ts` | Nueva `descargarEvidencia(path)`: baja los bytes del bucket privado `evidencias` con el cliente autenticado (política `evidencias_auth_select` de la migración 018). Si `url_storage` ya es una URL completa (datos viejos) → `fetch` directo. Devuelve `null` si falla — el informe sigue sin esa imagen, no se rompe. |
| `src/lib/pdf/generar-pre-informe.ts` | `imagenDataUrl(blob_local, url_storage)` en la carga de `equipo_identificaciones`: usa el blob local si está, si no descarga del bucket. |
| `src/lib/pdf/secciones-convencional.ts` | `cargarImagen` hace el mismo fallback para **todas** las fotos de `conv_evidencias` (plano radiométrico, avisos de protección, grupos A–E). |

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **601 tests** + build. Verde.

Tests nuevos: `descargarEvidencia` (path del bucket → blob, error → null, URL completa → fetch, sin path → null).

## Nota de despliegue

No hay migración nueva. Requiere que la **018** ya esté corrida (bucket + política de lectura para `authenticated`), lo cual ya está en producción.

Closes #67
