### PR TITLE
feat(grupo-a): Paquete E — drag&drop, avisos dinámicos, Combobox de elemento (#66, #69)

### DIFF
--- a/src/components/visita-modulos/grupo-a-modulo.tsx
+++ b/src/components/visita-modulos/grupo-a-modulo.tsx
@@ -34,6 +34,17 @@ import { getManualGrupo } from "@/lib/equipos/convencional/manual";
 import { SetupField } from "@/components/visita-modulos/setup-field";
 import { useRowSavedFlash } from "@/hooks/use-row-saved";
 import { useImagenSrc } from "@/hooks/use-imagen-src";
+import { ImagenConTitulo } from "@/components/imagen-con-titulo";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+  ComboboxValue,
+} from "@/components/ui/combobox";
 import type { ConvInspeccionItem } from "@/lib/equipos/convencional/db/types";
 
 // ─── Constants ───
@@ -62,13 +73,14 @@ const SLOTS_IMAGEN_21 = [
   { slot: "plano_radiometrico", label: "Plano / Croquis radiométrico de la sala" },
 ];
 
-/** Slots de fotografías de la prueba 2.2 (van a la sección 2.2.8 del informe) */
+/**
+ * Slots FIJOS de fotografías de la prueba 2.2 (sección 2.2.8 del informe).
+ * Los avisos de protección son una lista dinámica aparte (#66): una evidencia
+ * por aviso, `slot: "aviso_<uuid>"`, `descripcion` = título.
+ */
 const SLOTS_FOTOS_22 = [
   { slot: "equipo_rayos_x", label: "Equipo de rayos X" },
   { slot: "consola", label: "Consola del equipo" },
-  { slot: "aviso_proteccion_1", label: "Aviso de protección 1" },
-  { slot: "aviso_proteccion_2", label: "Aviso de protección 2" },
-  { slot: "aviso_proteccion_3", label: "Aviso de protección 3" },
 ];
 
 /** Carga de trabajo estándar para radiografía convencional (mA·min/sem) — piso del cálculo, metodología IAEA-TECDOC-1958 */
@@ -200,7 +212,12 @@ function ImageSlot({
   onRemove: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
   const preview = useImagenSrc(evidencia ?? {});
+
+  function pick(file?: File | null) {
+    if (file && file.type.startsWith("image/")) onCapture(file);
+  }
 
   return (
     <div className="space-y-2">
@@ -220,21 +237,33 @@ function ImageSlot({
         <button
           type="button"
           onClick={() => inputRef.current?.click()}
-          className="w-full h-32 border-2 border-dashed border-slate-300 rounded-xl flex flex-col items-center justify-center gap-2 text-slate-400 hover:border-primary hover:text-primary transition-colors"
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragOver(false);
+            pick(e.dataTransfer.files?.[0]);
+          }}
+          className={`w-full h-32 border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-2 transition-colors ${
+            dragOver
+              ? "border-primary text-primary bg-primary/5"
+              : "border-slate-300 text-slate-400 hover:border-primary hover:text-primary"
+          }`}
         >
           <Camera className="w-6 h-6" />
-          <span className="text-xs font-bold">Tomar foto o seleccionar</span>
+          <span className="text-xs font-bold">Tomar foto, elegir o arrastrar</span>
         </button>
       )}
       <input
         ref={inputRef}
         type="file"
         accept="image/*"
-        capture="environment"
         className="hidden"
         onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (file) onCapture(file);
+          pick(e.target.files?.[0]);
           e.target.value = "";
         }}
       />
@@ -253,7 +282,12 @@ function ElementoFotoCell({
   onRemove: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
   const preview = useImagenSrc(evidencia ?? {});
+
+  function pick(file?: File | null) {
+    if (file && file.type.startsWith("image/")) onCapture(file);
+  }
 
   return (
     <>
@@ -277,7 +311,21 @@ function ElementoFotoCell({
         <button
           type="button"
           onClick={() => inputRef.current?.click()}
-          className="w-10 h-10 border-2 border-dashed border-slate-300 rounded-lg flex items-center justify-center text-slate-400 hover:border-primary hover:text-primary transition-colors"
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragOver(false);
+            pick(e.dataTransfer.files?.[0]);
+          }}
+          className={`w-10 h-10 border-2 border-dashed rounded-lg flex items-center justify-center transition-colors ${
+            dragOver
+              ? "border-primary text-primary bg-primary/5"
+              : "border-slate-300 text-slate-400 hover:border-primary hover:text-primary"
+          }`}
           aria-label="Tomar foto del elemento"
         >
           <Camera className="w-4 h-4" />
@@ -287,15 +335,108 @@ function ElementoFotoCell({
         ref={inputRef}
         type="file"
         accept="image/*"
-        capture="environment"
         className="hidden"
         onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (file) onCapture(file);
+          pick(e.target.files?.[0]);
           e.target.value = "";
         }}
       />
     </>
+  );
+}
+
+/**
+ * Selector de elemento de protección (#69): Combobox buscable sobre el catálogo
+ * estándar; al elegir "Otro" habilita un input de texto libre. Controlado: el
+ * padre pasa `value` (= `descripcion`) y recibe el texto efectivo.
+ */
+function ElementoProteccionCombo({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const enCatalogo = CATALOGO_ELEMENTOS_PROTECCION.includes(value);
+  const [modoOtro, setModoOtro] = useState(value !== "" && !enCatalogo);
+  const seleccion = modoOtro ? "Otro" : value;
+
+  return (
+    <div className="space-y-1">
+      <Combobox
+        items={CATALOGO_ELEMENTOS_PROTECCION}
+        value={seleccion || null}
+        onValueChange={(v: string | null) => {
+          if (v === "Otro") {
+            setModoOtro(true);
+            onChange("");
+          } else {
+            setModoOtro(false);
+            onChange(v ?? "");
+          }
+        }}
+      >
+        <ComboboxTrigger className="w-full rounded-lg border border-slate-200 h-7 text-xs font-medium px-1.5 bg-white data-[placeholder]:text-slate-400">
+          <ComboboxValue placeholder="Seleccionar elemento" />
+        </ComboboxTrigger>
+        <ComboboxContent>
+          <ComboboxInput placeholder="Buscar..." />
+          <ComboboxEmpty>Sin resultados.</ComboboxEmpty>
+          <ComboboxList>
+            {(item: string) => (
+              <ComboboxItem key={item} value={item}>
+                {item}
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
+      {modoOtro && (
+        <Input
+          className="rounded-lg h-7 text-xs font-medium border-slate-200 w-full"
+          placeholder="Especificar elemento"
+          defaultValue={enCatalogo ? "" : value}
+          onBlur={(e) => onChange(e.target.value)}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Fila de aviso de protección (#66): título + foto con drag & drop + eliminar.
+ * Wrapper delgado que resuelve la URL de la imagen (hook) y delega en
+ * `<ImagenConTitulo>`.
+ */
+function AvisoRow({
+  evidencia,
+  onTitulo,
+  onCapture,
+  onRemoveImagen,
+  onDelete,
+}: {
+  evidencia: {
+    id?: string;
+    descripcion?: string;
+    blob_local?: Blob | null;
+    url_storage?: string | null;
+  };
+  onTitulo: (v: string) => void;
+  onCapture: (file: File) => void;
+  onRemoveImagen: () => void;
+  onDelete: () => void;
+}) {
+  const src = useImagenSrc(evidencia ?? {});
+  return (
+    <ImagenConTitulo
+      nombre={evidencia.descripcion ?? ""}
+      placeholder="Título del aviso (ej: Puerta de la sala de control)"
+      src={src}
+      onNombreChange={onTitulo}
+      onCapture={onCapture}
+      onRemoveImagen={src ? onRemoveImagen : undefined}
+      onDelete={onDelete}
+    />
   );
 }
 
@@ -487,6 +628,24 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
     if (foto?.id) await deleteAndSync("conv_evidencias", foto.id);
   }
 
+  // Avisos de protección — lista dinámica (#66): una evidencia por aviso,
+  // `slot: "aviso_<uuid>"`, `descripcion` = título.
+  async function addAviso() {
+    const now = new Date().toISOString();
+    const id = randomUUID();
+    await db.conv_evidencias.add({
+      id,
+      visita_id: visitaId,
+      prueba_codigo: "2.2",
+      slot: `aviso_${randomUUID()}`,
+      descripcion: "",
+      creado_en: now,
+      sync_status: "pending" as const,
+      last_modified: now,
+    });
+    pushSingle("conv_evidencias", id);
+  }
+
   async function captureImage(pruebaCodigo: string, slot: string, file: File) {
     const blob = new Blob([await file.arrayBuffer()], { type: file.type });
     const now = new Date().toISOString();
@@ -554,6 +713,10 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
   function getEvidencia(prueba: string, slot: string) {
     return data?.evidencias?.find((e) => e.prueba_codigo === prueba && e.slot === slot);
   }
+
+  const avisos = (data?.evidencias ?? [])
+    .filter((e) => e.prueba_codigo === "2.2" && e.slot?.startsWith("aviso_"))
+    .sort((a, b) => (a.creado_en ?? "").localeCompare(b.creado_en ?? ""));
 
   // ─── Loading / Error ───
   if (!isReady || data === undefined) {
@@ -637,8 +800,8 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
           </StepHeader>
           <Tip>
             Usa planos anteriores si están vigentes; lo ideal es solicitar el plano al cliente antes
-            de la visita. Los avisos de protección pueden ser varios: usa los tres espacios
-            disponibles.
+            de la visita. Podés arrastrar una imagen sobre el recuadro o elegir un archivo, además
+            de tomar la foto.
           </Tip>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {SLOTS_IMAGEN_21.map((s) => (
@@ -659,6 +822,44 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                 onRemove={() => removeImage("2.2", s.slot)}
               />
             ))}
+          </div>
+
+          {/* Avisos de protección radiológica — lista dinámica (#66) */}
+          <div className="space-y-3 pt-3 border-t border-slate-100">
+            <div className="flex items-center justify-between">
+              <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                Avisos de protección radiológica
+              </p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={addAviso}
+                className="h-7 text-xs text-primary hover:text-primary"
+              >
+                <Plus className="w-3.5 h-3.5 mr-1" /> Agregar aviso
+              </Button>
+            </div>
+            {avisos.length === 0 ? (
+              <p className="text-xs text-slate-400">
+                Sin avisos cargados. Agregá uno por cada aviso que haya en la sala (título + foto).
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {avisos.map((e) => (
+                  <AvisoRow
+                    key={e.id}
+                    evidencia={e}
+                    onTitulo={(v) =>
+                      e.id && updateAndSync("conv_evidencias", e.id, { descripcion: v })
+                    }
+                    onCapture={(file) => captureImage("2.2", e.slot, file)}
+                    onRemoveImagen={() => removeImage("2.2", e.slot)}
+                    onDelete={() => e.id && deleteAndSync("conv_evidencias", e.id)}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>
@@ -1141,22 +1342,14 @@ export function GrupoAModulo({ visitaId: id }: { visitaId: string }) {
                       </span>
                     </td>
                     <td className="py-1.5 px-1.5">
-                      <select
-                        className="w-full rounded-lg border border-slate-200 h-7 text-xs font-medium px-1 bg-white"
-                        defaultValue={elem.descripcion}
-                        onChange={(e) => {
+                      <ElementoProteccionCombo
+                        value={elem.descripcion ?? ""}
+                        onChange={(v) => {
                           if (!elem.id) return;
-                          updateElemento(elem.id, { descripcion: e.target.value });
+                          updateElemento(elem.id, { descripcion: v });
                           flash(elem.id);
                         }}
-                      >
-                        <option value="">Seleccionar elemento</option>
-                        {CATALOGO_ELEMENTOS_PROTECCION.map((nombre) => (
-                          <option key={nombre} value={nombre}>
-                            {nombre}
-                          </option>
-                        ))}
-                      </select>
+                      />
                     </td>
                     <td className="py-1.5 px-1.5">
                       <Input

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -105,6 +105,58 @@ describe("GrupoAModulo — capturar una foto dispara el push (#67)", () => {
   });
 });
 
+describe("GrupoAModulo — avisos de protección como lista dinámica (#66)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+    vi.mocked(pushSingle).mockClear();
+  });
+  afterEach(() => cleanup());
+
+  it("'Agregar aviso' crea una evidencia 2.2 con slot 'aviso_*' pending y dispara el push", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    render(<GrupoAModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /Agregar aviso/i }));
+
+    await waitFor(async () => {
+      const filas = await db.conv_evidencias.where("visita_id").equals(visita!.id!).toArray();
+      const aviso = filas.find((f) => f.slot?.startsWith("aviso_"));
+      expect(aviso).toBeTruthy();
+      expect(aviso!.prueba_codigo).toBe("2.2");
+      expect(aviso!.sync_status).toBe("pending");
+    });
+    expect(vi.mocked(pushSingle)).toHaveBeenCalledWith("conv_evidencias", expect.any(String));
+  });
+});
+
+describe("GrupoAModulo — elemento de protección con Combobox + 'Otro' (#69)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+  });
+  afterEach(() => cleanup());
+
+  it("un elemento con descripción fuera del catálogo abre el input de texto libre pre-cargado", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const now = new Date().toISOString();
+    await db.conv_elementos_proteccion.add({
+      id: "elem-otro-69",
+      visita_id: visita!.id!,
+      descripcion: "Mandil pediátrico especial",
+      creado_en: now,
+      sync_status: "pending",
+      last_modified: now,
+    });
+    render(<GrupoAModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    const libre = await screen.findByPlaceholderText("Especificar elemento");
+    expect(libre).toHaveValue("Mandil pediátrico especial");
+  });
+});
+
 describe("InfoModulo — Sistema de Adquisición de Imágenes (#62)", () => {
   beforeEach(async () => {
     await resetTestDb();

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -280,19 +280,27 @@ export async function recopilarDatosConv(visitaId: string): Promise<DatosConvenc
     (e) => e.prueba_codigo === "2.1" && e.slot === "plano_radiometrico"
   );
 
-  // Fotografías de la 2.2 (sección 2.2.8): orden fijo + una por elemento
+  // Fotografías de la 2.2 (sección 2.2.8): slots fijos + avisos (lista dinámica) + una por elemento
   const SLOTS_FOTOS_22: [string, string][] = [
     ["equipo_rayos_x", "Equipo de rayos X"],
     ["consola", "Consola del equipo"],
-    ["aviso_proteccion_1", "Aviso de protección radiológica"],
-    ["aviso_proteccion_2", "Aviso de protección radiológica"],
-    ["aviso_proteccion_3", "Aviso de protección radiológica"],
   ];
   const fotos22: NonNullable<DatosConvencional["fotos22"]> = [];
   for (const [slot, label] of SLOTS_FOTOS_22) {
     const ev = evidencias.find((e) => e.prueba_codigo === "2.2" && e.slot === slot);
     const img = await cargarImagen(ev);
     if (img) fotos22.push({ label, ...img });
+  }
+  // Avisos de protección — lista dinámica (#66): una evidencia por aviso,
+  // `slot` empieza en "aviso_", `descripcion` = título.
+  const avisos = evidencias
+    .filter((e) => e.prueba_codigo === "2.2" && e.slot?.startsWith("aviso_"))
+    .sort((a, b) => (a.creado_en ?? "").localeCompare(b.creado_en ?? ""));
+  for (const ev of avisos) {
+    const img = await cargarImagen(ev);
+    if (img) {
+      fotos22.push({ label: ev.descripcion?.trim() || "Aviso de protección radiológica", ...img });
+    }
   }
   for (const elem of elementos) {
     const ev = evidencias.find(


### PR DESCRIPTION
Paquete E del plan de remediación E2E. Dos mejoras de UX en la captura fotográfica del Grupo A.

## #66 — Captura de imágenes

| Pieza | Detalle |
|---|---|
| Drag & drop | `ImageSlot` y `ElementoFotoCell` (`grupo-a-modulo.tsx`) aceptan arrastrar y soltar un archivo de imagen sobre el recuadro, además del click. |
| Sin cámara forzada | Se quita `capture="environment"`: en desktop el click abre el explorador de archivos; en móvil `accept="image/*"` sigue ofreciendo cámara + galería. |
| Avisos como lista dinámica | De 3 slots fijos (`aviso_proteccion_1/2/3`, rótulo genérico) a una lista tipo "elementos de protección": botón **"Agregar aviso"**, cada fila = título editable + foto (con drag & drop) + eliminar, N sin límite. Cada fila = una evidencia `conv_evidencias` con `slot: "aviso_<uuid>"` y `descripcion` = título. Reutiliza `<ImagenConTitulo>` (el componente compartido de D2c). |
| PDF (2.2.8) | `secciones-convencional.ts` itera **toda** evidencia `2.2` con `slot` que empieza en `aviso_`, usando `descripcion` como rótulo (fallback "Aviso de protección radiológica"). Equipo de rayos X y consola siguen primero. |

## #69 — Combobox de elemento de protección

El `<select>` nativo de la columna *Elemento* (tabla de elementos de protección) pasa a `<Combobox>` buscable (el mismo de `sede-form-dialog`). Al elegir **"Otro"** aparece un input de texto libre. El valor efectivo (catálogo o libre) se persiste en `conv_elementos_proteccion.descripcion`; al reabrir el módulo, un texto que no está en el catálogo restaura el modo "Otro" con el input pre-cargado.

## Datos

**Sin migración.** `conv_evidencias` ya tiene `slot` y `descripcion` en Supabase (migración 010; `types.ts` generado está desactualizado, la tabla real sí los tiene) y ya está en `SYNC_TABLES` + `IMAGE_BLOB_TABLES`.

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **603 tests** + build. Verde.

Tests nuevos (`modulos-smoke.test.tsx`): "Agregar aviso" crea evidencia `aviso_*` `pending` + `pushSingle`; un elemento con descripción fuera del catálogo reabre el input de texto libre pre-cargado.

## Runbook

Actualizado con la sección **Paquete E** (E-AUTO-01 + E-01…E-05): https://claude.ai/code/artifact/cfba2b22-753a-40a8-aeef-4c9dd505e60f

Closes #66
Closes #69
