### PR TITLE
fix(usuarios): Paquete F1 — editar usuario carga y persiste (#58)

### DIFF
--- a/src/app/api/usuarios/[id]/route.test.ts
+++ b/src/app/api/usuarios/[id]/route.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ============================================================
+//  PATCH /api/usuarios/[id] — edición server-enforced (#58).
+//
+//  `usuarios` es MASTER_TABLE: el push del cliente no la toca, así que
+//  editar un usuario TIENE que pasar por acá. Mismo gate que el POST.
+//
+//  Contrato verificado:
+//   - 429 al superar el rate limit por IP
+//   - 401 sin sesión
+//   - 403 autenticado pero cargo != coordinador
+//   - 400 body inválido (sin filtrar el detalle del schema) / patch vacío
+//   - 404 si el id no existe
+//   - 200 + fila actualizada para un coordinador con body válido
+// ============================================================
+
+vi.mock("@/lib/env", () => ({
+  clientEnv: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "anon",
+  },
+  getServerEnv: () => ({ SUPABASE_SERVICE_ROLE_KEY: "service-role" }),
+}));
+
+const state = {
+  ip: "1.1.1.1",
+  user: null as { id: string } | null,
+  callerCargo: "coordinador" as string | null,
+  updateResult: {
+    data: { id: "u-1", nombre: "Editado", activo: true } as Record<string, unknown> | null,
+    error: null as { message: string; code?: string } | null,
+  },
+};
+const updateSpy = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ getAll: () => [] }),
+  headers: async () => new Map([["x-forwarded-for", state.ip]]),
+}));
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: () => ({
+    auth: { getUser: async () => ({ data: { user: state.user } }) },
+  }),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (_table: string) => ({
+      // caller cargo lookup
+      select: () => ({
+        eq: () => ({
+          single: async () => ({
+            data: state.callerCargo ? { cargo: state.callerCargo } : null,
+          }),
+        }),
+      }),
+      // update(...).eq(...).select().single()
+      update: (cambios: Record<string, unknown>) => {
+        updateSpy(cambios);
+        return {
+          eq: () => ({
+            select: () => ({ single: async () => state.updateResult }),
+          }),
+        };
+      },
+    }),
+  }),
+}));
+
+import { PATCH } from "./route";
+
+function req(body: unknown, id = "u-1") {
+  return [
+    { json: async () => body } as Parameters<typeof PATCH>[0],
+    { params: Promise.resolve({ id }) },
+  ] as const;
+}
+
+let ipCounter = 0;
+beforeEach(() => {
+  ipCounter += 1;
+  state.ip = `10.1.0.${ipCounter}`;
+  state.user = { id: "caller-auth-uid" };
+  state.callerCargo = "coordinador";
+  state.updateResult = {
+    data: { id: "u-1", nombre: "Editado", activo: true },
+    error: null,
+  };
+  updateSpy.mockClear();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("PATCH /api/usuarios/[id]", () => {
+  it("actualiza y responde 200 con la fila para un coordinador", async () => {
+    const res = await PATCH(...req({ nombre: "Nombre Nuevo", activo: false }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.usuario).toEqual({ id: "u-1", nombre: "Editado", activo: true });
+  });
+
+  it("normaliza telefono '' → null y solo manda los campos presentes", async () => {
+    await PATCH(...req({ cargo: "programador", telefono: "" }));
+    expect(updateSpy).toHaveBeenCalledWith({ cargo: "programador", telefono: null });
+  });
+
+  it("acepta el toggle activo suelto", async () => {
+    const res = await PATCH(...req({ activo: false }));
+    expect(res.status).toBe(200);
+    expect(updateSpy).toHaveBeenCalledWith({ activo: false });
+  });
+
+  it("responde 401 sin sesión", async () => {
+    state.user = null;
+    const res = await PATCH(...req({ activo: false }));
+    expect(res.status).toBe(401);
+  });
+
+  it("responde 403 si el llamante no es coordinador", async () => {
+    state.callerCargo = "tecnico";
+    const res = await PATCH(...req({ activo: false }));
+    expect(res.status).toBe(403);
+  });
+
+  it("responde 400 con body inválido sin filtrar el schema", async () => {
+    const res = await PATCH(...req({ cedula: "abc" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Datos inválidos");
+    expect(JSON.stringify(json)).not.toMatch(/regex|schema|issues/i);
+  });
+
+  it("responde 400 con un patch vacío", async () => {
+    const res = await PATCH(...req({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("rechaza un cargo fuera del enum", async () => {
+    const res = await PATCH(...req({ cargo: "superadmin" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("responde 404 si el usuario no existe (PGRST116)", async () => {
+    state.updateResult = { data: null, error: { message: "no rows", code: "PGRST116" } };
+    const res = await PATCH(...req({ activo: false }));
+    expect(res.status).toBe(404);
+  });
+
+  it("responde 429 al superar el límite por IP", async () => {
+    state.ip = "203.0.113.55";
+    for (let i = 0; i < 10; i++) {
+      const ok = await PATCH(...req({ activo: false }));
+      expect(ok.status).toBe(200);
+    }
+    const blocked = await PATCH(...req({ activo: false }));
+    expect(blocked.status).toBe(429);
+  });
+});

--- a/src/app/api/usuarios/[id]/route.ts
+++ b/src/app/api/usuarios/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { patchUsuarioSchema } from "@/lib/validation/schemas";
+import { rateLimit, getRateLimitKey } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+import { requireCoordinador } from "../helpers";
+
+/**
+ * PATCH /api/usuarios/[id] — edición de un usuario existente (#58).
+ *
+ * `usuarios` es MASTER_TABLE: no se sincroniza por el push del cliente. Un
+ * `db.usuarios.update(...)` local nunca llega a Supabase. Este endpoint aplica
+ * el cambio server-side con el mismo gate que el POST (sesión + coordinador)
+ * y devuelve la fila para que el cliente haga `db.usuarios.put(...)`.
+ */
+export async function PATCH(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const key = await getRateLimitKey("patch-user");
+  const { allowed } = rateLimit(key, 10, 60_000);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Demasiadas solicitudes. Intenta de nuevo en un minuto." },
+      { status: 429 }
+    );
+  }
+
+  const gate = await requireCoordinador(request);
+  if (!gate.ok) return gate.response;
+  const { supabaseAdmin } = gate;
+
+  const { id } = await ctx.params;
+  if (!id) {
+    return NextResponse.json({ error: "Falta el id del usuario" }, { status: 400 });
+  }
+
+  const body = await request.json();
+  const parsed = patchUsuarioSchema.safeParse(body);
+  if (!parsed.success) {
+    // A2: no exponer detalles del schema al cliente
+    logger.warn("usuarios", "PATCH validación fallida", parsed.error.issues);
+    return NextResponse.json({ error: "Datos inválidos" }, { status: 400 });
+  }
+
+  const { telefono, ...rest } = parsed.data;
+  const cambios: Record<string, unknown> = { ...rest };
+  if (telefono !== undefined) cambios.telefono = telefono || null;
+
+  const { data: usuario, error } = await supabaseAdmin
+    .from("usuarios")
+    .update(cambios)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error || !usuario) {
+    if (error?.code === "PGRST116") {
+      return NextResponse.json({ error: "Usuario no encontrado" }, { status: 404 });
+    }
+    logger.error("usuarios", "PATCH falló", { id, error });
+    return NextResponse.json({ error: "Error al actualizar el usuario" }, { status: 500 });
+  }
+
+  return NextResponse.json({ usuario });
+}

--- a/src/app/api/usuarios/helpers.ts
+++ b/src/app/api/usuarios/helpers.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { clientEnv, getServerEnv } from "@/lib/env";
+
+// M2: lazy init — el cliente admin solo se crea al recibir un request, no al cargar el módulo
+export function getAdminClient() {
+  return createClient(clientEnv.NEXT_PUBLIC_SUPABASE_URL, getServerEnv().SUPABASE_SERVICE_ROLE_KEY);
+}
+
+export async function getAuthenticatedUser(request: NextRequest) {
+  void request;
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    clientEnv.NEXT_PUBLIC_SUPABASE_URL,
+    clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+      },
+    }
+  );
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user;
+}
+
+/**
+ * Gate común de las rutas de `/api/usuarios`: exige sesión y que el llamante
+ * tenga `cargo = "coordinador"` en la tabla `usuarios`. Devuelve el cliente
+ * admin para reutilizarlo, o una respuesta 401/403 lista para retornar.
+ */
+export async function requireCoordinador(
+  request: NextRequest
+): Promise<
+  | { ok: true; supabaseAdmin: ReturnType<typeof getAdminClient> }
+  | { ok: false; response: NextResponse }
+> {
+  const user = await getAuthenticatedUser(request);
+  if (!user) {
+    return { ok: false, response: NextResponse.json({ error: "No autenticado" }, { status: 401 }) };
+  }
+
+  const supabaseAdmin = getAdminClient();
+  const { data: caller } = await supabaseAdmin
+    .from("usuarios")
+    .select("cargo")
+    .eq("auth_uid", user.id)
+    .single();
+
+  if (!caller || caller.cargo !== "coordinador") {
+    return { ok: false, response: NextResponse.json({ error: "Sin permisos" }, { status: 403 }) };
+  }
+
+  return { ok: true, supabaseAdmin };
+}

--- a/src/app/api/usuarios/route.ts
+++ b/src/app/api/usuarios/route.ts
@@ -1,35 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
 import { createUsuarioSchema } from "@/lib/validation/schemas";
 import { rateLimit, getRateLimitKey } from "@/lib/rate-limit";
-import { clientEnv, getServerEnv } from "@/lib/env";
 import { logger } from "@/lib/logger";
-
-// M2: lazy init — el cliente admin solo se crea al recibir un request, no al cargar el módulo
-function getAdminClient() {
-  return createClient(clientEnv.NEXT_PUBLIC_SUPABASE_URL, getServerEnv().SUPABASE_SERVICE_ROLE_KEY);
-}
-
-async function getAuthenticatedUser(request: NextRequest) {
-  const cookieStore = await cookies();
-  const supabase = createServerClient(
-    clientEnv.NEXT_PUBLIC_SUPABASE_URL,
-    clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-      },
-    }
-  );
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  return user;
-}
+import { requireCoordinador } from "./helpers";
 
 export async function POST(request: NextRequest) {
   const key = await getRateLimitKey("create-user");
@@ -41,22 +14,9 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const user = await getAuthenticatedUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "No autenticado" }, { status: 401 });
-  }
-
-  const supabaseAdmin = getAdminClient();
-
-  const { data: caller } = await supabaseAdmin
-    .from("usuarios")
-    .select("cargo")
-    .eq("auth_uid", user.id)
-    .single();
-
-  if (!caller || caller.cargo !== "coordinador") {
-    return NextResponse.json({ error: "Sin permisos" }, { status: 403 });
-  }
+  const gate = await requireCoordinador(request);
+  if (!gate.ok) return gate.response;
+  const { supabaseAdmin } = gate;
 
   const body = await request.json();
   const parsed = createUsuarioSchema.safeParse(body);

--- a/src/app/dashboard/configuracion/page.tsx
+++ b/src/app/dashboard/configuracion/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "@/lib/db";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -94,6 +95,28 @@ export default function ConfiguracionPage() {
 //  Tab: Usuarios
 // ============================================================
 
+/**
+ * Edita un usuario server-side (#58). `usuarios` es MASTER_TABLE: un
+ * `db.usuarios.update` local no llega a Supabase. Aplica el cambio vía
+ * `PATCH /api/usuarios/[id]` y refleja la respuesta en Dexie.
+ */
+async function patchUsuario(
+  id: string,
+  cambios: Record<string, unknown>
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const res = await fetch(`/api/usuarios/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(cambios),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return { ok: false, error: data.error ?? "Error al actualizar el usuario" };
+  }
+  if (data.usuario) await db.usuarios.put(data.usuario);
+  return { ok: true };
+}
+
 function UsuariosTab() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -119,6 +142,7 @@ function UsuariosTab() {
             Nuevo Usuario
           </DialogTrigger>
           <UsuarioFormDialog
+            open={dialogOpen}
             onClose={() => {
               setDialogOpen(false);
               setEditingId(null);
@@ -175,9 +199,7 @@ function UsuariosTab() {
                     variant="ghost"
                     size="icon-sm"
                     onClick={async () => {
-                      await db.usuarios.update(u.id!, {
-                        activo: !u.activo,
-                      });
+                      await patchUsuario(u.id!, { activo: !u.activo });
                     }}
                     className={
                       u.activo
@@ -201,9 +223,15 @@ function UsuariosTab() {
 //  Dialog: Crear / Editar usuario
 // ============================================================
 
-function UsuarioFormDialog({ onClose, editId }: { onClose: () => void; editId: string | null }) {
-  const existingUser = useLiveQuery(() => (editId ? db.usuarios.get(editId) : undefined), [editId]);
-
+function UsuarioFormDialog({
+  open,
+  onClose,
+  editId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  editId: string | null;
+}) {
   const [nombre, setNombre] = useState("");
   const [cedula, setCedula] = useState("");
   const [email, setEmail] = useState("");
@@ -212,20 +240,30 @@ function UsuarioFormDialog({ onClose, editId }: { onClose: () => void; editId: s
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [initialized, setInitialized] = useState(false);
 
-  if (editId && existingUser && !initialized) {
-    setNombre(existingUser.nombre);
-    setCedula(existingUser.cedula);
-    setEmail(existingUser.email ?? "");
-    setTelefono(existingUser.telefono ?? "");
-    setCargo(existingUser.cargo as RolUsuario);
-    setInitialized(true);
-  }
-
-  if (!editId && !initialized) {
-    setInitialized(true);
-  }
+  // Repoblar el form SOLO en la transición cerrado→abierto (#11 / #58). El
+  // hack anterior (setState en render con un flag `initialized` de un disparo)
+  // se consumía en el primer montaje y dejaba el form en blanco al editar.
+  useReseedOnOpen(open, () => {
+    void (async () => {
+      setError("");
+      if (editId) {
+        const u = await db.usuarios.get(editId);
+        setNombre(u?.nombre ?? "");
+        setCedula(u?.cedula ?? "");
+        setEmail(u?.email ?? "");
+        setTelefono(u?.telefono ?? "");
+        setCargo((u?.cargo as RolUsuario) ?? "tecnico");
+      } else {
+        setNombre("");
+        setCedula("");
+        setEmail("");
+        setTelefono("");
+        setCargo("tecnico");
+        setPassword("");
+      }
+    })();
+  });
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -234,12 +272,16 @@ function UsuarioFormDialog({ onClose, editId }: { onClose: () => void; editId: s
 
     try {
       if (editId) {
-        await db.usuarios.update(editId, {
+        const r = await patchUsuario(editId, {
           nombre,
           cedula,
           cargo,
-          telefono: telefono || undefined,
+          telefono: telefono || "",
         });
+        if (!r.ok) {
+          setError(r.error);
+          return;
+        }
         onClose();
       } else {
         const res = await fetch("/api/usuarios", {

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -24,3 +24,32 @@ export const createUsuarioSchema = z.object({
 });
 
 export type CreateUsuarioInput = z.infer<typeof createUsuarioSchema>;
+
+/**
+ * Edición de un usuario existente (#58). Todos los campos opcionales — el
+ * cliente manda solo lo que cambió (incluido el toggle activo/inactivo).
+ * No incluye `email` ni `password`: cambiar credenciales es otro flujo.
+ */
+export const patchUsuarioSchema = z
+  .object({
+    nombre: z
+      .string()
+      .min(2, "El nombre debe tener al menos 2 caracteres")
+      .max(150)
+      .transform((v) => v.trim().replace(/\s+/g, " "))
+      .optional(),
+    cedula: z
+      .string()
+      .regex(/^\d{5,15}$/, "Cédula inválida: debe contener entre 5 y 15 dígitos")
+      .optional(),
+    cargo: z.enum(CARGOS_VALIDOS).optional(),
+    telefono: z
+      .string()
+      .regex(/^\+?\d{7,15}$/, "Teléfono inválido")
+      .optional()
+      .or(z.literal("")),
+    activo: z.boolean().optional(),
+  })
+  .refine((o) => Object.keys(o).length > 0, { message: "Nada que actualizar" });
+
+export type PatchUsuarioInput = z.infer<typeof patchUsuarioSchema>;


### PR DESCRIPTION
Paquete F1 — parte usuarios de #58. (La parte de solicitudes/visitas, #64, va en F2.)

## Bugs

**1. El form de editar usuario abría en blanco.** El flag `initialized` de un disparo se consumía en el primer montaje del diálogo (estado "Nuevo Usuario"); al reabrir en modo edición, `if (editId && existingUser && !initialized)` ya no se cumplía y los campos quedaban vacíos.

**2. Los cambios no persistían.** `usuarios` es MASTER_TABLE — el push del cliente no la toca. `db.usuarios.update(...)` local nunca llegaba a Supabase, así que la edición y el toggle activo/inactivo se perdían en el próximo `fullSync`.

## Cambios

| Archivo | Qué |
|---|---|
| `src/app/api/usuarios/[id]/route.ts` (nuevo) | `PATCH` con el mismo gate que el `POST`: rate limit por IP (10/min), sesión, `cargo = "coordinador"`. Valida con `patchUsuarioSchema`, aplica el `update` en `public.usuarios` con el service role y devuelve la fila. `PGRST116` → 404. |
| `src/app/api/usuarios/helpers.ts` (nuevo) | `requireCoordinador()` — extrae el gate de auth/rol compartido por `POST` y `PATCH` (antes duplicado inline en `route.ts`). |
| `src/lib/validation/schemas.ts` | `patchUsuarioSchema` — `nombre` / `cedula` / `cargo` / `telefono` / `activo` opcionales, sin `email` ni `password`, `refine` "algo que actualizar". |
| `src/app/dashboard/configuracion/page.tsx` | El diálogo usa `useReseedOnOpen(open, ...)` (lee la fila de Dexie en la transición cerrado→abierto) en vez del hack de `setState` en render. `handleSubmit` (edición) y el toggle activo/inactivo llaman `PATCH /api/usuarios/[id]` y hacen `db.usuarios.put(respuesta)`. |

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **613 tests** + build. Verde.

`src/app/api/usuarios/[id]/route.test.ts` (10 casos): 429 / 401 / 403 / 400 (body inválido sin filtrar el schema, patch vacío, cargo fuera del enum) / 404 (PGRST116) / 200 con la fila; toggle `activo` suelto; `telefono: ""` → `null`. El test existente del `POST` sigue verde tras extraer `requireCoordinador`.

## Sin migración

`public.usuarios` ya tiene todas las columnas que toca el PATCH.

Closes #58
