### PR TITLE
feat(visitas): Paquete F2a — reprogramar visita (#64)

### DIFF
--- a/src/app/dashboard/solicitudes/[id]/page.tsx
+++ b/src/app/dashboard/solicitudes/[id]/page.tsx
@@ -30,10 +30,12 @@ import {
   CheckCircle2,
   ExternalLink,
   Pencil,
+  CalendarClock,
 } from "lucide-react";
 import Link from "next/link";
 import { crearVisitaDesdeSolicitud } from "@/lib/workflow/visita-service";
 import { SolicitudFormDialog } from "@/components/solicitud-form-dialog";
+import { ReprogramarVisitaDialog } from "@/components/reprogramar-visita-dialog";
 
 // ============================================================
 //  Detalle de solicitud + botón "Programar Visita"
@@ -79,10 +81,13 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
   const { id } = use(params);
   const solicitudId = id;
   const { isReady } = useDb();
-  const { hasPermission } = useRole();
+  const { hasPermission, role } = useRole();
   const canEditSolicitud = hasPermission("solicitudes", "editar");
   const canCrearVisitas = hasPermission("visitas", "crear");
+  // #64: reprogramar es una acción de agenda — programador / coordinador.
+  const canReprogramar = role?.cargo === "programador" || role?.cargo === "coordinador";
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [reprogramarId, setReprogramarId] = useState<string | null>(null);
   const [creatingVisita, setCreatingVisita] = useState(false);
   const [tecnicoSel, setTecnicoSel] = useState("");
   const [fechaVisitaSel, setFechaVisitaSel] = useState("");
@@ -386,30 +391,43 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                   eq.tipo_equipo ||
                   `Equipo #${eq.id}`
                 : null;
+              const puedeReprogramar = canReprogramar && visita.estado_visita === "asignada";
               return (
-                <a key={visita.id} href={`/dashboard/visitas/${visita.id}`}>
-                  <Card className="border-none shadow-sm hover:shadow-lg transition-all rounded-2xl bg-white group cursor-pointer overflow-hidden mb-2">
-                    <CardContent className="p-4 sm:p-5">
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="flex items-center gap-3 min-w-0">
-                          <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
-                            <ClipboardCheck className="w-4 h-4 text-primary" />
+                <div key={visita.id} className="mb-2">
+                  <a href={`/dashboard/visitas/${visita.id}`}>
+                    <Card className="border-none shadow-sm hover:shadow-lg transition-all rounded-2xl bg-white group cursor-pointer overflow-hidden">
+                      <CardContent className="p-4 sm:p-5">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="flex items-center gap-3 min-w-0">
+                            <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
+                              <ClipboardCheck className="w-4 h-4 text-primary" />
+                            </div>
+                            <div className="min-w-0">
+                              <p className="text-sm font-black text-slate-900 truncate">
+                                Visita #{visita.id}
+                                {eqNombre ? ` — ${eqNombre}` : ""}
+                              </p>
+                              <p className="text-[11px] text-slate-400 font-medium">
+                                Estado: {visita.estado_visita.replace("_", " ")}
+                                {visita.fecha_visita ? ` · ${visita.fecha_visita}` : ""}
+                              </p>
+                            </div>
                           </div>
-                          <div className="min-w-0">
-                            <p className="text-sm font-black text-slate-900 truncate">
-                              Visita #{visita.id}
-                              {eqNombre ? ` — ${eqNombre}` : ""}
-                            </p>
-                            <p className="text-[11px] text-slate-400 font-medium">
-                              Estado: {visita.estado_visita.replace("_", " ")}
-                            </p>
-                          </div>
+                          <ExternalLink className="w-4 h-4 text-slate-300 group-hover:text-primary transition-colors flex-shrink-0" />
                         </div>
-                        <ExternalLink className="w-4 h-4 text-slate-300 group-hover:text-primary transition-colors flex-shrink-0" />
-                      </div>
-                    </CardContent>
-                  </Card>
-                </a>
+                      </CardContent>
+                    </Card>
+                  </a>
+                  {puedeReprogramar && (
+                    <button
+                      type="button"
+                      onClick={() => setReprogramarId(visita.id!)}
+                      className="mt-1 ml-1 inline-flex items-center gap-1.5 text-[11px] font-bold text-slate-500 hover:text-primary transition-colors"
+                    >
+                      <CalendarClock className="w-3.5 h-3.5" /> Reprogramar
+                    </button>
+                  )}
+                </div>
               );
             })}
           </div>
@@ -576,6 +594,26 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
         onOpenChange={setEditDialogOpen}
         editSolicitud={solicitud}
       />
+
+      {/* Dialog reprogramar visita (#64) */}
+      {reprogramarId &&
+        role &&
+        (() => {
+          const v = visitas.find((x) => x.id === reprogramarId);
+          if (!v) return null;
+          return (
+            <ReprogramarVisitaDialog
+              open
+              onOpenChange={(o) => !o && setReprogramarId(null)}
+              visitaId={reprogramarId}
+              tecnicos={tecnicos}
+              usuarioId={role.usuarioId}
+              fechaActual={v.fecha_visita}
+              tecnicoActualId={v.tecnico_id}
+              onReprogramada={() => setReprogramarId(null)}
+            />
+          );
+        })()}
     </div>
   );
 }

--- a/src/components/reprogramar-visita-dialog.tsx
+++ b/src/components/reprogramar-visita-dialog.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
+import { reprogramarVisita } from "@/lib/workflow/reprogramar-visita";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+import { Loader2, CalendarClock } from "lucide-react";
+
+// ============================================================
+//  Dialog para reprogramar una visita `asignada` (#64)
+//  Fecha + técnico + motivo obligatorio. La lógica (traza, sync de la
+//  solicitud padre, gate de estado) vive en reprogramarVisita().
+// ============================================================
+
+interface TecnicoLite {
+  id?: string;
+  nombre: string;
+}
+
+interface ReprogramarVisitaDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  visitaId: string;
+  tecnicos: TecnicoLite[];
+  usuarioId: string;
+  /** Valores actuales de la visita, para precargar el form. */
+  fechaActual?: string;
+  tecnicoActualId?: string;
+  onReprogramada?: () => void;
+}
+
+const labelClass = "text-xs font-black text-slate-600 uppercase tracking-wider";
+
+export function ReprogramarVisitaDialog({
+  open,
+  onOpenChange,
+  visitaId,
+  tecnicos,
+  usuarioId,
+  fechaActual,
+  tecnicoActualId,
+  onReprogramada,
+}: ReprogramarVisitaDialogProps) {
+  const [fecha, setFecha] = useState("");
+  const [tecnicoId, setTecnicoId] = useState("");
+  const [motivo, setMotivo] = useState("");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useReseedOnOpen(open, () => {
+    setFecha(fechaActual ?? "");
+    setTecnicoId(tecnicoActualId ?? "");
+    setMotivo("");
+    setError("");
+  });
+
+  const tecnicoSel = tecnicos.find((t) => t.id === tecnicoId) ?? null;
+
+  async function handleConfirm() {
+    setError("");
+    setSaving(true);
+    try {
+      const r = await reprogramarVisita(visitaId, {
+        fechaVisita: fecha,
+        tecnicoId,
+        motivo,
+        usuarioId,
+      });
+      if (!r.success) {
+        setError(r.error ?? "No se pudo reprogramar la visita");
+        return;
+      }
+      onOpenChange(false);
+      onReprogramada?.();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="font-black flex items-center gap-2">
+            <CalendarClock className="w-4 h-4 text-primary" /> Reprogramar visita
+          </DialogTitle>
+          <DialogDescription>
+            Cambia la fecha y el técnico. Queda registrado quién reprogramó y por qué. Solo
+            disponible mientras la visita no se haya iniciado.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label className={labelClass}>Nueva fecha</Label>
+            <Input
+              type="date"
+              value={fecha}
+              onChange={(e) => setFecha(e.target.value)}
+              className="rounded-xl"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className={labelClass}>Técnico asignado</Label>
+            <Combobox
+              items={tecnicos}
+              itemToStringLabel={(t: TecnicoLite) => t.nombre}
+              value={tecnicoSel}
+              onValueChange={(t: TecnicoLite | null) => setTecnicoId(t?.id ?? "")}
+            >
+              <ComboboxTrigger className="w-full rounded-xl border-slate-200 h-11 data-[placeholder]:text-slate-400">
+                <ComboboxValue placeholder="Seleccionar técnico..." />
+              </ComboboxTrigger>
+              <ComboboxContent>
+                <ComboboxInput placeholder="Buscar técnico..." />
+                <ComboboxEmpty>Sin resultados.</ComboboxEmpty>
+                <ComboboxList>
+                  {(t: TecnicoLite) => (
+                    <ComboboxItem key={t.id} value={t}>
+                      {t.nombre}
+                    </ComboboxItem>
+                  )}
+                </ComboboxList>
+              </ComboboxContent>
+            </Combobox>
+          </div>
+
+          <div className="space-y-2">
+            <Label className={labelClass}>Motivo</Label>
+            <Textarea
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              placeholder="Por qué se reprograma (obligatorio)"
+              className="rounded-xl"
+              rows={3}
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs font-bold text-red-600 bg-red-50 border border-red-200 rounded-xl p-3">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            className="rounded-xl font-bold"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancelar
+          </Button>
+          <Button
+            className="rounded-xl font-black bg-primary hover:bg-primary/90 text-white"
+            onClick={handleConfirm}
+            disabled={saving || !fecha || !tecnicoId || !motivo.trim()}
+          >
+            {saving ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
+            Reprogramar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -585,6 +585,10 @@ export interface VisitaEjecucion extends SyncFields {
   /** Timestamp de la última devolución */
   devuelto_en?: string;
   fecha_visita?: string;
+  /** Reprogramación (#64): última vez que se cambió fecha/técnico de una visita `asignada`. */
+  reprogramada_en?: string;
+  reprogramada_por_id?: string;
+  reprogramacion_motivo?: string;
   creado_en?: string;
 }
 

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -2597,6 +2597,9 @@ export type Database = {
           porcentaje_rechazo: number | null;
           presion_hpa: number | null;
           radiografias_por_semana: number | null;
+          reprogramacion_motivo: string | null;
+          reprogramada_en: string | null;
+          reprogramada_por_id: string | null;
           solicitud_id: string;
           sync_status: string;
           tecnico_id: string | null;
@@ -2622,6 +2625,9 @@ export type Database = {
           porcentaje_rechazo?: number | null;
           presion_hpa?: number | null;
           radiografias_por_semana?: number | null;
+          reprogramacion_motivo?: string | null;
+          reprogramada_en?: string | null;
+          reprogramada_por_id?: string | null;
           solicitud_id: string;
           sync_status?: string;
           tecnico_id?: string | null;
@@ -2647,6 +2653,9 @@ export type Database = {
           porcentaje_rechazo?: number | null;
           presion_hpa?: number | null;
           radiografias_por_semana?: number | null;
+          reprogramacion_motivo?: string | null;
+          reprogramada_en?: string | null;
+          reprogramada_por_id?: string | null;
           solicitud_id?: string;
           sync_status?: string;
           tecnico_id?: string | null;

--- a/src/lib/workflow/reprogramar-visita.test.ts
+++ b/src/lib/workflow/reprogramar-visita.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+
+const pushSingle = vi.fn().mockResolvedValue(true);
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  pushSingle: (...a: unknown[]) => pushSingle(...a),
+}));
+
+import { reprogramarVisita } from "./reprogramar-visita";
+
+beforeEach(async () => {
+  await resetTestDb();
+  pushSingle.mockClear();
+});
+
+describe("reprogramarVisita (#64)", () => {
+  it("cambia fecha + técnico, deja traza y propaga a la solicitud", async () => {
+    const { visita, solicitud } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+
+    const r = await reprogramarVisita(visita!.id!, {
+      fechaVisita: "2026-09-15",
+      tecnicoId: "tec-nuevo",
+      motivo: "  El cliente pidió otra fecha  ",
+      usuarioId: "prog-1",
+    });
+    expect(r.success).toBe(true);
+
+    const v = await db.visitas.get(visita!.id!);
+    expect(v?.fecha_visita).toBe("2026-09-15");
+    expect(v?.tecnico_id).toBe("tec-nuevo");
+    expect(v?.reprogramacion_motivo).toBe("El cliente pidió otra fecha");
+    expect(v?.reprogramada_por_id).toBe("prog-1");
+    expect(v?.reprogramada_en).toBeTruthy();
+    expect(v?.sync_status).toBe("pending");
+    expect(v?.estado_visita).toBe("asignada"); // no cambia el estado
+
+    const s = await db.solicitudes.get(solicitud!.id!);
+    expect(s?.fecha_estimada_visita).toBe("2026-09-15");
+    expect(s?.tecnico_asignado_id).toBe("tec-nuevo");
+
+    expect(pushSingle).toHaveBeenCalledWith("visitas", visita!.id!);
+    expect(pushSingle).toHaveBeenCalledWith("solicitudes", solicitud!.id!);
+  });
+
+  it("exige motivo", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const r = await reprogramarVisita(visita!.id!, {
+      fechaVisita: "2026-09-15",
+      tecnicoId: "tec-1",
+      motivo: "   ",
+      usuarioId: "prog-1",
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/motivo/i);
+    // no tocó nada
+    expect(pushSingle).not.toHaveBeenCalled();
+  });
+
+  it("rechaza una visita que ya no está 'asignada'", async () => {
+    const { visita } = await seedGraph({
+      tipoEquipo: "CONVENCIONAL",
+      estadoVisita: "en_progreso",
+    });
+    const r = await reprogramarVisita(visita!.id!, {
+      fechaVisita: "2026-09-15",
+      tecnicoId: "tec-1",
+      motivo: "tarde",
+      usuarioId: "prog-1",
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/asignada/i);
+  });
+
+  it("visita inexistente → error", async () => {
+    const r = await reprogramarVisita("no-existe", {
+      fechaVisita: "2026-09-15",
+      tecnicoId: "tec-1",
+      motivo: "x",
+      usuarioId: "prog-1",
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/no encontrada/i);
+  });
+});

--- a/src/lib/workflow/reprogramar-visita.ts
+++ b/src/lib/workflow/reprogramar-visita.ts
@@ -1,0 +1,72 @@
+import { db } from "@/lib/db";
+import type { Solicitud, VisitaEjecucion } from "@/lib/db/types";
+
+// ============================================================
+//  Reprogramar visita (#64)
+//
+//  Cambia fecha y técnico de una visita que todavía está `asignada`.
+//  Motivo obligatorio + traza (quién / cuándo). Propaga fecha/técnico a la
+//  solicitud padre. No cambia `estado_visita`.
+// ============================================================
+
+export interface ReprogramarVisitaInput {
+  /** Fecha de la visita — `yyyy-mm-dd` o ISO. */
+  fechaVisita: string;
+  tecnicoId: string;
+  motivo: string;
+  /** Usuario que reprograma (para la traza). */
+  usuarioId: string;
+}
+
+export interface ReprogramarVisitaResult {
+  success: boolean;
+  error?: string;
+}
+
+export async function reprogramarVisita(
+  visitaId: string,
+  input: ReprogramarVisitaInput
+): Promise<ReprogramarVisitaResult> {
+  const motivo = input.motivo?.trim() ?? "";
+  if (!motivo) return { success: false, error: "El motivo de la reprogramación es obligatorio" };
+  if (!input.fechaVisita) return { success: false, error: "La fecha de la visita es obligatoria" };
+  if (!input.tecnicoId) return { success: false, error: "Hay que asignar un técnico" };
+
+  const visita = await db.visitas.get(visitaId);
+  if (!visita) return { success: false, error: "Visita no encontrada" };
+  if (visita.estado_visita !== "asignada") {
+    return {
+      success: false,
+      error: `Solo se puede reprogramar una visita en estado "asignada" (esta está en "${visita.estado_visita}")`,
+    };
+  }
+
+  const now = new Date().toISOString();
+
+  await db.transaction("rw", [db.visitas, db.solicitudes], async () => {
+    await db.visitas.update(visitaId, {
+      fecha_visita: input.fechaVisita,
+      tecnico_id: input.tecnicoId,
+      reprogramada_en: now,
+      reprogramada_por_id: input.usuarioId,
+      reprogramacion_motivo: motivo,
+      sync_status: "pending",
+      last_modified: now,
+    } satisfies Partial<VisitaEjecucion>);
+
+    if (visita.solicitud_id) {
+      await db.solicitudes.update(visita.solicitud_id, {
+        fecha_estimada_visita: input.fechaVisita,
+        tecnico_asignado_id: input.tecnicoId,
+        sync_status: "pending",
+        last_modified: now,
+      } satisfies Partial<Solicitud>);
+    }
+  });
+
+  const { pushSingle } = await import("@/lib/supabase/sync-engine");
+  pushSingle("visitas", visitaId);
+  if (visita.solicitud_id) pushSingle("solicitudes", visita.solicitud_id);
+
+  return { success: true };
+}

--- a/supabase/migrations/026_visita_reprogramacion.sql
+++ b/supabase/migrations/026_visita_reprogramacion.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+--  026 — Reprogramación de visitas (#64)
+--
+--  Un programador / coordinador puede cambiar la fecha y el técnico de una
+--  visita que todavía está en estado `asignada` (no iniciada). Se guarda
+--  traza: cuándo, quién y por qué. La fecha/técnico se propagan a la
+--  solicitud padre (`fecha_estimada_visita` / `tecnico_asignado_id`).
+--
+--  Aditiva e idempotente.
+-- ============================================================
+
+ALTER TABLE public.visitas
+  ADD COLUMN IF NOT EXISTS reprogramada_en timestamptz,
+  ADD COLUMN IF NOT EXISTS reprogramada_por_id uuid,
+  ADD COLUMN IF NOT EXISTS reprogramacion_motivo text;


### PR DESCRIPTION
Parte 1 de #64 (**F2a — reprogramar visita**). La parte de cancelar solicitud (estado `"cancelada"`, cascada sobre visitas, tab "Canceladas") va en **F2b**, aparte.

## Qué

Un **programador / coordinador** puede cambiar la **fecha** y el **técnico** de una visita que todavía está `asignada` (no iniciada), con **motivo obligatorio** y traza de quién/cuándo. No cambia `estado_visita`.

## Cómo

| Archivo | Qué |
|---|---|
| `src/lib/workflow/reprogramar-visita.ts` (nuevo) | `reprogramarVisita(visitaId, { fechaVisita, tecnicoId, motivo, usuarioId })` — valida `estado === "asignada"` + motivo no vacío, actualiza la visita (fecha/técnico + `reprogramada_en` / `reprogramada_por_id` / `reprogramacion_motivo`) y propaga `fecha_estimada_visita` / `tecnico_asignado_id` a la solicitud padre, todo en una transacción. Push inmediato de visita + solicitud. |
| `src/components/reprogramar-visita-dialog.tsx` (nuevo) | Fecha + `Combobox` de técnico + motivo. `useReseedOnOpen` precarga los valores actuales. Confirmar deshabilitado sin fecha/técnico/motivo. |
| `src/app/dashboard/solicitudes/[id]/page.tsx` | Botón "Reprogramar" por visita en la lista "Visitas Creadas", visible solo para visitas `asignada` y para cargo programador/coordinador. La tarjeta muestra la fecha junto al estado. |
| `src/lib/db/types.ts` + `src/lib/supabase/types.ts` | 3 campos de traza en `visitas` (Row/Insert/Update). |
| `supabase/migrations/026_visita_reprogramacion.sql` (nuevo) | `ADD COLUMN IF NOT EXISTS` × 3 sobre `public.visitas`. Aditiva, idempotente. |

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **617 tests** + build. Verde.

`reprogramar-visita.test.ts` (4 casos): happy path (fecha/técnico/traza + solicitud + push, `estado_visita` intacto), motivo vacío → error sin tocar nada, visita no `asignada` → error, visita inexistente → error. El guard `#39` de columnas sigue verde con los 3 campos nuevos.

## Migración que corre el dueño

`026_visita_reprogramacion.sql`.

Contributes to #64.
