### PR TITLE
feat(solicitudes): Paquete F2b — cancelar solicitud (#64)

### DIFF
--- a/src/app/dashboard/solicitudes/[id]/page.tsx
+++ b/src/app/dashboard/solicitudes/[id]/page.tsx
@@ -31,11 +31,13 @@ import {
   ExternalLink,
   Pencil,
   CalendarClock,
+  Ban,
 } from "lucide-react";
 import Link from "next/link";
 import { crearVisitaDesdeSolicitud } from "@/lib/workflow/visita-service";
 import { SolicitudFormDialog } from "@/components/solicitud-form-dialog";
 import { ReprogramarVisitaDialog } from "@/components/reprogramar-visita-dialog";
+import { CancelarSolicitudDialog } from "@/components/cancelar-solicitud-dialog";
 
 // ============================================================
 //  Detalle de solicitud + botón "Programar Visita"
@@ -47,6 +49,7 @@ const ESTADO_LABEL: Record<string, string> = {
   ejecucion: "Ejecución",
   notificado: "Notificado",
   enviado: "Enviado",
+  cancelada: "Cancelada",
 };
 
 const ESTADO_BADGE: Record<string, { bg: string; text: string; border: string }> = {
@@ -75,6 +78,11 @@ const ESTADO_BADGE: Record<string, { bg: string; text: string; border: string }>
     text: "text-emerald-600",
     border: "border-emerald-200",
   },
+  cancelada: {
+    bg: "bg-red-100",
+    text: "text-red-600",
+    border: "border-red-200",
+  },
 };
 
 export default function SolicitudDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -88,6 +96,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
   const canReprogramar = role?.cargo === "programador" || role?.cargo === "coordinador";
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [reprogramarId, setReprogramarId] = useState<string | null>(null);
+  const [cancelarOpen, setCancelarOpen] = useState(false);
   const [creatingVisita, setCreatingVisita] = useState(false);
   const [tecnicoSel, setTecnicoSel] = useState("");
   const [fechaVisitaSel, setFechaVisitaSel] = useState("");
@@ -120,8 +129,11 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
       ? await db.equipos.where("ubicacion_id").equals(solicitud.ubicacion_id).toArray()
       : [];
 
-    // Visitas ya creadas para esta solicitud
-    const visitas = await db.visitas.where("solicitud_id").equals(solicitudId).toArray();
+    // Visitas ya creadas para esta solicitud (las canceladas en cascada quedan
+    // con `deleted_at` — no se muestran).
+    const visitas = (await db.visitas.where("solicitud_id").equals(solicitudId).toArray()).filter(
+      (v) => !v.deleted_at
+    );
 
     return { solicitud, cliente, ubicacion, tecnico, contacto, equipos, visitas };
   }, [isReady, solicitudId]);
@@ -277,7 +289,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
               >
                 {ESTADO_LABEL[estado] ?? estado.replace("_", " ")}
               </span>
-              {canEditSolicitud && (
+              {canEditSolicitud && estado !== "cancelada" && (
                 <Button
                   variant="outline"
                   className="rounded-xl font-black border-slate-200 hover:bg-primary/5 h-9 px-3 text-xs"
@@ -287,8 +299,28 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                   Editar
                 </Button>
               )}
+              {canReprogramar && estado !== "cancelada" && (
+                <Button
+                  variant="outline"
+                  className="rounded-xl font-black border-red-200 text-red-600 hover:bg-red-50 h-9 px-3 text-xs"
+                  onClick={() => setCancelarOpen(true)}
+                >
+                  <Ban className="w-3.5 h-3.5 mr-1.5" />
+                  Cancelar
+                </Button>
+              )}
             </div>
           </div>
+
+          {estado === "cancelada" && (
+            <div className="flex gap-2 p-3 bg-red-50 rounded-xl border border-red-200 text-xs text-red-700 font-medium">
+              <Ban className="w-4 h-4 text-red-500 flex-shrink-0 mt-0.5" />
+              <span>
+                Solicitud cancelada
+                {solicitud.cancelada_motivo ? ` — ${solicitud.cancelada_motivo}` : ""}
+              </span>
+            </div>
+          )}
 
           {/* Metadata grid */}
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
@@ -594,6 +626,18 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
         onOpenChange={setEditDialogOpen}
         editSolicitud={solicitud}
       />
+
+      {/* Dialog cancelar solicitud (#64) */}
+      {role && (
+        <CancelarSolicitudDialog
+          open={cancelarOpen}
+          onOpenChange={setCancelarOpen}
+          solicitudId={solicitudId}
+          usuarioId={role.usuarioId}
+          visitasAsignadas={visitas.filter((v) => v.estado_visita === "asignada").length}
+          onCancelada={() => setCancelarOpen(false)}
+        />
+      )}
 
       {/* Dialog reprogramar visita (#64) */}
       {reprogramarId &&

--- a/src/app/dashboard/solicitudes/page.tsx
+++ b/src/app/dashboard/solicitudes/page.tsx
@@ -40,7 +40,8 @@ type PipelineTab =
   | "programacion"
   | "ejecucion"
   | "notificado"
-  | "enviado";
+  | "enviado"
+  | "cancelada";
 
 const PIPELINE_TABS: { id: PipelineTab; label: string; short: string }[] = [
   { id: "todas", label: "Todas", short: "Todas" },
@@ -49,6 +50,7 @@ const PIPELINE_TABS: { id: PipelineTab; label: string; short: string }[] = [
   { id: "ejecucion", label: "Ejecución", short: "Ejec." },
   { id: "notificado", label: "Notificado", short: "Notif." },
   { id: "enviado", label: "Enviado", short: "Env." },
+  { id: "cancelada", label: "Canceladas", short: "Cancel." },
 ];
 
 const ESTADO_LABEL: Record<string, string> = {
@@ -57,6 +59,7 @@ const ESTADO_LABEL: Record<string, string> = {
   ejecucion: "Ejecución",
   notificado: "Notificado",
   enviado: "Enviado",
+  cancelada: "Cancelada",
 };
 
 const ESTADO_BADGE: Record<string, { bg: string; text: string; border: string }> = {
@@ -84,6 +87,11 @@ const ESTADO_BADGE: Record<string, { bg: string; text: string; border: string }>
     bg: "bg-emerald-100",
     text: "text-emerald-600",
     border: "border-emerald-200",
+  },
+  cancelada: {
+    bg: "bg-red-100",
+    text: "text-red-600",
+    border: "border-red-200",
   },
 };
 
@@ -129,17 +137,20 @@ export default function SolicitudesPage() {
     );
   }
 
-  // Filter + counts
+  // Filter + counts. "Todas" excluye las canceladas — viven en su propia pestaña.
   const filtered =
-    activeTab === "todas" ? data : data.filter((d) => d.solicitud.pipeline_estado === activeTab);
+    activeTab === "todas"
+      ? data.filter((d) => d.solicitud.pipeline_estado !== "cancelada")
+      : data.filter((d) => d.solicitud.pipeline_estado === activeTab);
 
   const counts: Record<PipelineTab, number> = {
-    todas: data.length,
+    todas: data.filter((d) => d.solicitud.pipeline_estado !== "cancelada").length,
     solicitudes: data.filter((d) => d.solicitud.pipeline_estado === "solicitudes").length,
     programacion: data.filter((d) => d.solicitud.pipeline_estado === "programacion").length,
     ejecucion: data.filter((d) => d.solicitud.pipeline_estado === "ejecucion").length,
     notificado: data.filter((d) => d.solicitud.pipeline_estado === "notificado").length,
     enviado: data.filter((d) => d.solicitud.pipeline_estado === "enviado").length,
+    cancelada: data.filter((d) => d.solicitud.pipeline_estado === "cancelada").length,
   };
 
   return (

--- a/src/components/cancelar-solicitud-dialog.tsx
+++ b/src/components/cancelar-solicitud-dialog.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
+import { cancelarSolicitud } from "@/lib/workflow/cancelar-solicitud";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2, Ban, AlertTriangle } from "lucide-react";
+
+// ============================================================
+//  Dialog para cancelar una solicitud (#64)
+//  Motivo obligatorio. La regla sobre las visitas hijas (bloquear si hay
+//  alguna iniciada, cascada soft-delete si solo hay `asignada`) vive en
+//  cancelarSolicitud().
+// ============================================================
+
+interface CancelarSolicitudDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  solicitudId: string;
+  usuarioId: string;
+  /** Cantidad de visitas `asignada` que se cancelarían en cascada — para avisar. */
+  visitasAsignadas?: number;
+  onCancelada?: () => void;
+}
+
+const labelClass = "text-xs font-black text-slate-600 uppercase tracking-wider";
+
+export function CancelarSolicitudDialog({
+  open,
+  onOpenChange,
+  solicitudId,
+  usuarioId,
+  visitasAsignadas = 0,
+  onCancelada,
+}: CancelarSolicitudDialogProps) {
+  const [motivo, setMotivo] = useState("");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useReseedOnOpen(open, () => {
+    setMotivo("");
+    setError("");
+  });
+
+  async function handleConfirm() {
+    setError("");
+    setSaving(true);
+    try {
+      const r = await cancelarSolicitud(solicitudId, { motivo, usuarioId });
+      if (!r.success) {
+        setError(r.error ?? "No se pudo cancelar la solicitud");
+        return;
+      }
+      onOpenChange(false);
+      onCancelada?.();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="font-black flex items-center gap-2">
+            <Ban className="w-4 h-4 text-red-500" /> Cancelar solicitud
+          </DialogTitle>
+          <DialogDescription>
+            La solicitud pasa a estado <b>Cancelada</b> y sale del pipeline activo. Queda registrado
+            quién la canceló y por qué. No se puede si alguna visita ya se inició.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {visitasAsignadas > 0 && (
+            <div className="flex gap-2 p-3 bg-amber-50 rounded-xl border border-amber-200 text-xs text-amber-800 font-medium">
+              <AlertTriangle className="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" />
+              <span>
+                Se cancelarán también {visitasAsignadas} visita{visitasAsignadas > 1 ? "s" : ""}{" "}
+                asignada{visitasAsignadas > 1 ? "s" : ""} (todavía sin iniciar).
+              </span>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label className={labelClass}>Motivo</Label>
+            <Textarea
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              placeholder="Por qué se cancela (obligatorio)"
+              className="rounded-xl"
+              rows={3}
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs font-bold text-red-600 bg-red-50 border border-red-200 rounded-xl p-3">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            className="rounded-xl font-bold"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Volver
+          </Button>
+          <Button
+            className="rounded-xl font-black bg-red-500 hover:bg-red-600 text-white"
+            onClick={handleConfirm}
+            disabled={saving || !motivo.trim()}
+          >
+            {saving ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
+            Cancelar solicitud
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -545,13 +545,23 @@ export interface Solicitud extends Partial<SyncFields> {
   tecnico_asignado_id?: string;
   suitecrm_id?: string;
   tipo_servicio?: string;
-  pipeline_estado?: "solicitudes" | "programacion" | "ejecucion" | "notificado" | "enviado";
+  pipeline_estado?:
+    | "solicitudes"
+    | "programacion"
+    | "ejecucion"
+    | "notificado"
+    | "enviado"
+    | "cancelada";
   forma_pago?: string;
   pago_recibido: boolean;
   fecha_solicitud?: string;
   fecha_estimada_visita?: string;
   fecha_real_visita?: string;
   fecha_entrega?: string;
+  /** Cancelación (#64): motivo, quién y cuándo. Solo si `pipeline_estado === "cancelada"`. */
+  cancelada_motivo?: string;
+  cancelada_por_id?: string;
+  cancelada_en?: string;
   creado_en?: string;
 }
 

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1105,6 +1105,9 @@ export type Database = {
           valor_total: number | null;
         };
         Insert: {
+          cancelada_en?: string | null;
+          cancelada_motivo?: string | null;
+          cancelada_por_id?: string | null;
           cliente_id: string;
           creado_en?: string;
           estado?: string | null;
@@ -1117,6 +1120,9 @@ export type Database = {
           valor_total?: number | null;
         };
         Update: {
+          cancelada_en?: string | null;
+          cancelada_motivo?: string | null;
+          cancelada_por_id?: string | null;
           cliente_id?: string;
           creado_en?: string;
           estado?: string | null;
@@ -2186,6 +2192,9 @@ export type Database = {
       };
       solicitudes: {
         Row: {
+          cancelada_en: string | null;
+          cancelada_motivo: string | null;
+          cancelada_por_id: string | null;
           cliente_id: string;
           contacto_programar_id: string | null;
           cotizacion_id: string | null;

--- a/src/lib/workflow/cancelar-solicitud.test.ts
+++ b/src/lib/workflow/cancelar-solicitud.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+import { randomUUID } from "@/lib/uuid";
+
+const pushSingle = vi.fn().mockResolvedValue(true);
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  pushSingle: (...a: unknown[]) => pushSingle(...a),
+}));
+
+import { cancelarSolicitud } from "./cancelar-solicitud";
+import { crearVisitaDesdeSolicitud } from "./visita-service";
+
+beforeEach(async () => {
+  await resetTestDb();
+  pushSingle.mockClear();
+});
+
+describe("cancelarSolicitud (#64)", () => {
+  it("pasa la solicitud a 'cancelada' con traza y soft-deletea las visitas asignadas", async () => {
+    const { solicitud, visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+
+    const r = await cancelarSolicitud(solicitud!.id!, {
+      motivo: "  El cliente ya no lo necesita  ",
+      usuarioId: "coord-1",
+    });
+    expect(r.success).toBe(true);
+    expect(r.visitasCanceladas).toBe(1);
+
+    const s = await db.solicitudes.get(solicitud!.id!);
+    expect(s?.pipeline_estado).toBe("cancelada");
+    expect(s?.cancelada_motivo).toBe("El cliente ya no lo necesita");
+    expect(s?.cancelada_por_id).toBe("coord-1");
+    expect(s?.cancelada_en).toBeTruthy();
+
+    const v = await db.visitas.get(visita!.id!);
+    expect(v?.deleted_at).toBeTruthy();
+    expect(v?.sync_status).toBe("pending");
+
+    expect(pushSingle).toHaveBeenCalledWith("solicitudes", solicitud!.id!);
+    expect(pushSingle).toHaveBeenCalledWith("visitas", visita!.id!);
+  });
+
+  it("cancela sin visitas y no reporta cascada", async () => {
+    const { solicitud } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conVisita: false });
+    const r = await cancelarSolicitud(solicitud!.id!, { motivo: "duplicada", usuarioId: "u" });
+    expect(r.success).toBe(true);
+    expect(r.visitasCanceladas).toBe(0);
+  });
+
+  it("bloquea si hay una visita ya iniciada — no toca nada", async () => {
+    const { solicitud, visita } = await seedGraph({
+      tipoEquipo: "CONVENCIONAL",
+      estadoVisita: "en_progreso",
+    });
+    const r = await cancelarSolicitud(solicitud!.id!, { motivo: "tarde", usuarioId: "u" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/iniciada/i);
+
+    const s = await db.solicitudes.get(solicitud!.id!);
+    expect(s?.pipeline_estado).not.toBe("cancelada");
+    const v = await db.visitas.get(visita!.id!);
+    expect(v?.deleted_at).toBeFalsy();
+  });
+
+  it("exige motivo", async () => {
+    const { solicitud } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conVisita: false });
+    const r = await cancelarSolicitud(solicitud!.id!, { motivo: "  ", usuarioId: "u" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/motivo/i);
+  });
+
+  it("no se puede cancelar dos veces", async () => {
+    const { solicitud } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conVisita: false });
+    await cancelarSolicitud(solicitud!.id!, { motivo: "x", usuarioId: "u" });
+    const r = await cancelarSolicitud(solicitud!.id!, { motivo: "y", usuarioId: "u" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/ya está cancelada/i);
+  });
+
+  it("solicitud inexistente → error", async () => {
+    const r = await cancelarSolicitud("no-existe", { motivo: "x", usuarioId: "u" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/no encontrada/i);
+  });
+
+  it("crearVisitaDesdeSolicitud rechaza una solicitud cancelada", async () => {
+    const { solicitud, equipo } = await seedGraph({ tipoEquipo: "CONVENCIONAL", conVisita: false });
+    await cancelarSolicitud(solicitud!.id!, { motivo: "x", usuarioId: "u" });
+
+    const r = await crearVisitaDesdeSolicitud(solicitud!.id!, equipo.id!);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/cancelada/i);
+  });
+
+  it("no cancela visitas de OTRA solicitud", async () => {
+    const g1 = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const otraVisitaId = randomUUID();
+    await db.visitas.add({
+      id: otraVisitaId,
+      solicitud_id: "otra-solicitud",
+      estado_visita: "asignada",
+      sync_status: "pending",
+      last_modified: new Date().toISOString(),
+    });
+    await cancelarSolicitud(g1.solicitud!.id!, { motivo: "x", usuarioId: "u" });
+    const otra = await db.visitas.get(otraVisitaId);
+    expect(otra?.deleted_at).toBeFalsy();
+  });
+});

--- a/src/lib/workflow/cancelar-solicitud.ts
+++ b/src/lib/workflow/cancelar-solicitud.ts
@@ -1,0 +1,86 @@
+import { db } from "@/lib/db";
+import type { EstadoVisita, Solicitud, VisitaEjecucion } from "@/lib/db/types";
+
+// ============================================================
+//  Cancelar solicitud (#64)
+//
+//  Pasa la solicitud a `pipeline_estado: "cancelada"` con traza. Regla sobre
+//  las visitas hijas:
+//   - si alguna ya arrancó (>= en_progreso) → NO se cancela; hay que
+//     resolver esas visitas primero.
+//   - si solo hay visitas `asignada` → se soft-deletean en cascada.
+// ============================================================
+
+/** Estados de visita que ya no son "solo agendadas" — bloquean la cancelación. */
+const ESTADOS_VISITA_EN_MARCHA: EstadoVisita[] = [
+  "en_progreso",
+  "en_revision",
+  "aprobada",
+  "enviada",
+];
+
+export interface CancelarSolicitudInput {
+  motivo: string;
+  /** Usuario que cancela (para la traza). */
+  usuarioId: string;
+}
+
+export interface CancelarSolicitudResult {
+  success: boolean;
+  error?: string;
+  /** Visitas `asignada` que se soft-deletearon en cascada. */
+  visitasCanceladas?: number;
+}
+
+export async function cancelarSolicitud(
+  solicitudId: string,
+  input: CancelarSolicitudInput
+): Promise<CancelarSolicitudResult> {
+  const motivo = input.motivo?.trim() ?? "";
+  if (!motivo) return { success: false, error: "El motivo de la cancelación es obligatorio" };
+
+  const solicitud = await db.solicitudes.get(solicitudId);
+  if (!solicitud) return { success: false, error: "Solicitud no encontrada" };
+  if (solicitud.pipeline_estado === "cancelada") {
+    return { success: false, error: "La solicitud ya está cancelada" };
+  }
+
+  const visitas = (await db.visitas.where("solicitud_id").equals(solicitudId).toArray()).filter(
+    (v) => !v.deleted_at
+  );
+
+  const enMarcha = visitas.filter((v) => ESTADOS_VISITA_EN_MARCHA.includes(v.estado_visita));
+  if (enMarcha.length > 0) {
+    return {
+      success: false,
+      error: `No se puede cancelar: hay ${enMarcha.length} visita(s) ya iniciada(s). Completá o devolvé esas visitas antes de cancelar la solicitud.`,
+    };
+  }
+
+  const asignadas = visitas.filter((v) => v.estado_visita === "asignada");
+  const now = new Date().toISOString();
+
+  await db.transaction("rw", [db.solicitudes, db.visitas], async () => {
+    for (const v of asignadas) {
+      await db.visitas.update(v.id!, {
+        deleted_at: now,
+        sync_status: "pending",
+        last_modified: now,
+      } satisfies Partial<VisitaEjecucion>);
+    }
+    await db.solicitudes.update(solicitudId, {
+      pipeline_estado: "cancelada",
+      cancelada_motivo: motivo,
+      cancelada_por_id: input.usuarioId,
+      cancelada_en: now,
+      sync_status: "pending",
+      last_modified: now,
+    } satisfies Partial<Solicitud>);
+  });
+
+  const { pushSingle } = await import("@/lib/supabase/sync-engine");
+  pushSingle("solicitudes", solicitudId);
+  for (const v of asignadas) pushSingle("visitas", v.id!);
+
+  return { success: true, visitasCanceladas: asignadas.length };
+}

--- a/src/lib/workflow/visita-service.ts
+++ b/src/lib/workflow/visita-service.ts
@@ -31,6 +31,9 @@ export async function crearVisitaDesdeSolicitud(
   try {
     const solicitud = await db.solicitudes.get(solicitudId);
     if (!solicitud) return { success: false, error: "Solicitud no encontrada" };
+    if (solicitud.pipeline_estado === "cancelada") {
+      return { success: false, error: "La solicitud está cancelada" };
+    }
 
     const equipo = await db.equipos.get(equipoId);
     if (!equipo) return { success: false, error: "Equipo no encontrado" };

--- a/supabase/migrations/027_solicitud_cancelacion.sql
+++ b/supabase/migrations/027_solicitud_cancelacion.sql
@@ -1,0 +1,26 @@
+-- ============================================================
+--  027 — Cancelar solicitud (#64)
+--
+--  Nuevo valor `cancelada` en `pipeline_estado` + traza de la cancelación.
+--  Regla de negocio (en el cliente, `cancelarSolicitud`): se bloquea si hay
+--  visitas ya iniciadas; si solo hay visitas `asignada`, se hace soft-delete
+--  de esas visitas en cascada.
+--
+--  Aditiva e idempotente.
+-- ============================================================
+
+ALTER TABLE public.solicitudes
+  DROP CONSTRAINT IF EXISTS solicitudes_pipeline_estado_check;
+
+ALTER TABLE public.solicitudes
+  ADD CONSTRAINT solicitudes_pipeline_estado_check
+  CHECK (
+    pipeline_estado IN (
+      'solicitudes', 'programacion', 'ejecucion', 'notificado', 'enviado', 'cancelada'
+    )
+  );
+
+ALTER TABLE public.solicitudes
+  ADD COLUMN IF NOT EXISTS cancelada_motivo text,
+  ADD COLUMN IF NOT EXISTS cancelada_por_id uuid,
+  ADD COLUMN IF NOT EXISTS cancelada_en timestamptz;


### PR DESCRIPTION
Parte 2 de #64 (**F2b — cancelar solicitud**). Con F2a (reprogramar visita, PR #85 ya mergeado) cierra #64.

## Qué

Un **programador / coordinador** puede cancelar una solicitud, con **motivo obligatorio** y traza. Regla sobre las visitas hijas:

- alguna visita ya iniciada (`en_progreso` / `en_revision` / `aprobada` / `enviada`) → **no se puede cancelar**; hay que resolver esas visitas primero.
- solo visitas `asignada` → se **soft-deletean en cascada**.

## Cómo

| Archivo | Qué |
|---|---|
| `src/lib/workflow/cancelar-solicitud.ts` (nuevo) | `cancelarSolicitud(solicitudId, { motivo, usuarioId })` — valida motivo + estado, aplica la regla de visitas, pasa la solicitud a `pipeline_estado: "cancelada"` + `cancelada_motivo` / `_por_id` / `_en`. Transacción única; push de solicitud + visitas afectadas. |
| `src/lib/workflow/visita-service.ts` | `crearVisitaDesdeSolicitud` rechaza si `pipeline_estado === "cancelada"`. |
| `src/components/cancelar-solicitud-dialog.tsx` (nuevo) | Motivo obligatorio + aviso de cuántas visitas `asignada` se cancelan en cascada. Surface del error si la solicitud tiene visitas iniciadas. |
| `src/app/dashboard/solicitudes/page.tsx` | Pestaña **"Canceladas"**; "Todas" deja de incluirlas. Badge rojo. |
| `src/app/dashboard/solicitudes/[id]/page.tsx` | Botón "Cancelar" (programador/coordinador, oculto si ya cancelada); banner rojo con el motivo cuando está cancelada; el listado de visitas ahora filtra `deleted_at`. |
| `src/lib/db/types.ts` + `src/lib/supabase/types.ts` | `"cancelada"` en `pipeline_estado` + 3 campos de traza en `solicitudes` (Row/Insert/Update). |
| `supabase/migrations/027_solicitud_cancelacion.sql` (nuevo) | `pipeline_estado` CHECK extendido a `cancelada` + `ADD COLUMN IF NOT EXISTS` × 3. Aditiva, idempotente. |

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **625 tests** + build. Verde.

`cancelar-solicitud.test.ts` (8 casos): happy path con cascada de visitas + traza + push; sin visitas; bloqueo si hay una `en_progreso` (no toca nada); motivo vacío; doble cancelación; solicitud inexistente; `crearVisitaDesdeSolicitud` rechaza una cancelada; no toca visitas de otra solicitud. Guard `#39` verde con los 3 campos nuevos.

## Migración que corre el dueño

`027_solicitud_cancelacion.sql`.

Closes #64
