### PR TITLE
fix(info): campos obligatorios en blanco rompían el sync (23502)

### DIFF
--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -65,12 +65,19 @@ function EditableField({
   icon: Icon,
   onSave,
   type = "text",
+  required = false,
 }: {
   label: string;
   value: string;
   icon?: React.ComponentType<{ className?: string }>;
   onSave: (v: string) => void;
   type?: "text" | "number" | "date";
+  /**
+   * Columna NOT NULL: si se deja en blanco NO se guarda y el campo revierte al
+   * valor actual. Dejar `undefined` una columna obligatoria rompe el push a
+   * Supabase con `23502 not_null_violation` y la fila queda atascada en error.
+   */
+  required?: boolean;
 }) {
   // #68: los campos numéricos se muestran con coma decimal (es-CO) y aceptan
   // coma o punto. El input real es `text` + `inputMode=decimal` (evita la
@@ -97,12 +104,17 @@ function EditableField({
       setSaved(false);
       if (timer.current) clearTimeout(timer.current);
       timer.current = setTimeout(() => {
+        if (required && !v.trim()) {
+          // Campo obligatorio: no se puede dejar en blanco. Revertir al valor real.
+          setLocal(paraMostrar(value));
+          return;
+        }
         onSave(v);
         setSaved(true);
         setTimeout(() => setSaved(false), 1500);
       }, 800);
     },
-    [onSave]
+    [onSave, required, value]
   );
 
   return (
@@ -425,9 +437,21 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
 
   const now = () => new Date().toISOString();
 
+  // Columnas NOT NULL editables desde Info: dejarlas en blanco (→ `undefined`)
+  // rompe el push con `23502 not_null_violation` y la fila queda atascada.
+  // Guard de última línea además del `required` de <EditableField>.
+  function requeridoVacio(tabla: string, field: string, value: string): boolean {
+    const req: Record<string, string[]> = {
+      clientes: ["nombre_cliente", "nit"],
+      sedes: ["nombre_sede"],
+      ubicaciones_rx: ["nombre_servicio"],
+    };
+    return (req[tabla]?.includes(field) ?? false) && !value.trim();
+  }
+
   async function saveCliente(field: string, value: string) {
     const id = data?.cliente?.id;
-    if (!id) return;
+    if (!id || requeridoVacio("clientes", field, value)) return;
     await db.clientes.update(id, {
       [field]: value || undefined,
       sync_status: "pending",
@@ -438,7 +462,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
 
   async function saveSede(field: string, value: string) {
     const id = data?.sede?.id;
-    if (!id) return;
+    if (!id || requeridoVacio("sedes", field, value)) return;
     await db.sedes.update(id, {
       [field]: value || undefined,
       sync_status: "pending",
@@ -449,7 +473,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
 
   async function saveUbicacion(field: string, value: string, numeric = false) {
     const id = data?.ubicacion?.id;
-    if (!id) return;
+    if (!id || requeridoVacio("ubicaciones_rx", field, value)) return;
     const parsed = numeric ? (value === "" ? undefined : parseDecimal(value)) : value || undefined;
     await db.ubicaciones_rx.update(id, {
       [field]: parsed,
@@ -824,6 +848,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             label="Nombre de la Institución"
             value={toStr(cliente?.nombre_cliente)}
             icon={Building2}
+            required
             onSave={(v) => saveCliente("nombre_cliente", v)}
           />
           <div className="flex gap-2">
@@ -832,6 +857,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
                 label="NIT"
                 value={toStr(cliente?.nit)}
                 icon={Hash}
+                required
                 onSave={(v) => saveCliente("nit", v)}
               />
             </div>
@@ -847,6 +873,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             label="Sede"
             value={toStr(sede?.nombre_sede)}
             icon={MapPin}
+            required
             onSave={(v) => saveSede("nombre_sede", v)}
           />
           <EditableField
@@ -880,6 +907,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
           <EditableField
             label="Nombre del Servicio"
             value={toStr(ubicacion?.nombre_servicio)}
+            required
             onSave={(v) => saveUbicacion("nombre_servicio", v)}
           />
           <EditableField

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -157,6 +157,43 @@ describe("GrupoAModulo — elemento de protección con Combobox + 'Otro' (#69)",
   });
 });
 
+describe("InfoModulo — no se puede dejar en blanco una columna NOT NULL (23502)", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+  });
+  afterEach(() => cleanup());
+
+  it("borrar 'Nombre del Servicio' no persiste undefined y el campo revierte", async () => {
+    const { visita, ubicacion } = await seedGraph();
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    const input = screen.getByDisplayValue("Radiología Convencional") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+
+    // Pasado el debounce (800 ms) el guard revierte y NO guarda.
+    await new Promise((r) => setTimeout(r, 950));
+
+    const row = await db.ubicaciones_rx.get(ubicacion.id!);
+    expect(row?.nombre_servicio).toBe("Radiología Convencional");
+    expect(input.value).toBe("Radiología Convencional");
+  });
+
+  it("un valor nuevo no vacío sí se guarda", async () => {
+    const { visita, ubicacion } = await seedGraph();
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    const input = screen.getByDisplayValue("Radiología Convencional");
+    fireEvent.change(input, { target: { value: "Mamografía" } });
+    await new Promise((r) => setTimeout(r, 950));
+
+    const row = await db.ubicaciones_rx.get(ubicacion.id!);
+    expect(row?.nombre_servicio).toBe("Mamografía");
+  });
+});
+
 describe("InfoModulo — Sistema de Adquisición de Imágenes (#62)", () => {
   beforeEach(async () => {
     await resetTestDb();


### PR DESCRIPTION
## El error

Sync atascado en `ubicaciones_rx` — `POST .../rest/v1/ubicaciones_rx?on_conflict=id` → **400** con `Proxy-Status: PostgREST; error=23502` (`not_null_violation`).

En Información General, estos campos son `<EditableField>` de texto libre sobre **columnas NOT NULL** de Supabase:

| Campo (UI) | Columna |
|---|---|
| Nombre del Servicio | `ubicaciones_rx.nombre_servicio` |
| Nombre de la Institución | `clientes.nombre_cliente` |
| NIT | `clientes.nit` |
| Sede | `sedes.nombre_sede` |

Al **borrar** el campo, `saveUbicacion` / `saveCliente` / `saveSede` hacían `db.X.update(id, { [field]: value || undefined })`. Dexie con `undefined` **elimina la propiedad**; el push (`prepareForRemote` → `JSON.stringify`) manda la fila sin esa columna; el upsert de PostgREST evalúa el INSERT y explota con `23502` antes de resolver el `ON CONFLICT`. La fila queda en "con error" y "Reintentar todos" vuelve a fallar.

## El fix

- `<EditableField>` gana un prop **`required`**: si el valor queda en blanco tras el debounce, **no** llama `onSave` y el input **revierte** al valor real. Se marca en los 4 campos de arriba.
- `saveCliente` / `saveSede` / `saveUbicacion` tienen además un guard `requeridoVacio(tabla, field, value)` como última línea de defensa (por si otro caller).

## Recuperar una fila ya atascada

Abrir Información General de esa visita → volver a escribir el valor del campo afectado (probablemente "Nombre del Servicio", que se ve vacío) → se guarda → Sync → "Reintentar todos" pasa. No hace falta tocar nada en Supabase.

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **619 tests** + build. Verde.

2 tests nuevos en `modulos-smoke.test.tsx`: borrar "Nombre del Servicio" no persiste `undefined` y el campo revierte; un valor nuevo no vacío sí se guarda.

Sin migración.
