### PR TITLE
fix(auth): un usuario deshabilitado no entra a la app (#58)

### DIFF
--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -8,15 +8,29 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 const push = vi.fn();
 const refresh = vi.fn();
 let redirectParam: string | null = null;
+let disabledParam: string | null = null;
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push, refresh }),
-  useSearchParams: () => ({ get: (k: string) => (k === "redirect" ? redirectParam : null) }),
+  useSearchParams: () => ({
+    get: (k: string) =>
+      k === "redirect" ? redirectParam : k === "disabled" ? disabledParam : null,
+  }),
 }));
 
-const signInWithPassword = vi.fn().mockResolvedValue({ error: null });
+const signInWithPassword = vi
+  .fn()
+  .mockResolvedValue({ data: { user: { id: "auth-1" } }, error: null });
+const signOut = vi.fn().mockResolvedValue({ error: null });
+// Perfil devuelto por .from("usuarios").select("activo").eq(...).single()
+let perfilResult: { data: unknown; error: unknown } = { data: { activo: true }, error: null };
 vi.mock("@/lib/supabase/client", () => ({
-  createClient: () => ({ auth: { signInWithPassword } }),
+  createClient: () => ({
+    auth: { signInWithPassword, signOut },
+    from: () => ({
+      select: () => ({ eq: () => ({ single: async () => perfilResult }) }),
+    }),
+  }),
 }));
 vi.mock("@/lib/supabase/sync-engine", () => ({
   fullSync: vi.fn().mockResolvedValue({ errors: [] }),
@@ -50,6 +64,10 @@ describe("LoginForm — redirect tras autenticar", () => {
   beforeEach(() => {
     push.mockClear();
     signInWithPassword.mockClear();
+    signOut.mockClear();
+    redirectParam = null;
+    disabledParam = null;
+    perfilResult = { data: { activo: true }, error: null };
   });
   afterEach(cleanup);
 
@@ -74,5 +92,57 @@ describe("LoginForm — redirect tras autenticar", () => {
     redirectParam = "/dashboard/visitas";
     await submit();
     await waitFor(() => expect(push).toHaveBeenCalledWith("/dashboard/visitas"));
+  });
+});
+
+describe("LoginForm — gate de usuario deshabilitado (#58)", () => {
+  beforeEach(() => {
+    push.mockClear();
+    signInWithPassword.mockClear();
+    signOut.mockClear();
+    redirectParam = null;
+    disabledParam = null;
+    perfilResult = { data: { activo: true }, error: null };
+  });
+  afterEach(cleanup);
+
+  async function submit() {
+    render(<LoginPage />);
+    fireEvent.change(screen.getByPlaceholderText(/email|correo/i), {
+      target: { value: "user@sievert.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/contraseña|password|•/i), {
+      target: { value: "clave1234" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /ingresar|entrar|iniciar/i }));
+  }
+
+  it("un usuario activo=false no entra: signOut + mensaje, sin navegar", async () => {
+    perfilResult = { data: { activo: false }, error: null };
+    await submit();
+    await waitFor(() => expect(signOut).toHaveBeenCalled());
+    expect(push).not.toHaveBeenCalled();
+    expect(screen.getByText(/deshabilitado/i)).toBeInTheDocument();
+  });
+
+  it("un usuario sin perfil (PGRST116) tampoco entra", async () => {
+    perfilResult = { data: null, error: { code: "PGRST116" } };
+    await submit();
+    await waitFor(() => expect(signOut).toHaveBeenCalled());
+    expect(push).not.toHaveBeenCalled();
+    expect(screen.getByText(/perfil/i)).toBeInTheDocument();
+  });
+
+  it("un error transitorio al verificar NO bloquea el login", async () => {
+    perfilResult = { data: null, error: { code: "500", message: "boom" } };
+    await submit();
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/dashboard"));
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it("con ?disabled=1 muestra el mensaje al abrir el login", () => {
+    disabledParam = "1";
+    render(<LoginPage />);
+    expect(screen.getByText(/deshabilitado/i)).toBeInTheDocument();
   });
 });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,6 +37,9 @@ export default function LoginPage() {
   );
 }
 
+const MSG_DESHABILITADO =
+  "Tu usuario está deshabilitado. Contactá a un coordinador para reactivarlo.";
+
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -45,7 +48,9 @@ function LoginForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+  const [error, setError] = useState(() =>
+    searchParams.get("disabled") === "1" ? MSG_DESHABILITADO : ""
+  );
   const [cooldown, setCooldown] = useState(false);
   const failCount = useRef(0);
 
@@ -58,7 +63,7 @@ function LoginForm() {
 
     try {
       const supabase = createClient();
-      const { error: authError } = await supabase.auth.signInWithPassword({
+      const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
         email,
         password,
       });
@@ -75,6 +80,29 @@ function LoginForm() {
             : authError.message
         );
         return;
+      }
+
+      // Gate de usuario deshabilitado: las credenciales son válidas pero el
+      // perfil puede estar `activo=false`. No debe entrar a la app (#58).
+      const uid = authData.user?.id;
+      const { data: perfil, error: perfilError } = await supabase
+        .from("usuarios")
+        .select("activo")
+        .eq("auth_uid", uid ?? "")
+        .single();
+
+      if (perfilError?.code === "PGRST116" || (perfil && perfil.activo === false)) {
+        await supabase.auth.signOut();
+        setError(
+          perfilError
+            ? "No encontramos tu perfil en el sistema. Contactá a un coordinador."
+            : MSG_DESHABILITADO
+        );
+        return;
+      }
+      if (perfilError) {
+        // Error transitorio verificando el perfil — no bloquear un login legítimo.
+        logger.warn("login:gate-activo", "No se pudo verificar `activo`", perfilError);
       }
 
       failCount.current = 0;

--- a/src/components/role-provider.tsx
+++ b/src/components/role-provider.tsx
@@ -75,11 +75,21 @@ export function RoleProvider({ children }: { children: ReactNode }) {
       if (!navigator.onLine) return;
       const { data, error } = await supabase
         .from("usuarios")
-        .select("cargo")
+        .select("cargo, activo")
         .eq("auth_uid", uid)
         .single();
       if (error) {
         logger.warn("Role", "No se pudo verificar cargo desde Supabase", error);
+        return;
+      }
+      // Gate de usuario deshabilitado (#58): si el coordinador desactivó la
+      // cuenta mientras la sesión seguía abierta, se cierra y vuelve al login.
+      if (data && data.activo === false) {
+        logger.warn("Role", "Usuario deshabilitado — cerrando sesión");
+        await supabase.auth.signOut();
+        if (typeof window !== "undefined" && window.location.pathname !== "/login") {
+          window.location.assign("/login?disabled=1");
+        }
         return;
       }
       if (data?.cargo) setServerCargo(data.cargo as RolUsuario);


### PR DESCRIPTION
Detectado probando F1 (#58): un usuario con `activo = false` **autentica y pasa del login**. Queda dentro del shell de la app pero no puede cargar ninguna vista (RoleProvider filtra los inactivos → `role` queda `null` → `hasPermission` siempre false). No debería poder entrar.

## Cambios

| Archivo | Qué |
|---|---|
| `src/app/login/page.tsx` | Tras `signInWithPassword` OK, consulta `usuarios.activo` por `auth_uid`. Si es `false` (o no hay fila / `PGRST116`) → `supabase.auth.signOut()` + mensaje ("Tu usuario está deshabilitado…" / "No encontramos tu perfil…") y **no navega**. Un error transitorio al verificar (5xx) se loguea pero **no** bloquea un login legítimo. Con `?disabled=1` en la URL, el aviso ya aparece al abrir el login. |
| `src/components/role-provider.tsx` | `fetchAndSetCargo` ahora trae `cargo, activo`. Si el coordinador desactiva la cuenta con la sesión abierta, en el próximo load se hace `signOut()` y se redirige a `/login?disabled=1`. |

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **621 tests** + build. Verde.

`login/page.test.tsx` (+4 casos): `activo:false` → signOut + mensaje sin navegar; sin perfil (PGRST116) → idem; error transitorio → **sí** navega; `?disabled=1` muestra el aviso.

## Prueba manual

1. Coordinador → Configuración → desactivar un usuario.
2. Cerrar sesión de ese usuario e intentar entrar con sus credenciales → **queda en el login** con el aviso; no entra a la app.
3. Con el usuario ya adentro, que el coordinador lo desactive → al recargar, lo saca al login.

Sin migración.

Closes #58
