### PR TITLE
ui(solicitudes): tarjeta de visita legible + reprogramar dentro de la card (#64)

### DIFF
--- a/src/app/dashboard/solicitudes/[id]/page.tsx
+++ b/src/app/dashboard/solicitudes/[id]/page.tsx
@@ -406,8 +406,13 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                             <ClipboardCheck className="w-4 h-4 text-primary" />
                           </div>
                           <div className="min-w-0">
-                            <p className="text-sm font-black text-slate-900 truncate">
+                            <p className="text-sm font-black text-slate-900 truncate flex items-center gap-1.5">
                               Visita — {cliente?.nombre_cliente ?? "Sin cliente"}
+                              {visita.reprogramada_en && (
+                                <span className="px-1.5 py-0.5 rounded-md bg-amber-100 text-amber-700 border border-amber-200 text-[9px] font-black uppercase tracking-wider">
+                                  Reprogramada
+                                </span>
+                              )}
                             </p>
                             <p className="text-[11px] text-slate-500 font-medium truncate">
                               {[sede?.nombre_sede, eqNombre].filter(Boolean).join(" · ")}
@@ -417,6 +422,11 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                               {visita.fecha_visita ? ` · ${visita.fecha_visita}` : ""}
                               {` · #${visita.id!.slice(0, 8)}`}
                             </p>
+                            {visita.reprogramada_en && visita.reprogramacion_motivo && (
+                              <p className="text-[10px] text-amber-700 font-medium truncate mt-0.5">
+                                Motivo: {visita.reprogramacion_motivo}
+                              </p>
+                            )}
                           </div>
                         </div>
                         <ExternalLink className="w-4 h-4 text-slate-300 group-hover:text-primary transition-colors flex-shrink-0" />

--- a/src/app/dashboard/solicitudes/[id]/page.tsx
+++ b/src/app/dashboard/solicitudes/[id]/page.tsx
@@ -108,6 +108,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
     const ubicacion = solicitud.ubicacion_id
       ? await db.ubicaciones_rx.get(solicitud.ubicacion_id)
       : undefined;
+    const sede = ubicacion?.sede_id ? await db.sedes.get(ubicacion.sede_id) : undefined;
     const tecnico = solicitud.tecnico_asignado_id
       ? await db.usuarios.get(solicitud.tecnico_asignado_id)
       : undefined;
@@ -123,7 +124,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
     // Visitas ya creadas para esta solicitud
     const visitas = await db.visitas.where("solicitud_id").equals(solicitudId).toArray();
 
-    return { solicitud, cliente, ubicacion, tecnico, contacto, equipos, visitas };
+    return { solicitud, cliente, ubicacion, sede, tecnico, contacto, equipos, visitas };
   }, [isReady, solicitudId]);
 
   const tecnicos = useLiveQuery(
@@ -192,7 +193,7 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
     );
   }
 
-  const { solicitud, cliente, ubicacion, tecnico, contacto, equipos, visitas } = data;
+  const { solicitud, cliente, ubicacion, sede, tecnico, contacto, equipos, visitas } = data;
   const estado = solicitud.pipeline_estado ?? "solicitudes";
   const badge = ESTADO_BADGE[estado] ?? ESTADO_BADGE.solicitudes;
 
@@ -386,48 +387,55 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
           <div className="space-y-2">
             {visitas.map((visita) => {
               const eq = equipos.find((e) => e.id === visita.equipo_id);
-              const eqNombre = eq
-                ? [eq.gen_marca, eq.gen_modelo].filter(Boolean).join(" ") ||
-                  eq.tipo_equipo ||
-                  `Equipo #${eq.id}`
-                : null;
+              // Nombre del equipo: marca + modelo; si no hay, el tipo; si tampoco, un genérico.
+              const eqNombre =
+                [eq?.gen_marca, eq?.gen_modelo].filter(Boolean).join(" ") ||
+                eq?.tipo_equipo?.replace(/_/g, " ") ||
+                "Equipo sin identificar";
               const puedeReprogramar = canReprogramar && visita.estado_visita === "asignada";
               return (
-                <div key={visita.id} className="mb-2">
-                  <a href={`/dashboard/visitas/${visita.id}`}>
-                    <Card className="border-none shadow-sm hover:shadow-lg transition-all rounded-2xl bg-white group cursor-pointer overflow-hidden">
-                      <CardContent className="p-4 sm:p-5">
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="flex items-center gap-3 min-w-0">
-                            <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
-                              <ClipboardCheck className="w-4 h-4 text-primary" />
-                            </div>
-                            <div className="min-w-0">
-                              <p className="text-sm font-black text-slate-900 truncate">
-                                Visita #{visita.id}
-                                {eqNombre ? ` — ${eqNombre}` : ""}
-                              </p>
-                              <p className="text-[11px] text-slate-400 font-medium">
-                                Estado: {visita.estado_visita.replace("_", " ")}
-                                {visita.fecha_visita ? ` · ${visita.fecha_visita}` : ""}
-                              </p>
-                            </div>
+                <Card
+                  key={visita.id}
+                  className="border-none shadow-sm hover:shadow-lg transition-all rounded-2xl bg-white overflow-hidden mb-2"
+                >
+                  <a href={`/dashboard/visitas/${visita.id}`} className="group block">
+                    <CardContent className="p-4 sm:p-5">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-3 min-w-0">
+                          <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
+                            <ClipboardCheck className="w-4 h-4 text-primary" />
                           </div>
-                          <ExternalLink className="w-4 h-4 text-slate-300 group-hover:text-primary transition-colors flex-shrink-0" />
+                          <div className="min-w-0">
+                            <p className="text-sm font-black text-slate-900 truncate">
+                              Visita — {cliente?.nombre_cliente ?? "Sin cliente"}
+                            </p>
+                            <p className="text-[11px] text-slate-500 font-medium truncate">
+                              {[sede?.nombre_sede, eqNombre].filter(Boolean).join(" · ")}
+                            </p>
+                            <p className="text-[10px] text-slate-400 font-medium">
+                              Estado: {visita.estado_visita.replace(/_/g, " ")}
+                              {visita.fecha_visita ? ` · ${visita.fecha_visita}` : ""}
+                              {` · #${visita.id!.slice(0, 8)}`}
+                            </p>
+                          </div>
                         </div>
-                      </CardContent>
-                    </Card>
+                        <ExternalLink className="w-4 h-4 text-slate-300 group-hover:text-primary transition-colors flex-shrink-0" />
+                      </div>
+                    </CardContent>
                   </a>
                   {puedeReprogramar && (
-                    <button
-                      type="button"
-                      onClick={() => setReprogramarId(visita.id!)}
-                      className="mt-1 ml-1 inline-flex items-center gap-1.5 text-[11px] font-bold text-slate-500 hover:text-primary transition-colors"
-                    >
-                      <CalendarClock className="w-3.5 h-3.5" /> Reprogramar
-                    </button>
+                    <div className="px-4 sm:px-5 pb-3 -mt-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setReprogramarId(visita.id!)}
+                        className="h-8 rounded-lg text-xs font-bold text-slate-500 hover:text-primary hover:bg-primary/5"
+                      >
+                        <CalendarClock className="w-3.5 h-3.5 mr-1.5" /> Reprogramar
+                      </Button>
+                    </div>
                   )}
-                </div>
+                </Card>
               );
             })}
           </div>

--- a/src/app/dashboard/visitas/[id]/page.tsx
+++ b/src/app/dashboard/visitas/[id]/page.tsx
@@ -47,6 +47,7 @@ import {
   Lock,
   ShieldAlert,
   MessageSquareWarning,
+  CalendarClock,
   ClipboardList,
   Target,
   Zap,
@@ -269,6 +270,22 @@ export default function VisitaWorkspacePage({ params }: { params: Promise<{ id: 
             </span>
           </div>
           <p className="text-sm text-amber-700 font-medium ml-7">{visita.observaciones_revision}</p>
+        </div>
+      )}
+
+      {/* Banner: visita reprogramada (#64) */}
+      {visita.reprogramada_en && (
+        <div className="p-4 bg-blue-50 rounded-2xl border border-blue-200 space-y-2">
+          <div className="flex items-center gap-2">
+            <CalendarClock className="w-5 h-5 text-blue-600 flex-shrink-0" />
+            <span className="text-sm font-black text-blue-800">
+              Visita reprogramada
+              {visita.reprogramada_en ? ` · ${visita.reprogramada_en.slice(0, 10)}` : ""}
+            </span>
+          </div>
+          {visita.reprogramacion_motivo && (
+            <p className="text-sm text-blue-700 font-medium ml-7">{visita.reprogramacion_motivo}</p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Ajustes de UI sobre la tarjeta de visita en el detalle de la solicitud (seguimiento de #64 / F2a).

## Cambios

**1. Tarjeta de visita más legible.** Antes: `Visita #7e10f1d5-8f4c-4e06-8727-af95936d77da — Canon MRAD-A32S`. Ahora:

| Línea | Contenido |
|---|---|
| Título | `Visita — {nombre_cliente}` |
| Subtítulo | `{nombre_sede} · {equipo}` — equipo = `gen_marca gen_modelo`; si no tiene, el `tipo_equipo`; si tampoco, "Equipo sin identificar" |
| Meta | `Estado: {estado} · {fecha} · #{id corto (8)}` |

Se agrega `sede` a la query del detalle (`ubicacion.sede_id → db.sedes`).

**2. Botón "Reprogramar" dentro de la tarjeta.** Pasa de estar suelto debajo a un pie dentro de la `Card`. Sigue visible solo en visitas `asignada` y para **programador y coordinador** (`canReprogramar` ya incluía ambos).

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **617 tests** + build. Verde.

Sin migración. Sin cambios de lógica (solo presentación).

Contributes to #64.


---

### Update — indicador de reprogramación

- **Tarjeta de visita** (detalle de solicitud): chip **"Reprogramada"** + línea `Motivo: …` cuando `visita.reprogramada_en` está seteado.
- **Detalle de la visita**: banner azul *"Visita reprogramada · {fecha}"* con el motivo, junto a los otros avisos.

Antes, reprogramar cambiaba la fecha/técnico pero no se veía en ningún lado que la visita hubiera sido reprogramada.
