### PR TITLE
fix: signOut local + filtrar deleted_at en las listas (#34, #90)

### DIFF
--- a/src/app/dashboard/clientes/[id]/page.tsx
+++ b/src/app/dashboard/clientes/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -87,18 +87,26 @@ export default function ClienteDetailPage({ params }: { params: Promise<{ id: st
     const cliente = await db.clientes.get(clienteId);
     if (!cliente) return null;
 
-    const contactos = await db.contactos.where("cliente_id").equals(clienteId).toArray();
+    const contactos = (await db.contactos.where("cliente_id").equals(clienteId).toArray()).filter(
+      noBorrado
+    );
 
-    const sedes = await db.sedes.where("cliente_id").equals(clienteId).toArray();
+    const sedes = (await db.sedes.where("cliente_id").equals(clienteId).toArray()).filter(
+      noBorrado
+    );
 
     // Enrichir sedes con ubicaciones y equipos
     const sedesEnriched = await Promise.all(
       sedes.map(async (sede) => {
-        const ubicaciones = await db.ubicaciones_rx.where("sede_id").equals(sede.id!).toArray();
+        const ubicaciones = (
+          await db.ubicaciones_rx.where("sede_id").equals(sede.id!).toArray()
+        ).filter(noBorrado);
 
         const ubicacionesEnriched = await Promise.all(
           ubicaciones.map(async (ubi) => {
-            const equipos = await db.equipos.where("ubicacion_id").equals(ubi.id!).toArray();
+            const equipos = (
+              await db.equipos.where("ubicacion_id").equals(ubi.id!).toArray()
+            ).filter(noBorrado);
             return { ubicacion: ubi, equipos };
           })
         );

--- a/src/app/dashboard/clientes/page.tsx
+++ b/src/app/dashboard/clientes/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -36,21 +36,33 @@ export default function ClientesPage() {
   const data = useLiveQuery(async () => {
     if (!isReady) return undefined;
 
-    const clientes = await db.clientes.toArray();
+    const clientes = (await db.clientes.toArray()).filter(noBorrado);
 
     // Enriquecer con conteo de sedes y equipos
     const enriched = await Promise.all(
       clientes.map(async (cliente) => {
-        const sedes = await db.sedes.where("cliente_id").equals(cliente.id!).count();
+        const sedes = await db.sedes
+          .where("cliente_id")
+          .equals(cliente.id!)
+          .filter(noBorrado)
+          .count();
 
         // Contar equipos: sedes → ubicaciones → equipos
-        const sedesList = await db.sedes.where("cliente_id").equals(cliente.id!).toArray();
+        const sedesList = (await db.sedes.where("cliente_id").equals(cliente.id!).toArray()).filter(
+          noBorrado
+        );
         const sedeIds = sedesList.map((s) => s.id!);
         let equiposCount = 0;
         for (const sedeId of sedeIds) {
-          const ubis = await db.ubicaciones_rx.where("sede_id").equals(sedeId).toArray();
+          const ubis = (await db.ubicaciones_rx.where("sede_id").equals(sedeId).toArray()).filter(
+            noBorrado
+          );
           for (const ubi of ubis) {
-            const eqCount = await db.equipos.where("ubicacion_id").equals(ubi.id!).count();
+            const eqCount = await db.equipos
+              .where("ubicacion_id")
+              .equals(ubi.id!)
+              .filter(noBorrado)
+              .count();
             equiposCount += eqCount;
           }
         }

--- a/src/app/dashboard/equipos/[id]/page.tsx
+++ b/src/app/dashboard/equipos/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -78,7 +78,9 @@ export default function EquipoDetailPage({ params }: { params: Promise<{ id: str
     );
 
     // Visitas del equipo (más reciente primero)
-    const visitas = await db.visitas.where("equipo_id").equals(equipoId).toArray();
+    const visitas = (await db.visitas.where("equipo_id").equals(equipoId).toArray()).filter(
+      noBorrado
+    );
     visitas.sort((a, b) => (b.creado_en ?? "").localeCompare(a.creado_en ?? ""));
 
     // Informes del equipo (más reciente primero)

--- a/src/app/dashboard/equipos/page.tsx
+++ b/src/app/dashboard/equipos/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -43,7 +43,7 @@ export default function EquiposPage() {
   const data = useLiveQuery(async () => {
     if (!isReady) return undefined;
 
-    const equipos = await db.equipos.toArray();
+    const equipos = (await db.equipos.toArray()).filter(noBorrado);
 
     const enriched = await Promise.all(
       equipos.map(async (equipo) => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -24,7 +24,7 @@ export default function DashboardPage() {
   const kpis = useLiveQuery(async () => {
     if (!isReady || !role) return null;
 
-    const allVisitas = await db.visitas.toArray();
+    const allVisitas = (await db.visitas.toArray()).filter(noBorrado);
 
     const asignadas = allVisitas.filter((v) => v.estado_visita === "asignada").length;
     const enProgreso = allVisitas.filter((v) => v.estado_visita === "en_progreso").length;

--- a/src/app/dashboard/revision/page.tsx
+++ b/src/app/dashboard/revision/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -32,7 +32,9 @@ export default function RevisionPage() {
     if (!isReady) return undefined;
 
     // Obtener visitas pendientes de revisión
-    const pendientes = await db.visitas.where("estado_visita").equals("en_revision").toArray();
+    const pendientes = (
+      await db.visitas.where("estado_visita").equals("en_revision").toArray()
+    ).filter(noBorrado);
 
     const enriched = await Promise.all(
       pendientes.map(async (visita) => {

--- a/src/app/dashboard/solicitudes/page.tsx
+++ b/src/app/dashboard/solicitudes/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -106,7 +106,7 @@ export default function SolicitudesPage() {
   const data = useLiveQuery(async () => {
     if (!isReady) return undefined;
 
-    const solicitudes = await db.solicitudes.toArray();
+    const solicitudes = (await db.solicitudes.toArray()).filter(noBorrado);
 
     const enriched = await Promise.all(
       solicitudes.map(async (sol) => {

--- a/src/app/dashboard/visitas/page.tsx
+++ b/src/app/dashboard/visitas/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
@@ -49,7 +49,7 @@ export default function VisitasPage() {
   const visitas = useLiveQuery(async () => {
     if (!isReady) return undefined;
 
-    let allVisitas = await db.visitas.toArray();
+    let allVisitas = (await db.visitas.toArray()).filter(noBorrado);
 
     // Técnicos solo ven sus visitas asignadas
     if (role?.cargo === "tecnico" && role?.usuarioId) {

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -102,7 +102,10 @@ export function AppSidebar() {
 
   async function handleLogout() {
     const supabase = createClient();
-    await supabase.auth.signOut();
+    // `scope: "local"` — cerrar sesión solo en ESTE dispositivo. Sin scope,
+    // Supabase revoca el refresh token y tira abajo todas las sesiones del
+    // usuario (otros equipos, la app de campo, etc.).
+    await supabase.auth.signOut({ scope: "local" });
     router.push("/login");
   }
 

--- a/src/components/solicitud-form-dialog.tsx
+++ b/src/components/solicitud-form-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useReseedOnOpen } from "@/hooks/use-reseed-on-open";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import type { Solicitud } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
 import { pushSingle } from "@/lib/supabase/sync-engine";
@@ -87,16 +87,26 @@ export function SolicitudFormDialog({
   }
 
   // Data queries
-  const clientes = useLiveQuery(() => (isReady ? db.clientes.toArray() : []), [isReady], []);
+  const clientes = useLiveQuery(
+    () => (isReady ? db.clientes.filter(noBorrado).toArray() : []),
+    [isReady],
+    []
+  );
 
   const sedes = useLiveQuery(
-    () => (isReady && clienteId ? db.sedes.where("cliente_id").equals(clienteId).toArray() : []),
+    () =>
+      isReady && clienteId
+        ? db.sedes.where("cliente_id").equals(clienteId).filter(noBorrado).toArray()
+        : [],
     [isReady, clienteId],
     []
   );
 
   const ubicaciones = useLiveQuery(
-    () => (isReady && sedeId ? db.ubicaciones_rx.where("sede_id").equals(sedeId).toArray() : []),
+    () =>
+      isReady && sedeId
+        ? db.ubicaciones_rx.where("sede_id").equals(sedeId).filter(noBorrado).toArray()
+        : [],
     [isReady, sedeId],
     []
   );

--- a/src/components/trasladar-equipo-dialog.tsx
+++ b/src/components/trasladar-equipo-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { trasladarEquipo } from "@/lib/workflow/equipo-service";
@@ -79,13 +79,19 @@ export function TrasladarEquipoDialog({
   );
 
   const sedes = useLiveQuery(
-    () => (isReady && clienteId ? db.sedes.where("cliente_id").equals(clienteId).toArray() : []),
+    () =>
+      isReady && clienteId
+        ? db.sedes.where("cliente_id").equals(clienteId).filter(noBorrado).toArray()
+        : [],
     [isReady, clienteId],
     []
   );
 
   const ubicaciones = useLiveQuery(
-    () => (isReady && sedeId ? db.ubicaciones_rx.where("sede_id").equals(sedeId).toArray() : []),
+    () =>
+      isReady && sedeId
+        ? db.ubicaciones_rx.where("sede_id").equals(sedeId).filter(noBorrado).toArray()
+        : [],
     [isReady, sedeId],
     []
   );

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useRef } from "react";
 import { randomUUID } from "@/lib/uuid";
 import { parseDecimal, decimalInputValue } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "@/lib/db";
+import { db, noBorrado } from "@/lib/db";
 import { SISTEMAS_ADQUISICION } from "@/lib/db/types";
 import type { EquipoIdentificacion } from "@/lib/db/types";
 import { useImagenSrc } from "@/hooks/use-imagen-src";
@@ -412,7 +412,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
       : [];
 
     const contactos = cliente?.id
-      ? await db.contactos.where("cliente_id").equals(cliente.id).toArray()
+      ? (await db.contactos.where("cliente_id").equals(cliente.id).toArray()).filter(noBorrado)
       : [];
 
     return {

--- a/src/lib/db/deleted-at.test.ts
+++ b/src/lib/db/deleted-at.test.ts
@@ -1,22 +1,25 @@
 // Invariante deleted_at (borrado suave). Escenarios db-S16 / db-S18.
 //
 // El sync-engine escribe `deleted_at` sobre cualquier tabla vía deleteAndSync.
-// La regla es "toda lectura que arma una lista filtra !deleted_at". Hoy eso
-// NO se cumple para las tablas maestras: `db.clientes.toArray()` y similares
-// devuelven las filas borradas. Este test FIJA ese comportamiento imperfecto
-// para que cualquier cambio (bueno o malo) sea visible. Ver hallazgo #14.
+// La regla es "toda lectura que arma una lista filtra !deleted_at".
+//
+// Resolución #34: Dexie NO filtra solo (una `reading` hook no puede descartar
+// filas). El filtro es responsabilidad de cada lectura, encadenando el
+// predicado `noBorrado` antes de `.toArray()` / `.count()`. Todas las listas
+// de la app (maestras, visitas, solicitudes) lo hacen; este test fija el
+// contrato del helper y el hecho de que `.toArray()` crudo NO filtra.
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { db } from "./index";
+import { db, noBorrado } from "./index";
 import { resetTestDb } from "@/test/db-reset";
 import { makeCliente } from "@/test/factories";
 
-describe("deleted_at — comportamiento actual (pin)", () => {
+describe("deleted_at — invariante de borrado suave (#34)", () => {
   beforeEach(async () => {
     await resetTestDb();
   });
 
-  it("db-S16: db.clientes.toArray() DEVUELVE las filas con deleted_at (no filtra)", async () => {
+  it("db-S16: `.toArray()` crudo NO filtra — hay que encadenar `noBorrado`", async () => {
     await db.clientes.add(makeCliente({ id: "vivo", nombre_cliente: "Vivo" }));
     await db.clientes.add(
       makeCliente({
@@ -26,22 +29,28 @@ describe("deleted_at — comportamiento actual (pin)", () => {
       })
     );
 
-    const todos = await db.clientes.toArray();
+    // Crudo: devuelve las 2 (Dexie no filtra).
+    expect(await db.clientes.toArray()).toHaveLength(2);
 
-    // Comportamiento ACTUAL: devuelve las 2. Cuando se arregle el hallazgo
-    // #14, este test debe actualizarse a `toHaveLength(1)`.
-    expect(todos).toHaveLength(2);
-    expect(todos.map((c) => c.id).sort()).toEqual(["borrado", "vivo"]);
-  });
-
-  it("un filtro manual !deleted_at sí las excluye (patrón que usan los conv_*)", async () => {
-    await db.clientes.add(makeCliente({ id: "vivo" }));
-    await db.clientes.add(makeCliente({ id: "borrado", deleted_at: new Date().toISOString() }));
-
-    const vivos = (await db.clientes.toArray()).filter((c) => !c.deleted_at);
-
+    // Con el predicado: solo la viva. Es el patrón que usan TODAS las listas.
+    const vivos = (await db.clientes.toArray()).filter(noBorrado);
     expect(vivos).toHaveLength(1);
     expect(vivos[0].id).toBe("vivo");
+  });
+
+  it("`noBorrado` también encadena en la query de Dexie (.filter antes de .count/.toArray)", async () => {
+    await db.clientes.add(makeCliente({ id: "a" }));
+    await db.clientes.add(makeCliente({ id: "b", deleted_at: new Date().toISOString() }));
+
+    expect(await db.clientes.filter(noBorrado).count()).toBe(1);
+    expect((await db.clientes.filter(noBorrado).toArray()).map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("`noBorrado`: null / undefined / ausente → vivo; string → borrado", () => {
+    expect(noBorrado({ deleted_at: null })).toBe(true);
+    expect(noBorrado({ deleted_at: undefined })).toBe(true);
+    expect(noBorrado({})).toBe(true);
+    expect(noBorrado({ deleted_at: "2026-01-01T00:00:00.000Z" })).toBe(false);
   });
 
   it("db-S18: deleted_at es parte del tipo (opcional) en filas sincronizables", async () => {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -339,6 +339,14 @@ class EyCDatabase extends Dexie {
 
 export const db = new EyCDatabase();
 
+/**
+ * Predicado de borrado suave (#34). Invariante: TODA lectura que arma una
+ * lista (maestras, visitas, solicitudes…) filtra las filas con `deleted_at`.
+ * Dexie no filtra solo; se encadena `.filter(noBorrado)` antes de
+ * `.toArray()` / `.count()`. Los consumidores `conv_*` ya lo hacían inline.
+ */
+export const noBorrado = (r: { deleted_at?: string | null }): boolean => r.deleted_at == null;
+
 db.on("blocked", () => {
   if (typeof window !== "undefined") {
     window.location.reload();


### PR DESCRIPTION
Hardening chico antes de la 2ª pasada E2E — dos issues del backlog diferido que ya aportan valor.

## #90 — `signOut()` sin scope revoca todas las sesiones

`app-sidebar.tsx` → cerrar sesión desde el sidebar hacía `supabase.auth.signOut()` sin `scope` → Supabase revoca el refresh token y **tira abajo todas las sesiones del usuario** (otros dispositivos, la app de campo). Ahora: `signOut({ scope: "local" })`.

Los `signOut()` de `login/page.tsx` y `role-provider.tsx` (casos "tu usuario está deshabilitado, salí") se dejan igual — ahí un scope más amplio es aceptable.

## #34 — `deleted_at` no se filtraba en las listas

La invariante es "toda lectura que arma una lista filtra `!deleted_at`". Solo lo cumplían los consumidores `conv_*`. Con **F2b (cancelar solicitud)**, que hace soft-delete en cascada de las visitas `asignada`, esas visitas aparecían como **fantasmas** en `/dashboard/visitas` y en el dashboard.

| Qué | Detalle |
|---|---|
| `noBorrado` | Predicado en `@/lib/db` (`r.deleted_at == null`). Dexie no filtra solo (una `reading` hook no puede descartar filas); se encadena `.filter(noBorrado)` antes de `.toArray()` / `.count()`. |
| Aplicado a | `visitas` (listado, dashboard, revisión, hoja de vida del equipo), `solicitudes` (listado), y las maestras `clientes` / `sedes` / `ubicaciones_rx` / `equipos` / `contactos` en las páginas de dashboard + diálogos de traslado y de solicitud. |
| No se toca | `usuarios` — no es soft-deletable (usa `activo`). `equipo-form-dialog` y `solicitudes/[id]` ya filtraban. |

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **632 tests** + build. Verde.

`deleted-at.test.ts` reescrito: fija el contrato de `noBorrado` y que el `.toArray()` crudo no filtra.

Sin migración.

Closes #34
Closes #90
