### PR TITLE
feat(sync): botón para resetear datos locales, con modal de riesgo (#36)

### DIFF
--- a/src/app/dashboard/sync/page.test.tsx
+++ b/src/app/dashboard/sync/page.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+// ============================================================
+//  /dashboard/sync — botón "Resetear datos locales" (#36)
+//
+//  Cualquiera puede borrar el IndexedDB de su dispositivo desde acá, con un
+//  modal que advierte el riesgo. NO toca el servidor (usa resetAndReopen).
+// ============================================================
+
+const resetAndReopen = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/db/recovery", () => ({ resetAndReopen: () => resetAndReopen() }));
+
+const state = { online: true, authenticated: true, pendingCount: 0, errorCount: 0 };
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  fullSync: vi.fn().mockResolvedValue({ pushed: 0, pulled: 0, errors: [], timestamp: Date.now() }),
+  checkSyncStatus: vi.fn(async () => ({ ...state })),
+  getErrorRecords: vi.fn().mockResolvedValue([]),
+  getPendingRecords: vi.fn().mockResolvedValue([]),
+  retryErrorRecords: vi.fn().mockResolvedValue(undefined),
+  retryRecord: vi.fn().mockResolvedValue(undefined),
+}));
+
+import SyncPage from "./page";
+
+const reload = vi.fn();
+
+beforeEach(() => {
+  resetAndReopen.mockClear();
+  reload.mockClear();
+  state.online = true;
+  state.pendingCount = 0;
+  state.errorCount = 0;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, reload },
+  });
+});
+afterEach(() => cleanup());
+
+describe("SyncPage — resetear datos locales", () => {
+  it("el modal exige tildar el aviso antes de borrar, y llama resetAndReopen", async () => {
+    render(<SyncPage />);
+    fireEvent.click(await screen.findByRole("button", { name: /Resetear$/i }));
+
+    const confirmar = await screen.findByRole("button", { name: /Borrar y recargar/i });
+    expect(confirmar).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(confirmar).toBeEnabled();
+
+    fireEvent.click(confirmar);
+    await waitFor(() => expect(resetAndReopen).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(reload).toHaveBeenCalled());
+  });
+
+  it("avisa que se pierden los registros sin subir cuando hay pendientes/errores", async () => {
+    state.pendingCount = 3;
+    state.errorCount = 1;
+    render(<SyncPage />);
+    await screen.findByRole("button", { name: /Resetear$/i });
+    fireEvent.click(screen.getByRole("button", { name: /Resetear$/i }));
+
+    expect(await screen.findByText(/Se van a perder/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 pendientes y 1 con error/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/dashboard/sync/page.tsx
+++ b/src/app/dashboard/sync/page.tsx
@@ -4,6 +4,15 @@ import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { resetAndReopen } from "@/lib/db/recovery";
+import {
   RefreshCw,
   Wifi,
   WifiOff,
@@ -17,6 +26,8 @@ import {
   RotateCcw,
   ChevronDown,
   ChevronUp,
+  Trash2,
+  ShieldAlert,
 } from "lucide-react";
 import {
   fullSync,
@@ -115,6 +126,9 @@ export default function SyncPage() {
   const [pendingRecords, setPendingRecords] = useState<SyncRecordPreview[]>([]);
   const [pendingExpanded, setPendingExpanded] = useState(false);
   const [retryingRecordId, setRetryingRecordId] = useState<string | null>(null);
+  const [resetOpen, setResetOpen] = useState(false);
+  const [resetAck, setResetAck] = useState(false);
+  const [resetting, setResetting] = useState(false);
 
   const refreshStatus = useCallback(async () => {
     const s = await checkSyncStatus();
@@ -177,6 +191,24 @@ export default function SyncPage() {
       setRetryingRecordId(null);
     }
   }
+
+  /**
+   * Borra TODO el IndexedDB de este dispositivo y lo reabre vacío. NO toca el
+   * servidor: los datos ya sincronizados se vuelven a bajar en el próximo
+   * `fullSync`. Los registros pendientes / con error (que aún no subieron) se
+   * pierden. Sin gate de rol — cualquiera en un dispositivo compartido puede
+   * necesitarlo; el riesgo lo cubre el modal de confirmación.
+   */
+  async function handleResetLocal() {
+    setResetting(true);
+    try {
+      await resetAndReopen();
+    } finally {
+      window.location.reload();
+    }
+  }
+
+  const hayDatosSinSubir = (status?.pendingCount ?? 0) > 0 || (status?.errorCount ?? 0) > 0;
 
   return (
     <div className="space-y-6">
@@ -503,6 +535,99 @@ export default function SyncPage() {
           </div>
         </div>
       )}
+
+      {/* Zona de riesgo — resetear datos locales */}
+      <Card className="border-2 border-dashed border-red-200 shadow-none rounded-2xl bg-red-50/40 overflow-hidden">
+        <CardContent className="p-5 sm:p-6 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+          <div className="flex-1 min-w-0">
+            <h3 className="text-base font-black text-red-700 tracking-tight flex items-center gap-2">
+              <ShieldAlert className="w-5 h-5" />
+              Resetear datos locales
+            </h3>
+            <p className="text-sm text-slate-500 font-medium mt-1">
+              Borra todo lo guardado en <strong>este dispositivo</strong> y lo vuelve a descargar
+              del servidor. Útil si los datos locales quedaron inconsistentes o vas a prestar el
+              equipo. No toca el servidor.
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            className="rounded-xl font-black text-red-700 hover:bg-red-100 h-11 px-5 flex-shrink-0"
+            onClick={() => {
+              setResetAck(false);
+              setResetOpen(true);
+            }}
+          >
+            <Trash2 className="w-4 h-4 mr-2" />
+            Resetear
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Dialog open={resetOpen} onOpenChange={(o) => !resetting && setResetOpen(o)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="font-black flex items-center gap-2 text-red-700">
+              <ShieldAlert className="w-5 h-5" /> Resetear datos locales
+            </DialogTitle>
+            <DialogDescription>
+              Se van a borrar <strong>todos los datos guardados en este dispositivo</strong>{" "}
+              (IndexedDB) y la app se va a recargar.
+            </DialogDescription>
+          </DialogHeader>
+
+          <ul className="text-sm text-slate-600 font-medium space-y-2 list-disc pl-5">
+            <li>
+              <strong>No</strong> toca el servidor: lo que ya está sincronizado se vuelve a bajar
+              solo tras el próximo <code className="text-xs">fullSync</code>.
+            </li>
+            <li>
+              Hay que <strong>volver a iniciar sesión</strong> si la sesión no persiste, y esperar
+              la sincronización inicial.
+            </li>
+          </ul>
+
+          {hayDatosSinSubir && (
+            <div className="flex gap-2 p-3 bg-red-50 rounded-xl border border-red-200 text-xs text-red-700 font-bold">
+              <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <span>
+                Tenés {status?.pendingCount ?? 0} pendiente
+                {(status?.pendingCount ?? 0) !== 1 ? "s" : ""} y {status?.errorCount ?? 0} con error
+                sin subir. <strong>Se van a perder.</strong> Sincronizá primero si tenés conexión.
+              </span>
+            </div>
+          )}
+
+          <label className="flex items-start gap-2 text-sm text-slate-700 font-medium cursor-pointer">
+            <input
+              type="checkbox"
+              className="mt-1 accent-red-600"
+              checked={resetAck}
+              onChange={(e) => setResetAck(e.target.checked)}
+            />
+            Entiendo que se borran los datos locales de este dispositivo.
+          </label>
+
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              className="rounded-xl font-bold"
+              onClick={() => setResetOpen(false)}
+              disabled={resetting}
+            >
+              Cancelar
+            </Button>
+            <Button
+              className="rounded-xl font-black bg-red-600 hover:bg-red-700 text-white"
+              onClick={handleResetLocal}
+              disabled={!resetAck || resetting}
+            >
+              {resetting ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
+              Borrar y recargar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
Antes esto solo existía como **pantalla de recuperación automática** en `db-provider.tsx` (aparece sola si `db.open()` falla con un error de esquema no migrable). No se podía disparar a mano.

Ahora hay un botón deliberado en **Sincronización** (`/dashboard/sync`), **para cualquier usuario** (sin gate de rol), con modal de confirmación.

## Qué

| Elemento | Detalle |
|---|---|
| Card "Zona de riesgo" | Al pie de la página de sync, borde rojo punteado. Botón "Resetear". |
| Modal (`<Dialog>`) | Advierte: borra **todo lo guardado en este dispositivo** (IndexedDB); **no** toca el servidor (se re-baja tras el próximo `fullSync`); hay que re-login + esperar la sync inicial. |
| Aviso de pérdida | Si `pendingCount > 0` o `errorCount > 0`, muestra el conteo en rojo: "Se van a perder. Sincronizá primero si tenés conexión." |
| Guardarraíl | Checkbox "Entiendo que se borran los datos locales" — habilita el botón "Borrar y recargar". |
| Acción | `resetAndReopen()` (ya existía en `src/lib/db/recovery.ts`, testeado: `db.close()` + `db.delete()` + `db.open()`) → `window.location.reload()`. |

Reemplaza el paso manual "DevTools → Clear site data" del runbook de la 2ª pasada.

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **634 tests** + build. Verde.

`src/app/dashboard/sync/page.test.tsx` (2 casos): el modal exige el checkbox antes de habilitar el botón y llama `resetAndReopen` + `reload`; con pendientes/errores muestra el aviso de pérdida con el conteo.

Sin migración. Cierra la parte de `resetAllLocalData` de #36 (queda superada por este botón, que usa `resetAndReopen`).

Closes #36
