### PR TITLE
feat: consecutivo de solicitud + teléfono contacto + técnico/búsqueda en visitas

### DIFF
--- a/src/app/dashboard/solicitudes/[id]/page.tsx
+++ b/src/app/dashboard/solicitudes/[id]/page.tsx
@@ -32,6 +32,7 @@ import {
   Pencil,
   CalendarClock,
   Ban,
+  Phone,
 } from "lucide-react";
 import Link from "next/link";
 import { crearVisitaDesdeSolicitud } from "@/lib/workflow/visita-service";
@@ -278,10 +279,13 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
       <Card className="border-none shadow-sm rounded-2xl md:rounded-3xl bg-white overflow-hidden">
         <CardContent className="p-4 sm:p-5 md:p-6 space-y-4">
           <div className="flex items-start justify-between gap-3">
-            <div className="space-y-1">
+            <div className="space-y-1 min-w-0">
               <h2 className="text-lg sm:text-xl md:text-2xl font-black text-slate-900 tracking-tight">
-                Solicitud #{solicitud.id}
+                Solicitud {solicitud.numero_solicitud ?? `#${solicitud.id!.slice(0, 8)}`}
               </h2>
+              <p className="text-[11px] text-slate-400 font-mono font-medium truncate">
+                #{solicitud.id}
+              </p>
               <p className="text-sm text-slate-500 font-medium">{cliente?.nombre_cliente}</p>
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">
@@ -353,6 +357,12 @@ export default function SolicitudDetailPage({ params }: { params: Promise<{ id: 
                   Contacto
                 </p>
                 <p className="text-sm font-bold text-slate-700">{contacto.nombre}</p>
+                {contacto.telefono && (
+                  <p className="text-xs font-medium text-slate-500 flex items-center gap-1">
+                    <Phone className="w-3 h-3 text-slate-400" />
+                    {contacto.telefono}
+                  </p>
+                )}
               </div>
             )}
             {solicitud.tipo_servicio && (

--- a/src/app/dashboard/solicitudes/page.tsx
+++ b/src/app/dashboard/solicitudes/page.tsx
@@ -227,6 +227,7 @@ export default function SolicitudesPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
+                    <TableHead>N.º</TableHead>
                     <TableHead>Cliente</TableHead>
                     <TableHead>Ubicación</TableHead>
                     <TableHead>Técnico</TableHead>
@@ -247,6 +248,9 @@ export default function SolicitudesPage() {
                         className="cursor-pointer group"
                         onClick={() => router.push(`/dashboard/solicitudes/${solicitud.id}`)}
                       >
+                        <TableCell className="font-mono text-xs font-bold text-slate-500 whitespace-nowrap">
+                          {solicitud.numero_solicitud ?? "—"}
+                        </TableCell>
                         <TableCell>
                           <div className="flex items-center gap-3 min-w-0">
                             <div className="bg-primary/10 p-2 rounded-xl flex-shrink-0">
@@ -318,6 +322,11 @@ export default function SolicitudesPage() {
                             <p className="font-black text-slate-900 text-sm sm:text-base truncate">
                               {cliente?.nombre_cliente ?? "—"}
                             </p>
+                            {solicitud.numero_solicitud && (
+                              <span className="font-mono text-[10px] font-bold text-slate-400 flex-shrink-0">
+                                {solicitud.numero_solicitud}
+                              </span>
+                            )}
                           </div>
 
                           {/* Metadata */}

--- a/src/app/dashboard/visitas/page.tsx
+++ b/src/app/dashboard/visitas/page.tsx
@@ -6,6 +6,7 @@ import { db, noBorrado } from "@/lib/db";
 import { useDb } from "@/components/db-provider";
 import { useRole } from "@/components/role-provider";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { ESTADO_CONFIG } from "@/lib/workflow/visit-state-machine";
 import { getVisitCompletenessBulk } from "@/lib/workflow/module-completeness";
 import {
@@ -16,6 +17,8 @@ import {
   Calendar,
   ArrowRight,
   Loader2,
+  User,
+  Search,
 } from "lucide-react";
 import { irAVisita } from "@/lib/visita-nav";
 import type { EstadoVisita } from "@/lib/db/types";
@@ -45,6 +48,7 @@ export default function VisitasPage() {
   const { isReady } = useDb();
   const { role } = useRole();
   const [activeFilter, setActiveFilter] = useState<FilterTab>("todas");
+  const [search, setSearch] = useState("");
 
   const visitas = useLiveQuery(async () => {
     if (!isReady) return undefined;
@@ -64,18 +68,23 @@ export default function VisitasPage() {
     const solicitudIds = [
       ...new Set(allVisitas.map((v) => v.solicitud_id).filter(Boolean)),
     ] as string[];
+    const tecnicoIds = [
+      ...new Set(allVisitas.map((v) => v.tecnico_id).filter(Boolean)),
+    ] as string[];
     const visitaIds = allVisitas.map((v) => v.id!);
 
-    const [equipos, ubicaciones, solicitudes, completenessMap] = await Promise.all([
+    const [equipos, ubicaciones, solicitudes, tecnicos, completenessMap] = await Promise.all([
       db.equipos.bulkGet(equipoIds),
       db.ubicaciones_rx.bulkGet(ubicacionIds),
       db.solicitudes.bulkGet(solicitudIds),
+      db.usuarios.bulkGet(tecnicoIds),
       getVisitCompletenessBulk(visitaIds),
     ]);
 
     const equipoMap = new Map(equipoIds.map((id, i) => [id, equipos[i]]));
     const ubicacionMap = new Map(ubicacionIds.map((id, i) => [id, ubicaciones[i]]));
     const solicitudMap = new Map(solicitudIds.map((id, i) => [id, solicitudes[i]]));
+    const tecnicoMap = new Map(tecnicoIds.map((id, i) => [id, tecnicos[i]]));
 
     // Fetch sedes y clientes (secondary lookups)
     const sedeIds = [
@@ -109,6 +118,7 @@ export default function VisitasPage() {
       const solicitud = solicitudMap.get(visita.solicitud_id);
       const sede = ubicacion?.sede_id ? sedeMap.get(ubicacion.sede_id) : undefined;
       const cliente = solicitud?.cliente_id ? clienteMap.get(solicitud.cliente_id) : undefined;
+      const tecnico = visita.tecnico_id ? tecnicoMap.get(visita.tecnico_id) : undefined;
 
       return {
         visita,
@@ -116,6 +126,7 @@ export default function VisitasPage() {
         ubicacion,
         sede,
         cliente,
+        tecnico,
         solicitud,
         completeness: completenessMap.get(visita.id!) ?? {
           total: 0,
@@ -139,10 +150,25 @@ export default function VisitasPage() {
 
   // Filtrar por tab activo
   const activeTab = FILTER_TABS.find((t) => t.id === activeFilter)!;
-  const filteredVisitas =
+  const porTab =
     activeFilter === "todas"
       ? visitas
       : visitas.filter((v) => activeTab.states.includes(v.visita.estado_visita));
+
+  // Búsqueda por cliente / equipo / técnico
+  const q = search.trim().toLowerCase();
+  const filteredVisitas = q
+    ? porTab.filter((v) => {
+        const campos = [
+          v.cliente?.nombre_cliente,
+          v.equipo?.gen_marca,
+          v.equipo?.gen_modelo,
+          v.equipo?.tipo_equipo?.replace(/_/g, " "),
+          v.tecnico?.nombre,
+        ];
+        return campos.some((c) => c?.toLowerCase().includes(q));
+      })
+    : porTab;
 
   // Contadores por filtro
   const counts: Record<FilterTab, number> = {
@@ -165,6 +191,17 @@ export default function VisitasPage() {
         <p className="text-slate-500 font-medium text-sm md:text-lg mt-1">
           Servicios asignados y en progreso
         </p>
+      </div>
+
+      {/* Búsqueda */}
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Buscar por cliente, equipo o técnico…"
+          className="pl-9 rounded-xl border-slate-200 h-11"
+        />
       </div>
 
       {/* Filter tabs */}
@@ -223,6 +260,7 @@ export default function VisitasPage() {
                     <TableHead>Cliente</TableHead>
                     <TableHead>Ubicación</TableHead>
                     <TableHead>Equipo</TableHead>
+                    <TableHead>Técnico</TableHead>
                     <TableHead>Fecha</TableHead>
                     <TableHead className="text-center">Progreso</TableHead>
                     <TableHead>Estado</TableHead>
@@ -231,7 +269,7 @@ export default function VisitasPage() {
                 </TableHeader>
                 <TableBody>
                   {filteredVisitas.map(
-                    ({ visita, equipo, ubicacion, sede, cliente, completeness }) => {
+                    ({ visita, equipo, ubicacion, sede, cliente, tecnico, completeness }) => {
                       const estado = ESTADO_CONFIG[visita.estado_visita];
                       const muestraProgreso =
                         visita.estado_visita !== "asignada" &&
@@ -269,6 +307,16 @@ export default function VisitasPage() {
                             )}
                           </TableCell>
                           <TableCell className="font-medium text-slate-600 whitespace-nowrap">
+                            {tecnico ? (
+                              <span className="flex items-center gap-1.5">
+                                <User className="w-3.5 h-3.5 text-slate-400" />
+                                {tecnico.nombre.split(" ").slice(0, 2).join(" ")}
+                              </span>
+                            ) : (
+                              <span className="text-slate-400">Sin asignar</span>
+                            )}
+                          </TableCell>
+                          <TableCell className="font-medium text-slate-600 whitespace-nowrap">
                             {visita.fecha_visita ?? "Sin fecha"}
                           </TableCell>
                           <TableCell className="text-center">
@@ -301,70 +349,78 @@ export default function VisitasPage() {
 
           {/* Tarjetas (móvil) */}
           <div className="space-y-3 md:hidden">
-            {filteredVisitas.map(({ visita, equipo, ubicacion, sede, cliente, completeness }) => {
-              const estado = ESTADO_CONFIG[visita.estado_visita];
-              return (
-                <a key={visita.id} href={`/dashboard/visitas/${visita.id}`}>
-                  <Card className="border-none shadow-sm hover:shadow-lg transition-all duration-300 rounded-2xl md:rounded-3xl bg-white group cursor-pointer overflow-hidden mb-3">
-                    <CardContent className="p-4 sm:p-5 md:p-6">
-                      <div className="flex items-start justify-between gap-3">
-                        {/* Info principal */}
-                        <div className="flex-1 min-w-0 space-y-2">
-                          {/* Cliente */}
-                          <div className="flex items-start gap-2">
-                            <Building2 className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
-                            <p className="font-black text-slate-900 text-sm sm:text-base leading-tight">
-                              {cliente?.nombre_cliente ?? "Sin cliente"}
-                            </p>
-                          </div>
+            {filteredVisitas.map(
+              ({ visita, equipo, ubicacion, sede, cliente, tecnico, completeness }) => {
+                const estado = ESTADO_CONFIG[visita.estado_visita];
+                return (
+                  <a key={visita.id} href={`/dashboard/visitas/${visita.id}`}>
+                    <Card className="border-none shadow-sm hover:shadow-lg transition-all duration-300 rounded-2xl md:rounded-3xl bg-white group cursor-pointer overflow-hidden mb-3">
+                      <CardContent className="p-4 sm:p-5 md:p-6">
+                        <div className="flex items-start justify-between gap-3">
+                          {/* Info principal */}
+                          <div className="flex-1 min-w-0 space-y-2">
+                            {/* Cliente */}
+                            <div className="flex items-start gap-2">
+                              <Building2 className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
+                              <p className="font-black text-slate-900 text-sm sm:text-base leading-tight">
+                                {cliente?.nombre_cliente ?? "Sin cliente"}
+                              </p>
+                            </div>
 
-                          {/* Ubicación y equipo */}
-                          <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] sm:text-xs text-slate-500 font-medium">
-                            <span className="flex items-center gap-1">
-                              <MapPin className="w-3 h-3" />
-                              {sede?.ciudad ?? "—"}, {ubicacion?.nombre_servicio ?? "—"}
-                            </span>
-                            <span className="flex items-center gap-1">
-                              <Radio className="w-3 h-3" />
-                              {equipo?.gen_marca} {equipo?.gen_modelo}
-                            </span>
-                            <span className="flex items-center gap-1">
-                              <Calendar className="w-3 h-3" />
-                              {visita.fecha_visita ?? "Sin fecha"}
-                            </span>
-                          </div>
-
-                          {/* Badges + Progress */}
-                          <div className="flex flex-wrap items-center gap-2 pt-1">
-                            <span
-                              className={`px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest ${estado.bgColor} ${estado.color} border ${estado.borderColor}`}
-                            >
-                              {estado.label}
-                            </span>
-                            {equipo?.tipo_equipo && (
-                              <span className="px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest bg-slate-100 text-slate-500 border border-slate-200">
-                                {equipo.tipo_equipo.replace(/_/g, " ")}
+                            {/* Ubicación y equipo */}
+                            <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] sm:text-xs text-slate-500 font-medium">
+                              <span className="flex items-center gap-1">
+                                <MapPin className="w-3 h-3" />
+                                {sede?.ciudad ?? "—"}, {ubicacion?.nombre_servicio ?? "—"}
                               </span>
-                            )}
-                            {/* Progress pill */}
-                            {visita.estado_visita !== "asignada" &&
-                              visita.estado_visita !== "aprobada" &&
-                              visita.estado_visita !== "enviada" && (
-                                <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary border border-primary/20">
-                                  {completeness.completed}/{completeness.total}
+                              <span className="flex items-center gap-1">
+                                <Radio className="w-3 h-3" />
+                                {equipo?.gen_marca} {equipo?.gen_modelo}
+                              </span>
+                              <span className="flex items-center gap-1">
+                                <User className="w-3 h-3" />
+                                {tecnico
+                                  ? tecnico.nombre.split(" ").slice(0, 2).join(" ")
+                                  : "Sin asignar"}
+                              </span>
+                              <span className="flex items-center gap-1">
+                                <Calendar className="w-3 h-3" />
+                                {visita.fecha_visita ?? "Sin fecha"}
+                              </span>
+                            </div>
+
+                            {/* Badges + Progress */}
+                            <div className="flex flex-wrap items-center gap-2 pt-1">
+                              <span
+                                className={`px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest ${estado.bgColor} ${estado.color} border ${estado.borderColor}`}
+                              >
+                                {estado.label}
+                              </span>
+                              {equipo?.tipo_equipo && (
+                                <span className="px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest bg-slate-100 text-slate-500 border border-slate-200">
+                                  {equipo.tipo_equipo.replace(/_/g, " ")}
                                 </span>
                               )}
+                              {/* Progress pill */}
+                              {visita.estado_visita !== "asignada" &&
+                                visita.estado_visita !== "aprobada" &&
+                                visita.estado_visita !== "enviada" && (
+                                  <span className="px-2 py-0.5 rounded-full text-[10px] font-black bg-primary/10 text-primary border border-primary/20">
+                                    {completeness.completed}/{completeness.total}
+                                  </span>
+                                )}
+                            </div>
                           </div>
-                        </div>
 
-                        {/* Flecha */}
-                        <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-1 group-hover:text-primary transition-colors" />
-                      </div>
-                    </CardContent>
-                  </Card>
-                </a>
-              );
-            })}
+                          {/* Flecha */}
+                          <ArrowRight className="w-5 h-5 text-slate-300 flex-shrink-0 mt-1 group-hover:text-primary transition-colors" />
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </a>
+                );
+              }
+            )}
           </div>
         </>
       )}

--- a/src/components/solicitud-form-dialog.tsx
+++ b/src/components/solicitud-form-dialog.tsx
@@ -7,6 +7,7 @@ import { db, noBorrado } from "@/lib/db";
 import type { Solicitud } from "@/lib/db/types";
 import { randomUUID } from "@/lib/uuid";
 import { pushSingle } from "@/lib/supabase/sync-engine";
+import { generarNumeroSolicitud } from "@/lib/workflow/solicitud-numero";
 import {
   Dialog,
   DialogContent,
@@ -187,6 +188,7 @@ export function SolicitudFormDialog({
       } else {
         // Modo creación
         const data: Omit<Solicitud, "id"> = {
+          numero_solicitud: await generarNumeroSolicitud(),
           cliente_id: clienteId,
           contacto_programar_id: contactoId || undefined,
           ubicacion_id: ubicacionId || undefined,

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -538,6 +538,13 @@ export interface Cotizacion {
 
 export interface Solicitud extends Partial<SyncFields> {
   id?: string;
+  /**
+   * Consecutivo legible `SOL-{año}-{NNN}` para identificar la solicitud a
+   * simple vista. El `id` (uuid) sigue siendo la clave real. Se asigna al
+   * crear (mismo criterio que `numero_informe`); no es garantía de unicidad
+   * global offline — es una etiqueta.
+   */
+  numero_solicitud?: string;
   cotizacion_id?: string;
   cliente_id: string;
   contacto_programar_id?: string;

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -2206,6 +2206,7 @@ export type Database = {
           forma_pago: string | null;
           id: string;
           last_modified: string;
+          numero_solicitud: string | null;
           pago_recibido: boolean;
           pipeline_estado: string;
           sync_status: string;
@@ -2225,6 +2226,7 @@ export type Database = {
           forma_pago?: string | null;
           id?: string;
           last_modified?: string;
+          numero_solicitud?: string | null;
           pago_recibido?: boolean;
           pipeline_estado?: string;
           sync_status?: string;
@@ -2244,6 +2246,7 @@ export type Database = {
           forma_pago?: string | null;
           id?: string;
           last_modified?: string;
+          numero_solicitud?: string | null;
           pago_recibido?: boolean;
           pipeline_estado?: string;
           sync_status?: string;

--- a/src/lib/workflow/solicitud-numero.test.ts
+++ b/src/lib/workflow/solicitud-numero.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { makeCliente } from "@/test/factories";
+import { generarNumeroSolicitud } from "./solicitud-numero";
+
+function sol(over: Partial<Parameters<typeof db.solicitudes.add>[0]> = {}) {
+  return {
+    id: crypto.randomUUID(),
+    cliente_id: "c1",
+    pago_recibido: false,
+    sync_status: "synced" as const,
+    last_modified: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+beforeEach(async () => {
+  await resetTestDb();
+  await db.clientes.add(makeCliente({ id: "c1" }));
+});
+
+describe("generarNumeroSolicitud", () => {
+  // `new Date(y, m, d)` (constructor local) — evita el corrimiento de zona
+  // horaria de `new Date("2027-01-01")` (que se parsea como UTC).
+  const dia = (y: number, m: number, d: number) => new Date(y, m - 1, d);
+
+  it("SOL-{año}-001 para la primera del año", async () => {
+    expect(await generarNumeroSolicitud(dia(2026, 5, 10))).toBe("SOL-2026-001");
+  });
+
+  it("incrementa sobre el máximo del año, ignorando otros años", async () => {
+    await db.solicitudes.add(sol({ numero_solicitud: "SOL-2026-001" }));
+    await db.solicitudes.add(sol({ numero_solicitud: "SOL-2026-007" }));
+    await db.solicitudes.add(sol({ numero_solicitud: "SOL-2025-050" }));
+    await db.solicitudes.add(sol({ numero_solicitud: undefined }));
+
+    expect(await generarNumeroSolicitud(dia(2026, 9, 1))).toBe("SOL-2026-008");
+    expect(await generarNumeroSolicitud(dia(2025, 9, 1))).toBe("SOL-2025-051");
+    expect(await generarNumeroSolicitud(dia(2027, 1, 1))).toBe("SOL-2027-001");
+  });
+
+  it("padea a 3 dígitos pero no rompe con seq > 999", async () => {
+    await db.solicitudes.add(sol({ numero_solicitud: "SOL-2026-999" }));
+    expect(await generarNumeroSolicitud(dia(2026, 1, 1))).toBe("SOL-2026-1000");
+  });
+});

--- a/src/lib/workflow/solicitud-numero.ts
+++ b/src/lib/workflow/solicitud-numero.ts
@@ -1,0 +1,27 @@
+import { db } from "@/lib/db";
+
+/**
+ * Consecutivo legible `SOL-{año}-{NNN}` de una solicitud. El `id` (uuid)
+ * sigue siendo la clave real; esto es solo una etiqueta para identificarla
+ * a simple vista.
+ *
+ * Se numera contando las solicitudes locales del año — mismo criterio que
+ * `numero_informe` (ver `informe-service.ts`). No garantiza unicidad global
+ * offline: dos dispositivos sin conexión pueden generar el mismo número.
+ * Aceptable porque no es un identificador, y el backfill de la migración
+ * 028 ya numeró las existentes.
+ */
+export async function generarNumeroSolicitud(fecha = new Date()): Promise<string> {
+  const year = fecha.getFullYear();
+  const prefix = `SOL-${year}-`;
+
+  const all = await db.solicitudes.toArray();
+  let maxSeq = 0;
+  for (const s of all) {
+    if (!s.numero_solicitud || !s.numero_solicitud.startsWith(prefix)) continue;
+    const seq = parseInt(s.numero_solicitud.slice(prefix.length), 10);
+    if (!Number.isNaN(seq) && seq > maxSeq) maxSeq = seq;
+  }
+
+  return prefix + String(maxSeq + 1).padStart(3, "0");
+}

--- a/supabase/migrations/028_solicitud_numero_consecutivo.sql
+++ b/supabase/migrations/028_solicitud_numero_consecutivo.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+--  028 — Consecutivo legible de solicitudes
+--
+--  `numero_solicitud` (SOL-{año}-{NNN}) para identificar la solicitud a
+--  simple vista. El `id` (uuid) sigue siendo la clave real. Se asigna en
+--  el cliente al crear (mismo criterio que `numero_informe`).
+--
+--  Aditiva. El backfill numera las solicitudes existentes por año según
+--  `creado_en`. Sin constraint de unicidad — offline puede generar
+--  duplicados y no queremos rechazar syncs por eso.
+-- ============================================================
+
+ALTER TABLE public.solicitudes
+  ADD COLUMN IF NOT EXISTS numero_solicitud text;
+
+WITH numeradas AS (
+  SELECT
+    id,
+    'SOL-' || to_char(creado_en, 'YYYY') || '-' ||
+    lpad(
+      (row_number() OVER (
+        PARTITION BY to_char(creado_en, 'YYYY')
+        ORDER BY creado_en, id
+      ))::text,
+      3, '0'
+    ) AS num
+  FROM public.solicitudes
+)
+UPDATE public.solicitudes s
+SET numero_solicitud = n.num
+FROM numeradas n
+WHERE s.id = n.id
+  AND s.numero_solicitud IS NULL;


### PR DESCRIPTION
Tres mejoras de legibilidad en los listados de solicitudes y visitas.

## Solicitudes — consecutivo `SOL-{año}-{NNN}`

Identificador legible a simple vista. **El uuid no se reemplaza** — sigue visible en gris bajo el título.

| Dónde | Antes | Ahora |
|---|---|---|
| Detalle (título) | `Solicitud #3dda25e8-4466-…` | `Solicitud SOL-2026-012` <br> `#3dda25e8-4466-…` (gris, mono) |
| Listado | — | columna **"N.º"** |

- `numero_solicitud` se asigna al **crear**, contando las solicitudes locales del año (mismo criterio que `numero_informe`). No garantiza unicidad global offline — es una etiqueta, no una clave.
- Migración **`028_solicitud_numero_consecutivo.sql`**: `ADD COLUMN` + backfill de las existentes por año según `creado_en`. Sin constraint de unicidad (offline podría duplicar y no queremos rechazar syncs).
- Sin cambio de esquema Dexie (`numero_solicitud` no es índice).

## Solicitudes — teléfono del contacto

En el header del detalle, bajo el nombre del contacto para programar.

## Visitas — columna Técnico + búsqueda

- **Columna "Técnico"** en la tabla y en las tarjetas móviles — el coordinador lo ve sin abrir cada visita. "Sin asignar" si no tiene. La query hace `bulkGet` de los técnicos.
- **Barra de búsqueda** por cliente / equipo (marca, modelo, tipo) / técnico, encima del filtro por estado.

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **586 tests** + build. Verde.

`solicitud-numero.test.ts` (3 casos): primera del año → `SOL-{año}-001`; incrementa sobre el máx del año ignorando otros años; padea a 3 dígitos y no rompe con seq > 999. `#39` guard verde con la columna nueva.

## Migración que corre el dueño

`028_solicitud_numero_consecutivo.sql`.
