### PR TITLE
fix(info): Información General guarda al salir del campo, no por debounce

### DIFF
--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState } from "react";
 import { randomUUID } from "@/lib/uuid";
 import { parseDecimal, decimalInputValue } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
@@ -89,7 +89,6 @@ function EditableField({
   const [local, setLocal] = useState(() => paraMostrar(value));
   const [prevValue, setPrevValue] = useState(value);
   const [saved, setSaved] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Sincronizar `local` cuando el valor externo cambia (guardado remoto,
   // sync entre dispositivos): ajuste de estado en render, no en efecto.
@@ -98,24 +97,20 @@ function EditableField({
     setLocal(paraMostrar(value));
   }
 
-  const handleChange = useCallback(
-    (v: string) => {
-      setLocal(v);
-      setSaved(false);
-      if (timer.current) clearTimeout(timer.current);
-      timer.current = setTimeout(() => {
-        if (required && !v.trim()) {
-          // Campo obligatorio: no se puede dejar en blanco. Revertir al valor real.
-          setLocal(paraMostrar(value));
-          return;
-        }
-        onSave(v);
-        setSaved(true);
-        setTimeout(() => setSaved(false), 1500);
-      }, 800);
-    },
-    [onSave, required, value]
-  );
+  // #68 / feedback: se guarda AL SALIR del campo (blur), no por debounce por
+  // tecla. Si guardaba mientras escribías, un decimal a medias como `1,` se
+  // parseaba a `1` y te borraba la coma en pleno tipeo. Ahora se comporta como
+  // los campos de los grupos A–E (`SetupField`).
+  function handleBlur() {
+    if (required && !local.trim()) {
+      setLocal(paraMostrar(value)); // obligatorio: no se puede dejar vacío
+      return;
+    }
+    if (local === paraMostrar(value)) return; // sin cambios reales
+    onSave(local);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 1500);
+  }
 
   return (
     <div className="space-y-1">
@@ -129,7 +124,11 @@ function EditableField({
         inputMode={esNumero ? "decimal" : undefined}
         className="rounded-xl border-slate-200 focus:border-primary font-medium h-9 text-sm"
         value={local}
-        onChange={(e) => handleChange(e.target.value)}
+        onChange={(e) => {
+          setLocal(e.target.value);
+          setSaved(false);
+        }}
+        onBlur={handleBlur}
         placeholder="—"
       />
     </div>
@@ -194,7 +193,6 @@ function EditableTextArea({
   const [local, setLocal] = useState(value);
   const [prevValue, setPrevValue] = useState(value);
   const [saved, setSaved] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Sincronizar `local` cuando el valor externo cambia (guardado remoto,
   // sync entre dispositivos): ajuste de estado en render, no en efecto.
@@ -203,19 +201,13 @@ function EditableTextArea({
     setLocal(value);
   }
 
-  const handleChange = useCallback(
-    (v: string) => {
-      setLocal(v);
-      setSaved(false);
-      if (timer.current) clearTimeout(timer.current);
-      timer.current = setTimeout(() => {
-        onSave(v);
-        setSaved(true);
-        setTimeout(() => setSaved(false), 1500);
-      }, 800);
-    },
-    [onSave]
-  );
+  // Guarda al salir del campo (blur), no por debounce por tecla.
+  function handleBlur() {
+    if (local === value) return;
+    onSave(local);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 1500);
+  }
 
   return (
     <div className="space-y-1">
@@ -226,7 +218,11 @@ function EditableTextArea({
       <textarea
         className="w-full rounded-xl border border-slate-200 p-2.5 text-sm font-medium resize-none h-20 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
         value={local}
-        onChange={(e) => handleChange(e.target.value)}
+        onChange={(e) => {
+          setLocal(e.target.value);
+          setSaved(false);
+        }}
+        onBlur={handleBlur}
         placeholder={placeholder}
       />
     </div>

--- a/src/components/visita-modulos/modulos-smoke.test.tsx
+++ b/src/components/visita-modulos/modulos-smoke.test.tsx
@@ -164,33 +164,47 @@ describe("InfoModulo — no se puede dejar en blanco una columna NOT NULL (23502
   });
   afterEach(() => cleanup());
 
-  it("borrar 'Nombre del Servicio' no persiste undefined y el campo revierte", async () => {
+  it("borrar 'Nombre del Servicio' no persiste undefined y el campo revierte (al salir del campo)", async () => {
     const { visita, ubicacion } = await seedGraph();
     render(<InfoModulo visitaId={visita!.id!} />);
     await screen.findByText(/Volver al workspace/i);
 
     const input = screen.getByDisplayValue("Radiología Convencional") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
 
-    // Pasado el debounce (800 ms) el guard revierte y NO guarda.
-    await new Promise((r) => setTimeout(r, 950));
-
+    await waitFor(() => expect(input.value).toBe("Radiología Convencional"));
     const row = await db.ubicaciones_rx.get(ubicacion.id!);
     expect(row?.nombre_servicio).toBe("Radiología Convencional");
-    expect(input.value).toBe("Radiología Convencional");
   });
 
-  it("un valor nuevo no vacío sí se guarda", async () => {
+  it("un valor nuevo no vacío se guarda al salir del campo", async () => {
     const { visita, ubicacion } = await seedGraph();
     render(<InfoModulo visitaId={visita!.id!} />);
     await screen.findByText(/Volver al workspace/i);
 
     const input = screen.getByDisplayValue("Radiología Convencional");
     fireEvent.change(input, { target: { value: "Mamografía" } });
-    await new Promise((r) => setTimeout(r, 950));
+    fireEvent.blur(input);
 
-    const row = await db.ubicaciones_rx.get(ubicacion.id!);
-    expect(row?.nombre_servicio).toBe("Mamografía");
+    await waitFor(async () => {
+      const row = await db.ubicaciones_rx.get(ubicacion.id!);
+      expect(row?.nombre_servicio).toBe("Mamografía");
+    });
+  });
+
+  it("un decimal a medias como '1,' no se reformatea mientras escribís (solo al salir)", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const { container } = render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    // Primer campo numérico (inputMode=decimal) de la sección equipo.
+    const input = container.querySelector('input[inputmode="decimal"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    fireEvent.change(input, { target: { value: "1," } });
+    await new Promise((r) => setTimeout(r, 60));
+    // Sin blur: conserva "1," tal cual, no lo parsea a "1".
+    expect(input.value).toBe("1,");
   });
 });
 


### PR DESCRIPTION
En **Información General** los campos autoguardaban con un debounce de 800 ms por tecla. Los grupos de prueba A–E (`SetupField`) guardan al salir del campo (`onBlur`). Esa diferencia rompía la carga de decimales.

## El bug

Escribís un decimal con coma: `1,`. A los 800 ms el debounce dispara `onSave("1,")`, `parseDecimal` lo normaliza a `1` y el input se reformatea — **se come la coma** y no podés terminar de escribir `1,5`.

## El fix

`EditableField` y `EditableTextArea` ahora guardan en `onBlur`, igual que `SetupField`:

| Situación | Comportamiento |
|---|---|
| Campo obligatorio que quedó vacío | revierte al valor previo (fix #34 / 23502 intacto) |
| Sin cambios reales | no-op, no escribe |
| Valor nuevo | `onSave` + flash "Guardado" |

Mientras escribís no pasa nada: `onChange` solo actualiza el estado local. `1,` se queda `1,` hasta que salís del campo.

`SelectField` no cambia (ya guardaba en `onChange`, no hay problema a mitad de tipeo).

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + tests + build. Verde.

`modulos-smoke.test.tsx`: los 2 casos de "NOT NULL" pasaron de esperar el debounce a `fireEvent.blur`; se agregó un caso nuevo — `1,` no se reparsea mientras escribís.

Sin migración.