### PR TITLE
feat(info): Condiciones Ambientales usa el catálogo DIVIPOLA para departamento/ciudad

### DIFF
--- a/src/components/sede-form-dialog.tsx
+++ b/src/components/sede-form-dialog.tsx
@@ -29,6 +29,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
+import { matchIdPorNombre } from "@/lib/divipola";
 
 // ============================================================
 //  Dialog para crear / editar una sede
@@ -49,14 +50,6 @@ interface SedeFormDialogProps {
 
 const labelClass = "text-xs font-black text-slate-600 uppercase tracking-wider";
 const inputClass = "rounded-xl border-slate-200 focus:border-primary font-medium h-11";
-
-/** Busca el id de un departamento/municipio por nombre (sedes antiguas con texto plano) */
-function matchIdPorNombre(items: { id: number; nombre: string }[], nombre?: string): string {
-  if (!nombre) return "";
-  const target = nombre.trim().toLowerCase();
-  const match = items.find((item) => item.nombre.toLowerCase() === target);
-  return match ? String(match.id) : "";
-}
 
 export function SedeFormDialog({
   open,

--- a/src/components/visita-modulos/info-modulo-geo.test.tsx
+++ b/src/components/visita-modulos/info-modulo-geo.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { db } from "@/lib/db";
+import { resetTestDb } from "@/test/db-reset";
+import { seedGraph } from "@/test/seed";
+
+// ============================================================
+//  Condiciones Ambientales — Departamento / Ciudad
+//
+//  Antes eran dos campos de texto libre (sede.departamento / sede.ciudad).
+//  Ahora traen lo que la sede ya tenga y ofrecen la lista del catálogo
+//  DIVIPOLA. Sin catálogo sincronizado, caen al texto libre de siempre.
+// ============================================================
+
+const useDb = vi.fn();
+vi.mock("@/components/db-provider", () => ({ useDb: () => useDb() }));
+vi.mock("@/components/role-provider", () => ({
+  useRole: () => ({ role: "tecnico", cargo: "tecnico", usuarioId: "u1", nombre: "Tec" }),
+}));
+vi.mock("@/lib/supabase/sync-engine", () => ({
+  pushSingle: vi.fn(),
+  updateAndSync: vi.fn().mockResolvedValue(undefined),
+  deleteAndSync: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { InfoModulo } from "./info-modulo";
+
+describe("InfoModulo — Condiciones Ambientales: Departamento / Ciudad", () => {
+  beforeEach(async () => {
+    await resetTestDb();
+    useDb.mockReturnValue({ isReady: true });
+  });
+  afterEach(() => cleanup());
+
+  it("sin catálogo sincronizado usa el texto libre de la sede", async () => {
+    const { visita } = await seedGraph(); // sede: departamento "Cundinamarca", ciudad "Bogotá"
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    expect(screen.getByText("Departamento")).toBeInTheDocument();
+    expect(screen.getByText("Ciudad")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Cundinamarca")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Bogotá")).toBeInTheDocument();
+  });
+
+  it("con catálogo sincronizado precarga el departamento/ciudad de la sede por nombre", async () => {
+    const { visita } = await seedGraph();
+    await db.departamentos.bulkAdd([
+      { id: 25, codigo_dane: "25", nombre: "Cundinamarca" },
+      { id: 5, codigo_dane: "05", nombre: "Antioquia" },
+    ]);
+    await db.municipios.bulkAdd([
+      { id: 25001, departamento_id: 25, codigo_dane: "25001", nombre: "Bogotá" },
+      { id: 5001, departamento_id: 5, codigo_dane: "05001", nombre: "Medellín" },
+    ]);
+
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    // El valor seleccionado del combobox se muestra como texto, no como <input>.
+    expect(await screen.findByText("Cundinamarca")).toBeInTheDocument();
+    expect(await screen.findByText("Bogotá")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Cundinamarca")).not.toBeInTheDocument();
+  });
+
+  it("con catálogo sincronizado precarga por *_id aunque el nombre plano difiera", async () => {
+    const { sede, visita } = await seedGraph();
+    await db.sedes.update(sede.id!, {
+      departamento_id: 5,
+      municipio_id: 5001,
+      departamento: "texto viejo",
+      ciudad: "otra cosa",
+    });
+    await db.departamentos.bulkAdd([{ id: 5, codigo_dane: "05", nombre: "Antioquia" }]);
+    await db.municipios.bulkAdd([
+      { id: 5001, departamento_id: 5, codigo_dane: "05001", nombre: "Medellín" },
+    ]);
+
+    render(<InfoModulo visitaId={visita!.id!} />);
+    await screen.findByText(/Volver al workspace/i);
+
+    expect(await screen.findByText("Antioquia")).toBeInTheDocument();
+    expect(await screen.findByText("Medellín")).toBeInTheDocument();
+  });
+});

--- a/src/components/visita-modulos/info-modulo.tsx
+++ b/src/components/visita-modulos/info-modulo.tsx
@@ -6,7 +6,8 @@ import { parseDecimal, decimalInputValue } from "@/lib/decimal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db, noBorrado } from "@/lib/db";
 import { SISTEMAS_ADQUISICION } from "@/lib/db/types";
-import type { EquipoIdentificacion } from "@/lib/db/types";
+import type { EquipoIdentificacion, Sede } from "@/lib/db/types";
+import { matchIdPorNombre } from "@/lib/divipola";
 import { useImagenSrc } from "@/hooks/use-imagen-src";
 import { ImagenConTitulo } from "@/components/imagen-con-titulo";
 import { useDb } from "@/components/db-provider";
@@ -14,6 +15,16 @@ import { useRole } from "@/components/role-provider";
 import { pushSingle } from "@/lib/supabase/sync-engine";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+  ComboboxValue,
+} from "@/components/ui/combobox";
 import {
   ArrowLeft,
   Building2,
@@ -177,6 +188,142 @@ function SelectField({
         ))}
       </select>
     </div>
+  );
+}
+
+// Ciudad / Departamento en Condiciones Ambientales: precarga lo que la sede
+// ya tenga definido (id del catálogo DIVIPOLA, o texto plano de sedes viejas)
+// y deja elegir de la lista. Escribe id + nombre denormalizado sobre la sede.
+function GeoAmbientalFields({
+  sede,
+  onSave,
+}: {
+  sede: Sede | undefined;
+  onSave: (patch: Partial<Sede>) => void;
+}) {
+  const [deptoOverride, setDeptoOverride] = useState<string | null>(null);
+  const [muniOverride, setMuniOverride] = useState<string | null>(null);
+
+  const departamentos =
+    useLiveQuery(
+      async () =>
+        (await db.departamentos.toArray()).sort((a, b) => a.nombre.localeCompare(b.nombre, "es")),
+      []
+    ) ?? [];
+
+  const deptoId =
+    deptoOverride ??
+    (sede?.departamento_id
+      ? String(sede.departamento_id)
+      : matchIdPorNombre(departamentos, sede?.departamento));
+
+  const municipios =
+    useLiveQuery(
+      async () =>
+        deptoId
+          ? (
+              await db.municipios.where("departamento_id").equals(parseInt(deptoId, 10)).toArray()
+            ).sort((a, b) => a.nombre.localeCompare(b.nombre, "es"))
+          : [],
+      [deptoId]
+    ) ?? [];
+
+  const muniId =
+    muniOverride ??
+    (sede?.municipio_id ? String(sede.municipio_id) : matchIdPorNombre(municipios, sede?.ciudad));
+
+  const catalogoListo = departamentos.length > 0;
+
+  if (!catalogoListo) {
+    // Catálogo aún no sincronizado — texto libre como antes.
+    return (
+      <>
+        <EditableField
+          label="Departamento"
+          value={sede?.departamento ?? ""}
+          icon={MapPin}
+          onSave={(v) => onSave({ departamento: v || undefined })}
+        />
+        <EditableField
+          label="Ciudad"
+          value={sede?.ciudad ?? ""}
+          icon={MapPin}
+          onSave={(v) => onSave({ ciudad: v || undefined })}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-1">
+        <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
+          <MapPin className="w-3 h-3" />
+          Departamento
+        </p>
+        <Combobox
+          items={departamentos}
+          itemToStringLabel={(d) => d.nombre}
+          value={departamentos.find((d) => String(d.id) === deptoId) ?? null}
+          onValueChange={(d) => {
+            setDeptoOverride(d ? String(d.id) : "");
+            setMuniOverride("");
+            onSave({
+              departamento_id: d?.id,
+              departamento: d?.nombre,
+              municipio_id: undefined,
+              ciudad: undefined,
+            });
+          }}
+        >
+          <ComboboxTrigger className="w-full rounded-xl border border-slate-200 focus:border-primary font-medium h-9 text-sm px-3 bg-white text-slate-800 data-[placeholder]:text-slate-400">
+            <ComboboxValue placeholder="Seleccionar..." />
+          </ComboboxTrigger>
+          <ComboboxContent>
+            <ComboboxInput placeholder="Buscar departamento..." />
+            <ComboboxEmpty>Sin resultados.</ComboboxEmpty>
+            <ComboboxList>
+              {(d: { id: number; nombre: string }) => (
+                <ComboboxItem key={d.id} value={d}>
+                  {d.nombre}
+                </ComboboxItem>
+              )}
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+      </div>
+      <div className="space-y-1">
+        <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-1.5">
+          <MapPin className="w-3 h-3" />
+          Ciudad
+        </p>
+        <Combobox
+          items={municipios}
+          itemToStringLabel={(m) => m.nombre}
+          value={municipios.find((m) => String(m.id) === muniId) ?? null}
+          onValueChange={(m) => {
+            setMuniOverride(m ? String(m.id) : "");
+            onSave({ municipio_id: m?.id, ciudad: m?.nombre });
+          }}
+          disabled={!deptoId}
+        >
+          <ComboboxTrigger className="w-full rounded-xl border border-slate-200 focus:border-primary font-medium h-9 text-sm px-3 bg-white text-slate-800 data-[placeholder]:text-slate-400">
+            <ComboboxValue placeholder={deptoId ? "Seleccionar..." : "Elegí departamento"} />
+          </ComboboxTrigger>
+          <ComboboxContent>
+            <ComboboxInput placeholder="Buscar ciudad..." />
+            <ComboboxEmpty>Sin resultados.</ComboboxEmpty>
+            <ComboboxList>
+              {(m: { id: number; nombre: string }) => (
+                <ComboboxItem key={m.id} value={m}>
+                  {m.nombre}
+                </ComboboxItem>
+              )}
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+      </div>
+    </>
   );
 }
 
@@ -465,6 +612,20 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
     if (!id || requeridoVacio("sedes", field, value)) return;
     await db.sedes.update(id, {
       [field]: value || undefined,
+      sync_status: "pending",
+      last_modified: now(),
+    });
+    pushSingle("sedes", id);
+  }
+
+  // Actualiza varios campos geográficos de la sede a la vez (depto/municipio del
+  // catálogo + su nombre denormalizado). `Table.update` con `undefined` borra la
+  // clave — acá es lo que queremos al limpiar el municipio.
+  async function saveSedeGeo(patch: Partial<Sede>) {
+    const id = data?.sede?.id;
+    if (!id) return;
+    await db.sedes.update(id, {
+      ...patch,
       sync_status: "pending",
       last_modified: now(),
     });
@@ -1331,18 +1492,7 @@ export function InfoModulo({ visitaId: id }: { visitaId: string }) {
             type="number"
             onSave={(v) => saveVisita("presion_hpa", v, true)}
           />
-          <EditableField
-            label="Ciudad"
-            value={toStr(sede?.ciudad)}
-            icon={MapPin}
-            onSave={(v) => saveSede("ciudad", v)}
-          />
-          <EditableField
-            label="Departamento"
-            value={toStr(sede?.departamento)}
-            icon={MapPin}
-            onSave={(v) => saveSede("departamento", v)}
-          />
+          <GeoAmbientalFields sede={sede} onSave={saveSedeGeo} />
           <div className="sm:col-span-2 lg:col-span-3">
             <EditableField
               label="Observaciones"

--- a/src/lib/divipola.ts
+++ b/src/lib/divipola.ts
@@ -1,0 +1,16 @@
+// Helpers del catálogo DIVIPOLA (departamentos / municipios).
+
+/**
+ * Busca el id de un departamento o municipio por nombre exacto (case-insensitive).
+ * Sirve para sedes antiguas que solo guardan `ciudad` / `departamento` como texto
+ * plano, sin el `*_id` del catálogo. Devuelve "" si no hay coincidencia.
+ */
+export function matchIdPorNombre(
+  items: { id: number; nombre: string }[],
+  nombre?: string | null
+): string {
+  if (!nombre) return "";
+  const target = nombre.trim().toLowerCase();
+  const match = items.find((item) => item.nombre.toLowerCase() === target);
+  return match ? String(match.id) : "";
+}


### PR DESCRIPTION
En **Información General → Condiciones Ambientales**, Departamento y Ciudad eran dos campos de texto libre que escribían `sede.departamento` / `sede.ciudad`. El formulario de sede ya usa el catálogo DIVIPOLA (tablas `departamentos` / `municipios` sincronizadas). Esta pantalla no.

## Qué cambia

| | Antes | Ahora |
|---|---|---|
| Precarga | solo el texto plano | `departamento_id` / `municipio_id` del catálogo si la sede los tiene; si no, match por nombre del texto viejo |
| Edición | texto libre | **lista desplegable con búsqueda** (Combobox), igual que el formulario de sede — municipio filtrado por el departamento elegido |
| Al guardar | un campo | `id` + nombre denormalizado en la sede en un solo `update` (`saveSedeGeo`) |
| Sin catálogo sincronizado | — | cae al campo de texto de antes |

## Cambios

| Archivo | Cambio |
|---|---|
| `src/lib/divipola.ts` | **nuevo** — `matchIdPorNombre`, extraído de `sede-form-dialog` para compartirlo |
| `src/components/sede-form-dialog.tsx` | importa `matchIdPorNombre` del util en vez de su copia local |
| `src/components/visita-modulos/info-modulo.tsx` | `GeoAmbientalFields` (Combobox depto/municipio con fallback a texto) + `saveSedeGeo` |
| `src/components/visita-modulos/info-modulo-geo.test.tsx` | **nuevo** — fallback de texto, precarga por nombre, precarga por `*_id` |

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + tests + build. Verde.

Sin migración — `departamento_id` / `municipio_id` / `ciudad` / `departamento` ya existen en el esquema y ya los sincroniza el formulario de sede.