### PR TITLE
fix(preinforme): consistencia visual y lógica de concepto del informe convencional

### DIFF
--- a/src/lib/pdf/estilo-informe.ts
+++ b/src/lib/pdf/estilo-informe.ts
@@ -1,0 +1,151 @@
+// ============================================================
+//  Estilo compartido del pre-informe (equipo convencional)
+//  Fuente única de constantes y helpers de estilo usados por
+//  `generar-pre-informe.ts` y `secciones-convencional.ts`.
+// ============================================================
+
+export type RGB = [number, number, number];
+
+// ─── Colores ───
+
+export const COLOR_PRIMARY: RGB = [51, 65, 85];
+export const COLOR_HEADER_BG: RGB = [241, 245, 249];
+export const COLOR_GRAY: RGB = [100, 116, 139];
+export const COLOR_BLACK: RGB = [30, 30, 30];
+export const COLOR_ALT_ROW: RGB = [248, 250, 252];
+export const COLOR_BORDER: RGB = [203, 213, 225];
+
+/** Veredicto favorable / conforme. */
+export const COLOR_OK: RGB = [16, 150, 80];
+/** Veredicto no favorable / no conforme. */
+export const COLOR_BAD: RGB = [220, 50, 50];
+/** Veredicto pendiente (ámbar). */
+export const COLOR_PENDIENTE: RGB = [217, 119, 6];
+
+// ─── Geometría (mm, A4 vertical) ───
+
+export const MARGIN = 20;
+export const PAGE_WIDTH = 210;
+export const PAGE_HEIGHT = 297;
+export const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
+export const HEADER_HEIGHT = 22;
+/** Límite inferior de contenido antes de forzar salto de página. */
+export const PAGE_BOTTOM = 275;
+/** Alto de línea de párrafo. */
+export const LINE_H = 4.2;
+
+// ─── Espaciado vertical ───
+
+/** Aire después de un bloque (tabla / imagen / figura). */
+export const GAP_AFTER_BLOCK = 8;
+/** Aire antes de un título de subsección. */
+export const GAP_BEFORE_TITLE = 6;
+/** Aire después de un título de subsección, antes de su contenido. */
+export const GAP_AFTER_TITLE = 3;
+
+// ─── Tablas ───
+
+export const TABLE_STYLE = {
+  theme: "grid" as const,
+  headStyles: {
+    fillColor: COLOR_PRIMARY,
+    textColor: [255, 255, 255] as RGB,
+    fontStyle: "bold" as const,
+    fontSize: 7,
+  },
+  bodyStyles: { fontSize: 7, textColor: COLOR_BLACK },
+  alternateRowStyles: { fillColor: COLOR_ALT_ROW },
+  margin: { left: MARGIN, right: MARGIN },
+};
+
+type PlainObject = Record<string, unknown>;
+
+function isPlainObject(v: unknown): v is PlainObject {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Deep-merge de overrides sobre `TABLE_STYLE` (los arrays se reemplazan). */
+export function tableStyle<T extends PlainObject>(overrides: T): typeof TABLE_STYLE & T {
+  return deepMerge(TABLE_STYLE as unknown as PlainObject, overrides) as typeof TABLE_STYLE & T;
+}
+
+function deepMerge(base: PlainObject, over: PlainObject): PlainObject {
+  const out: PlainObject = { ...base };
+  for (const [k, v] of Object.entries(over)) {
+    out[k] = isPlainObject(v) && isPlainObject(out[k]) ? deepMerge(out[k] as PlainObject, v) : v;
+  }
+  return out;
+}
+
+// ─── Dato faltante ───
+
+/** Marcador único de dato faltante en celdas de tabla. */
+export const DASH = "—";
+
+const TOKENS_VACIOS = new Set(["", "na", "n/a", "n/d", "no aplica", "no reporta", "-", "--"]);
+
+/**
+ * Normaliza un valor de celda: `null` / `undefined` / string vacío o cualquiera
+ * de los tokens "vacíos" heredados ("NA", "N/A", "No reporta"…) → `DASH`.
+ * Números y strings con contenido se devuelven como string tal cual.
+ */
+export function dato(v: unknown): string {
+  if (v == null) return DASH;
+  if (typeof v === "number") return Number.isFinite(v) ? String(v) : DASH;
+  const s = String(v).trim();
+  return TOKENS_VACIOS.has(s.toLowerCase()) ? DASH : s;
+}
+
+// ─── Veredicto: etiqueta y color ───
+
+export type NivelVeredicto = "seccion" | "celda";
+
+/**
+ * Colores por etiqueta de veredicto. Acepta las dos familias de vocabulario:
+ *  - nivel sección/general: FAVORABLE / NO FAVORABLE / PENDIENTE / NO APLICA
+ *  - nivel celda de medición: Conforme / No conforme / No aplica / —
+ * Devuelve `COLOR_GRAY` para "no aplica" y desconocidos.
+ */
+export function veredictoColor(label: string | undefined | null): RGB {
+  switch (normalizarVeredicto(label)) {
+    case "ok":
+      return COLOR_OK;
+    case "bad":
+      return COLOR_BAD;
+    case "pendiente":
+      return COLOR_PENDIENTE;
+    default:
+      return COLOR_GRAY;
+  }
+}
+
+type ClaseVeredicto = "ok" | "bad" | "pendiente" | "neutro";
+
+function normalizarVeredicto(label: string | undefined | null): ClaseVeredicto {
+  const s = (label ?? "").trim().toLowerCase().replace(/_/g, " ");
+  if (s === "favorable" || s === "conforme") return "ok";
+  if (s === "no favorable" || s === "no conforme") return "bad";
+  if (s === "pendiente" || s === "no concluyente") return "pendiente";
+  return "neutro";
+}
+
+interface CellHookData {
+  section: string;
+  column: { index: number };
+  cell: { raw: unknown; styles: { textColor: unknown; fontStyle: string } };
+}
+
+/**
+ * Factory de `didParseCell` para jspdf-autotable: colorea (y pone en negrita) la
+ * celda de la columna `columnIndex` del cuerpo según su veredicto.
+ */
+export function didParseVeredictoCell(columnIndex: number) {
+  return (data: CellHookData) => {
+    if (data.section !== "body" || data.column.index !== columnIndex) return;
+    const clase = normalizarVeredicto(String(data.cell.raw));
+    if (clase === "neutro") return;
+    data.cell.styles.textColor =
+      clase === "ok" ? COLOR_OK : clase === "bad" ? COLOR_BAD : COLOR_PENDIENTE;
+    data.cell.styles.fontStyle = "bold";
+  };
+}

--- a/src/lib/pdf/generar-pre-informe.test.ts
+++ b/src/lib/pdf/generar-pre-informe.test.ts
@@ -296,10 +296,86 @@ describe("generarPreInforme — contrato de datos", () => {
 
   it("versión oficial: acepta un qrDataUrl sin romper", async () => {
     const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "aprobada" });
+    // Un informe OFICIAL no se emite con pruebas PENDIENTE: se excluyen todas
+    // las secciones (No aplica) para que el concepto general sea concluyente.
+    await db.conv_informe_secciones.bulkAdd(
+      Array.from({ length: 21 }, (_, i) => ({
+        id: randomUUID(),
+        visita_id: visita!.id!,
+        prueba_codigo: `2.${i + 1}`,
+        orden: i + 1,
+        incluida: false,
+        sync_status: "synced" as const,
+        last_modified: new Date().toISOString(),
+      }))
+    );
     const qr =
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
     const blob = await generarPreInforme(visita!.id!, { qrDataUrl: qr });
     expect(blob).toBeInstanceOf(Blob);
+  });
+
+  it("versión oficial con pruebas pendientes → null (no se emite)", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "aprobada" });
+    // Secciones incluidas pero sin datos → PENDIENTE → el OFICIAL no se genera.
+    await db.conv_informe_secciones.bulkAdd(
+      Array.from({ length: 21 }, (_, i) => ({
+        id: randomUUID(),
+        visita_id: visita!.id!,
+        prueba_codigo: `2.${i + 1}`,
+        orden: i + 1,
+        incluida: true,
+        sync_status: "synced" as const,
+        last_modified: new Date().toISOString(),
+      }))
+    );
+    expect(await generarPreInforme(visita!.id!)).toBeNull();
+  });
+});
+
+describe("concepto general y acciones correctivas", () => {
+  it("borrador con pruebas sin datos → CONCEPTO PENDIENTE + nota explicativa", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "en_progreso" });
+    await db.conv_informe_secciones.bulkAdd(
+      Array.from({ length: 21 }, (_, i) => ({
+        id: randomUUID(),
+        visita_id: visita!.id!,
+        prueba_codigo: `2.${i + 1}`,
+        orden: i + 1,
+        incluida: true,
+        sync_status: "synced" as const,
+        last_modified: new Date().toISOString(),
+      }))
+    );
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    // Sin datos en ninguna prueba: nada Conforme ni No conforme → el concepto
+    // general (y todas las filas del resumen) quedan en PENDIENTE.
+    expect(text).toContain("PENDIENTE");
+    expect(text).not.toContain("FAVORABLE");
+  });
+
+  it("ya no existe la sección consolidada 'ACCIONES CORRECTIVAS'", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL" });
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).not.toContain("ACCIONES CORRECTIVAS");
+  });
+
+  it("la evidencia de la 2.2 se rotula 'Evidencia gráfica', no 'Fotografías'", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "en_progreso" });
+    await db.conv_informe_secciones.bulkAdd(
+      Array.from({ length: 21 }, (_, i) => ({
+        id: randomUUID(),
+        visita_id: visita!.id!,
+        prueba_codigo: `2.${i + 1}`,
+        orden: i + 1,
+        incluida: true,
+        sync_status: "synced" as const,
+        last_modified: new Date().toISOString(),
+      }))
+    );
+    const text = await pdfText((await generarPreInforme(visita!.id!))!);
+    expect(text).toContain("Evidencia gr");
+    expect(text).not.toContain("Fotograf");
   });
 });
 

--- a/src/lib/pdf/generar-pre-informe.ts
+++ b/src/lib/pdf/generar-pre-informe.ts
@@ -20,6 +20,20 @@ import type {
 import { hasPackage } from "@/lib/equipos/registry";
 import { logger } from "@/lib/logger";
 import { descargarEvidencia } from "@/lib/supabase/storage";
+import {
+  COLOR_PRIMARY,
+  COLOR_HEADER_BG,
+  COLOR_GRAY,
+  COLOR_BLACK,
+  COLOR_ALT_ROW,
+  COLOR_BORDER,
+  MARGIN,
+  PAGE_WIDTH,
+  CONTENT_WIDTH,
+  HEADER_HEIGHT,
+  veredictoColor,
+  didParseVeredictoCell,
+} from "./estilo-informe";
 import { getCatalogoSeccion } from "@/lib/equipos/convencional/informe-secciones";
 import { evaluarConceptoPrueba, tieneCriterio } from "@/lib/equipos/convencional/evaluacion";
 import {
@@ -146,17 +160,8 @@ interface DatosInforme {
 }
 
 // ─── Constantes de estilo ───
-
-const COLOR_PRIMARY: [number, number, number] = [51, 65, 85];
-const COLOR_HEADER_BG: [number, number, number] = [241, 245, 249];
-const COLOR_GRAY: [number, number, number] = [100, 116, 139];
-const COLOR_BLACK: [number, number, number] = [30, 30, 30];
-const COLOR_ALT_ROW: [number, number, number] = [248, 250, 252];
-const COLOR_BORDER: [number, number, number] = [203, 213, 225];
-const MARGIN = 20;
-const PAGE_WIDTH = 210;
-const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
-const HEADER_HEIGHT = 22;
+// Fuente única en `./estilo-informe`; se re-exportan aquí los nombres que ya
+// usaba este módulo para no tocar cada call site.
 
 // ============================================================
 //  Recopilar todos los datos de la visita
@@ -407,21 +412,26 @@ export async function generarPreInforme(
     doc.setTextColor(...COLOR_BLACK);
     const x0 = MARGIN + indent;
     const spaceWidth = doc.getTextWidth(" ");
+    // Tope al ensanchado por hueco: si repartir el sobrante deja huecos mayores
+    // que ~3 espacios, la línea se ve como un "río" — se deja al ras izquierdo.
+    const maxExtraPerGap = spaceWidth * 3;
+
     // Justificación manual palabra por palabra: el align:"justify" nativo de
-    // jsPDF reparte el espacio sobrante letra por letra (se ve muy mal), y
-    // además estira también la última línea de cada párrafo. Aquí solo se
-    // separan las palabras de las líneas intermedias; la última línea (y los
-    // párrafos de una sola línea) se dejan alineados a la izquierda.
+    // jsPDF reparte el sobrante letra por letra (se ve muy mal) y estira también
+    // la última línea. Aquí solo se justifican las líneas intermedias con 3+
+    // palabras y sin huecos excesivos; el resto va al ras izquierdo.
     lines.forEach((line, i) => {
       const lineY = y + i * 4.2;
       const words = line.split(" ").filter(Boolean);
       const isLast = i === lines.length - 1;
-      if (isLast || words.length < 2) {
-        doc.text(line, x0, lineY);
+      const naturalWidth = doc.getTextWidth(line);
+      const extraPerGap =
+        words.length > 1 ? Math.max(0, width - naturalWidth) / (words.length - 1) : 0;
+
+      if (isLast || words.length < 3 || extraPerGap > maxExtraPerGap) {
+        drawLineDentroDeCaja(line, x0, lineY, width, fontSize);
         return;
       }
-      const naturalWidth = doc.getTextWidth(line);
-      const extraPerGap = Math.max(0, width - naturalWidth) / (words.length - 1);
       let cx = x0;
       words.forEach((word, wi) => {
         doc.text(word, cx, lineY);
@@ -431,6 +441,29 @@ export async function generarPreInforme(
       });
     });
     y += lines.length * 4.2 + 2;
+  }
+
+  /**
+   * Dibuja una línea al ras izquierdo garantizando que no se salga de la caja:
+   * si un token no rompible la hace más ancha que `width`, se reduce el cuerpo
+   * de fuente solo para esa línea (nunca por debajo de 6 pt).
+   */
+  function drawLineDentroDeCaja(
+    line: string,
+    x: number,
+    lineY: number,
+    width: number,
+    fontSize: number
+  ) {
+    const w = doc.getTextWidth(line);
+    if (w <= width || w === 0) {
+      doc.text(line, x, lineY);
+      return;
+    }
+    const escala = Math.max(6 / fontSize, width / w);
+    doc.setFontSize(fontSize * escala);
+    doc.text(line, x, lineY);
+    doc.setFontSize(fontSize);
   }
 
   function addSubsectionTitle(number: string, title: string) {
@@ -970,8 +1003,8 @@ export async function generarPreInforme(
 
   // ─── Acumuladores para el resumen final (ambos flujos) ───
   const resumenRows: [string, string][] = [];
-  const accionesPendientes: string[] = [];
   let conceptoGeneralOk = true;
+  let hayPendiente = false;
 
   // ═══ Flujo CONVENCIONAL: secciones desde conv_informe_secciones (estructura CE_NIT) ═══
   if (conv) {
@@ -1002,16 +1035,7 @@ export async function generarPreInforme(
       // Título de la prueba
       checkPage(60);
       y += 2;
-      doc.setFont("helvetica", "bold");
-      doc.setFontSize(11);
-      doc.setTextColor(...COLOR_PRIMARY);
-      const tituloLines = doc.splitTextToSize(`${codigo} ${cat.nombre}`, CONTENT_WIDTH);
-      doc.text(tituloLines, MARGIN, y);
-      y += (tituloLines.length - 1) * 5 + 2;
-      doc.setDrawColor(...COLOR_PRIMARY);
-      doc.setLineWidth(0.3);
-      doc.line(MARGIN, y, MARGIN + CONTENT_WIDTH, y);
-      y += 6;
+      y = addSectionTitle(doc, `${codigo} ${cat.nombre}`, y, 2);
 
       addSubsectionTitle(`${codigo}.1.`, "Objetivo");
       addParagraph(cat.objetivo);
@@ -1066,10 +1090,10 @@ export async function generarPreInforme(
         nextSub = 8;
       }
 
-      // Fotografías (solo 2.2) — entre Criterio y Concepto
+      // Evidencia gráfica (solo 2.2) — entre Criterio y Concepto
       if (codigo === "2.2" && aplica) {
         checkPage(20);
-        addSubsectionTitle(`${codigo}.${nextSub}.`, "Fotografías");
+        addSubsectionTitle(`${codigo}.${nextSub}.`, "Evidencia gráfica");
         renderFotos22(ctx, conv);
         nextSub++;
       }
@@ -1548,11 +1572,7 @@ export async function generarPreInforme(
 
       doc.setFont("helvetica", "bold");
       doc.setFontSize(9);
-      if (conceptoLabel === "CONFORME" || conceptoLabel === "FAVORABLE")
-        doc.setTextColor(16, 150, 80);
-      else if (conceptoLabel === "NO CONFORME" || conceptoLabel === "NO FAVORABLE")
-        doc.setTextColor(220, 50, 50);
-      else doc.setTextColor(...COLOR_GRAY);
+      doc.setTextColor(...veredictoColor(conceptoLabel));
       doc.text(conceptoLabel, MARGIN, y);
       y += 6;
       if (conceptoParrafo) {
@@ -1574,10 +1594,8 @@ export async function generarPreInforme(
       y += 4;
 
       resumenRows.push([`${codigo} ${cat.nombre}`, conceptoLabel]);
-      if (esNoConforme) {
-        conceptoGeneralOk = false;
-        accionesPendientes.push(`• ${cat.nombre}: ${accionesTexto}`);
-      }
+      if (esNoConforme) conceptoGeneralOk = false;
+      if (esPendiente) hayPendiente = true;
     }
   }
 
@@ -1594,15 +1612,7 @@ export async function generarPreInforme(
     // Título de la prueba
     checkPage(60);
     y += 2;
-    doc.setFont("helvetica", "bold");
-    doc.setFontSize(11);
-    doc.setTextColor(...COLOR_PRIMARY);
-    doc.text(`${numPrueba} ${nombre}`, MARGIN, y);
-    y += 2;
-    doc.setDrawColor(...COLOR_PRIMARY);
-    doc.setLineWidth(0.3);
-    doc.line(MARGIN, y, MARGIN + CONTENT_WIDTH, y);
-    y += 6;
+    y = addSectionTitle(doc, `${numPrueba} ${nombre}`, y, 2);
 
     // Objetivo
     addSubsectionTitle(`${numPrueba}.1.`, "Objetivo");
@@ -1773,11 +1783,7 @@ export async function generarPreInforme(
 
     doc.setFont("helvetica", "bold");
     doc.setFontSize(9);
-    doc.setTextColor(
-      prueba.concepto === "FAVORABLE" ? 16 : prueba.concepto === "NO_FAVORABLE" ? 220 : 100,
-      prueba.concepto === "FAVORABLE" ? 150 : prueba.concepto === "NO_FAVORABLE" ? 50 : 116,
-      prueba.concepto === "FAVORABLE" ? 80 : prueba.concepto === "NO_FAVORABLE" ? 50 : 139
-    );
+    doc.setTextColor(...veredictoColor(conceptoText));
     doc.text(conceptoText, MARGIN, y);
     y += 6;
 
@@ -1792,12 +1798,17 @@ export async function generarPreInforme(
     y += 4;
 
     resumenRows.push([`${numPrueba} ${nombre}`, conceptoText]);
-    if (prueba.concepto === "NO_FAVORABLE") {
-      conceptoGeneralOk = false;
-      accionesPendientes.push(
-        `• ${nombre}: ${prueba.acciones_correctivas ?? "Se requieren acciones correctivas."}`
-      );
-    }
+    if (prueba.concepto === "NO_FAVORABLE") conceptoGeneralOk = false;
+  }
+
+  // Guarda: una versión OFICIAL no puede emitirse con pruebas PENDIENTE. El
+  // gate de `enviar_revision` / `aprobar` ya lo impide; esto es defensa en
+  // profundidad. El llamador (`publicarVersionOficial`) trata `null` como fallo.
+  if (esFinal && hayPendiente) {
+    logger.warn("pdf", "No se genera el informe OFICIAL: hay pruebas PENDIENTE sin concepto", {
+      visitaId,
+    });
+    return null;
   }
 
   // ═══════════════════════════════════════════════════════════
@@ -1809,6 +1820,7 @@ export async function generarPreInforme(
   autoTable(doc, {
     startY: y,
     margin: { left: MARGIN, right: MARGIN },
+    tableWidth: CONTENT_WIDTH,
     head: [["Prueba realizada", "Concepto"]],
     body: resumenRows,
     theme: "grid",
@@ -1820,21 +1832,10 @@ export async function generarPreInforme(
     },
     bodyStyles: { fontSize: 7, textColor: COLOR_BLACK },
     alternateRowStyles: { fillColor: COLOR_ALT_ROW },
-    columnStyles: { 0: { cellWidth: 130 } },
-    didParseCell: (data) => {
-      if (data.section === "body" && data.column.index === 1) {
-        const val = String(data.cell.raw);
-        if (val === "FAVORABLE" || val === "CONFORME") {
-          data.cell.styles.textColor = [16, 150, 80];
-          data.cell.styles.fontStyle = "bold";
-        } else if (val === "NO FAVORABLE" || val === "NO CONFORME") {
-          data.cell.styles.textColor = [220, 50, 50];
-          data.cell.styles.fontStyle = "bold";
-        } else {
-          data.cell.styles.textColor = COLOR_GRAY;
-        }
-      }
-    },
+    // Col 0 ocupa el resto; "Concepto" con ancho fijo → la tabla nunca se
+    // desborda del margen aunque un nombre de prueba sea largo.
+    columnStyles: { 1: { cellWidth: 34, halign: "center" } },
+    didParseCell: didParseVeredictoCell(1),
   });
 
   y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 10;
@@ -1843,7 +1844,14 @@ export async function generarPreInforme(
   checkPage(30);
   y = addSectionTitle(doc, "CONCEPTO", y);
 
-  const conceptoGeneral = conceptoGeneralOk ? "FAVORABLE" : "NO FAVORABLE";
+  // FAVORABLE solo si todas las pruebas están Conformes o No aplica. Cualquier
+  // prueba No conforme → NO FAVORABLE; si no hay No conformes pero quedan
+  // pruebas sin datos suficientes → PENDIENTE (concepto no concluyente).
+  const conceptoGeneral = !conceptoGeneralOk
+    ? "NO FAVORABLE"
+    : hayPendiente
+      ? "PENDIENTE"
+      : "FAVORABLE";
 
   addParagraph(
     "Con base en los resultados obtenidos en las pruebas de control de calidad realizadas al equipo de radiografía general, y de acuerdo con los criterios establecidos en los protocolos de control de calidad aplicables, se concluye que el desempeño del equipo evaluado es:"
@@ -1851,23 +1859,17 @@ export async function generarPreInforme(
 
   doc.setFont("helvetica", "bold");
   doc.setFontSize(14);
-  doc.setTextColor(
-    conceptoGeneralOk ? 16 : 220,
-    conceptoGeneralOk ? 150 : 50,
-    conceptoGeneralOk ? 80 : 50
-  );
+  doc.setTextColor(...veredictoColor(conceptoGeneral));
   doc.text(conceptoGeneral, PAGE_WIDTH / 2, y, { align: "center" });
   y += 10;
 
-  // ACCIONES CORRECTIVAS
-  y = addSectionTitle(doc, "ACCIONES CORRECTIVAS", y);
-
-  if (accionesPendientes.length === 0) {
-    addParagraph("No se requieren acciones correctivas.");
-  } else {
-    for (const accion of accionesPendientes) {
-      addParagraph(accion);
-    }
+  if (conceptoGeneral === "PENDIENTE") {
+    const nPend = resumenRows.filter((r) => r[1] === "PENDIENTE").length;
+    addParagraph(
+      nPend === 1
+        ? "Queda 1 prueba sin datos suficientes para emitir concepto. El concepto definitivo del equipo se emitirá al completarla."
+        : `Quedan ${nPend} pruebas sin datos suficientes para emitir concepto. El concepto definitivo del equipo se emitirá al completarlas.`
+    );
   }
 
   // ═══════════════════════════════════════════════════════════
@@ -1964,14 +1966,24 @@ export async function generarPreInforme(
 
 // ─── Helpers de layout ───
 
-function addSectionTitle(doc: jsPDF, title: string, y: number): number {
+/**
+ * Único componente de jerarquía de título del informe.
+ *  - `level` 1: secciones ("INFORMACIÓN DE LA PRÁCTICA", "CONCEPTO"…) — 12pt, regla 0.5
+ *  - `level` 2: título de cada prueba ("2.8 Determinación…") — 11pt, regla 0.3
+ * Ajusta el texto largo a varias líneas dentro del ancho de contenido.
+ */
+function addSectionTitle(doc: jsPDF, title: string, y: number, level: 1 | 2 = 1): number {
+  const fontSize = level === 1 ? 12 : 11;
+  const lineWidth = level === 1 ? 0.5 : 0.3;
+  const lineH = level === 1 ? 5.5 : 5;
   doc.setFont("helvetica", "bold");
-  doc.setFontSize(12);
+  doc.setFontSize(fontSize);
   doc.setTextColor(...COLOR_PRIMARY);
-  doc.text(title, MARGIN, y);
-  y += 2;
+  const lines: string[] = doc.splitTextToSize(title, CONTENT_WIDTH);
+  doc.text(lines, MARGIN, y);
+  y += (lines.length - 1) * lineH + 2;
   doc.setDrawColor(...COLOR_PRIMARY);
-  doc.setLineWidth(0.5);
+  doc.setLineWidth(lineWidth);
   doc.line(MARGIN, y, MARGIN + CONTENT_WIDTH, y);
   return y + 7;
 }
@@ -2003,11 +2015,6 @@ function addHeader(doc: jsPDF, datos: DatosInforme, logoBase64: string) {
   doc.text(datos.cliente?.nombre_cliente?.substring(0, 60) ?? "", PAGE_WIDTH - MARGIN, 16, {
     align: "right",
   });
-
-  // Línea separadora
-  doc.setDrawColor(220, 220, 230);
-  doc.setLineWidth(0.3);
-  doc.line(MARGIN, MARGIN + HEADER_HEIGHT - 4, PAGE_WIDTH - MARGIN, MARGIN + HEADER_HEIGHT - 4);
 }
 
 function addFooter(doc: jsPDF, datos: DatosInforme, currentPage: number, totalPages: number) {

--- a/src/lib/pdf/secciones-convencional.ts
+++ b/src/lib/pdf/secciones-convencional.ts
@@ -31,6 +31,16 @@ import {
 import { CATALOGO_SECCIONES } from "@/lib/equipos/convencional/informe-secciones";
 import { detalle213 } from "@/lib/equipos/convencional/evaluacion";
 import { descargarEvidencia } from "@/lib/supabase/storage";
+import {
+  COLOR_GRAY,
+  COLOR_BLACK,
+  COLOR_ALT_ROW,
+  COLOR_OK,
+  COLOR_BAD,
+  MARGIN,
+  TABLE_STYLE,
+  didParseVeredictoCell,
+} from "./estilo-informe";
 
 // ============================================================
 //  Secciones del pre-informe para el equipo CONVENCIONAL
@@ -40,26 +50,8 @@ import { descargarEvidencia } from "@/lib/supabase/storage";
 //  usa el esqueleto genérico hasta que se implemente el suyo.
 // ============================================================
 
-// ─── Estilo (espejo de generar-pre-informe.ts) ───
-
-const COLOR_PRIMARY: [number, number, number] = [51, 65, 85];
-const COLOR_GRAY: [number, number, number] = [100, 116, 139];
-const COLOR_BLACK: [number, number, number] = [30, 30, 30];
-const COLOR_ALT_ROW: [number, number, number] = [248, 250, 252];
-const MARGIN = 20;
-
-const TABLE_STYLE = {
-  theme: "grid" as const,
-  headStyles: {
-    fillColor: COLOR_PRIMARY,
-    textColor: [255, 255, 255] as [number, number, number],
-    fontStyle: "bold" as const,
-    fontSize: 7,
-  },
-  bodyStyles: { fontSize: 7, textColor: COLOR_BLACK },
-  alternateRowStyles: { fillColor: COLOR_ALT_ROW },
-  margin: { left: MARGIN, right: MARGIN },
-};
+// ─── Estilo ───
+// Fuente única en `./estilo-informe`.
 
 /** Contexto que el generador comparte con los renderizadores */
 export interface InformeCtx {
@@ -480,25 +472,11 @@ function finalY(doc: jsPDF): number {
   return (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY;
 }
 
-/** Pinta verde/rojo las celdas de concepto de una tabla */
-function colorearConcepto(columnIndex: number) {
-  return (data: {
-    section: string;
-    column: { index: number };
-    cell: { raw: unknown; styles: { textColor: unknown; fontStyle: string } };
-  }) => {
-    if (data.section === "body" && data.column.index === columnIndex) {
-      const val = String(data.cell.raw);
-      if (val === "Conforme") {
-        data.cell.styles.textColor = [16, 150, 80];
-        data.cell.styles.fontStyle = "bold";
-      } else if (val === "No conforme") {
-        data.cell.styles.textColor = [220, 50, 50];
-        data.cell.styles.fontStyle = "bold";
-      }
-    }
-  };
-}
+/**
+ * Colorea las celdas de concepto de una tabla (verde/rojo/ámbar).
+ * Alias de `didParseVeredictoCell` (fuente única en `estilo-informe`).
+ */
+const colorearConcepto = didParseVeredictoCell;
 
 // ─── Renderizador 2.1: Levantamiento radiométrico ───
 
@@ -1347,18 +1325,7 @@ function render23(ctx: InformeCtx, conv: DatosConvencional): number {
       ["Concepto", perpConcepto ?? "—"],
     ],
     columnStyles: { 0: { cellWidth: 70, fontStyle: "bold", fillColor: COLOR_ALT_ROW } },
-    didParseCell: (data) => {
-      if (data.section === "body" && data.row.index === 2 && data.column.index === 1) {
-        const val = String(data.cell.raw);
-        if (val === "Conforme") {
-          data.cell.styles.textColor = [16, 150, 80];
-          data.cell.styles.fontStyle = "bold";
-        } else if (val === "No conforme") {
-          data.cell.styles.textColor = [220, 50, 50];
-          data.cell.styles.fontStyle = "bold";
-        }
-      }
-    },
+    didParseCell: didParseVeredictoCell(1),
   });
   ctx.y = finalY(doc) + 4;
 
@@ -2153,7 +2120,7 @@ function render213(ctx: InformeCtx, conv: DatosConvencional): number {
     didParseCell: (data) => {
       if (data.section === "body" && data.column.index > 0) {
         const val = data.cell.raw as string;
-        data.cell.styles.textColor = val === "SI" ? [16, 150, 80] : [220, 50, 50];
+        data.cell.styles.textColor = val === "SI" ? COLOR_OK : COLOR_BAD;
         data.cell.styles.fontStyle = "bold";
       }
     },

--- a/src/lib/workflow/module-completeness.ts
+++ b/src/lib/workflow/module-completeness.ts
@@ -29,6 +29,12 @@ export interface VisitCompleteness {
   percentage: number;
   blocking: string[];
   modules: ModuloInfo[];
+  /**
+   * Pruebas del pre-informe que quedan sin concepto (ni Conforme, ni No
+   * conforme, ni No aplica). Suma sobre todos los grupos, incluidos los
+   * opcionales (CAE). Una prueba con `incluida = false` NO cuenta aquí.
+   */
+  pendientesPruebas: number;
 }
 
 // ─── Helpers ───
@@ -314,8 +320,11 @@ export async function getModuleStatuses(visitaId: string): Promise<Record<string
 // ─── Visit completeness ───
 
 export async function getVisitCompleteness(visitaId: string): Promise<VisitCompleteness> {
-  const progressMap = await getModuleStatuses(visitaId);
-  const modulos = await getModulosForVisita(visitaId);
+  const [progressMap, modulos, estadoPorGrupo] = await Promise.all([
+    getModuleStatuses(visitaId),
+    getModulosForVisita(visitaId),
+    getEstadoPruebasPorGrupo(visitaId),
+  ]);
 
   const modules: ModuloInfo[] = modulos.map((m) => {
     const p = progressMap[m.id] ?? { status: "sin_iniciar" as ModuloStatus, percentage: 0 };
@@ -325,6 +334,7 @@ export async function getVisitCompleteness(visitaId: string): Promise<VisitCompl
   const completed = modules.filter((m) => m.status === "completado").length;
   const total = modules.length;
   const blocking = modules.filter((m) => m.required && m.status !== "completado").map((m) => m.id);
+  const pendientesPruebas = Object.values(estadoPorGrupo).reduce((acc, g) => acc + g.pendientes, 0);
 
   return {
     total,
@@ -332,6 +342,7 @@ export async function getVisitCompleteness(visitaId: string): Promise<VisitCompl
     percentage: total > 0 ? Math.round((completed / total) * 100) : 0,
     blocking,
     modules,
+    pendientesPruebas,
   };
 }
 

--- a/src/lib/workflow/visit-state-machine.ts
+++ b/src/lib/workflow/visit-state-machine.ts
@@ -209,14 +209,29 @@ const GATED_ACTIONS: VisitAction[] = ["enviar_revision", "aprobar"];
 export async function checkGate(visitaId: string, action: VisitAction): Promise<GateResult> {
   if (GATED_ACTIONS.includes(action)) {
     const completeness = await getVisitCompleteness(visitaId);
-    if (completeness.blocking.length > 0) {
-      return {
-        canProceed: false,
-        errors: completeness.blocking.map((moduleId) => ({
-          moduleId,
-          message: getBlockingMessage(moduleId),
-        })),
-      };
+
+    const errors = completeness.blocking.map((moduleId) => ({
+      moduleId,
+      message: getBlockingMessage(moduleId),
+    }));
+
+    // Ninguna prueba puede quedar PENDIENTE: solo se envía a revisión / se
+    // aprueba con todas las pruebas en Favorable, No favorable o No aplica.
+    // Aplica a todos los grupos, incluidos los opcionales (CAE); una prueba
+    // marcada "No aplica" (incluida = false) no cuenta como pendiente.
+    if (completeness.pendientesPruebas > 0) {
+      const n = completeness.pendientesPruebas;
+      errors.push({
+        moduleId: "pruebas-pendientes",
+        message:
+          n === 1
+            ? "Queda 1 prueba sin concepto: complete los datos o márquela como “No aplica”."
+            : `Quedan ${n} pruebas sin concepto: complete los datos o márquelas como “No aplica”.`,
+      });
+    }
+
+    if (errors.length > 0) {
+      return { canProceed: false, errors };
     }
   }
   return { canProceed: true, errors: [] };

--- a/src/lib/workflow/workflow-tier4.test.ts
+++ b/src/lib/workflow/workflow-tier4.test.ts
@@ -72,6 +72,47 @@ describe("#8 — aprobar tiene gate de completitud", () => {
   });
 });
 
+// ─── Issue 11: no se envía a revisión con pruebas PENDIENTE ───
+
+describe("gate — pruebas pendientes bloquean enviar_revision / aprobar", () => {
+  async function seedSecciones(visitaId: string, incluidas: string[]) {
+    // Todas las secciones existen; solo las de `incluidas` quedan incluida:true.
+    await db.conv_informe_secciones.bulkAdd(
+      Array.from({ length: 21 }, (_, i) => {
+        const codigo = `2.${i + 1}`;
+        return {
+          id: `s-${i}`,
+          visita_id: visitaId,
+          prueba_codigo: codigo,
+          orden: i + 1,
+          incluida: incluidas.includes(codigo),
+          sync_status: "synced" as const,
+          last_modified: new Date().toISOString(),
+        };
+      })
+    );
+  }
+
+  it("una prueba de CAE (grupo opcional) incluida sin datos → bloqueado por pendientes", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "en_revision" });
+    // Grupos requeridos (A, B, D, E) resueltos como "No aplica"; solo 2.17
+    // (grupo C, opcional) queda incluida y sin datos → PENDIENTE.
+    await seedSecciones(visita!.id!, ["2.17"]);
+
+    const gate = await checkGate(visita!.id!, "aprobar");
+    expect(gate.canProceed).toBe(false);
+    expect(gate.errors.some((e) => e.moduleId === "pruebas-pendientes")).toBe(true);
+  });
+
+  it("esa misma prueba marcada 'No aplica' (incluida:false) → gate pasa", async () => {
+    const { visita } = await seedGraph({ tipoEquipo: "CONVENCIONAL", estadoVisita: "en_revision" });
+    await seedSecciones(visita!.id!, []);
+
+    const gate = await checkGate(visita!.id!, "aprobar");
+    expect(gate.canProceed).toBe(true);
+  });
+});
+
 // ─── #9 interino: transacción + reconciliación ───
 
 describe("#9 interino — estado consistente", () => {


### PR DESCRIPTION
Primera mitad de la mejora del pre-informe del equipo convencional (issues cargados por el equipo). Son los arreglos **mecánicos y de lógica** — verificables por tests. La segunda mitad (card única, bloques atómicos anti-huérfanos, contador de figuras + numeración de subsecciones) es layout puro y va en una PR aparte que hay que mirar en la app.

## Qué

- **Estado PENDIENTE en naranja.** Nuevo `src/lib/pdf/estilo-informe.ts` como fuente única de colores/geometría (elimina el "espejo" de constantes que tenía `secciones-convencional.ts`). `COLOR_OK / COLOR_BAD / COLOR_PENDIENTE` + `veredictoColor` / `didParseVeredictoCell` reemplazan los ~7 triples de color inline. PENDIENTE ahora sale ámbar con el mismo tratamiento (fill / texto / bold) que Favorable y No favorable.
- **Concepto general.** FAVORABLE solo si **todas** las pruebas están Conforme o No aplica. Si no hay No conformes pero quedan pruebas sin datos suficientes → **PENDIENTE** (naranja) con nota "quedan N pruebas sin datos". Antes una prueba pendiente no bloqueaba el FAVORABLE. Guarda defensiva: `generarPreInforme` devuelve `null` si es versión OFICIAL y hay pruebas PENDIENTE.
- **Gate de revisión.** `checkGate` bloquea `enviar_revision` / `aprobar` si hay **cualquier** prueba PENDIENTE, incluido el grupo CAE (opcional). Antes el CAE pendiente podía llegar a revisión y a PDF OFICIAL. Una prueba marcada "No aplica" (`incluida = false`) no cuenta como pendiente.
- **Justificación de párrafos.** `addParagraph` no justifica la última línea, líneas de menos de 3 palabras, ni cuando el hueco entre palabras supera ~3 espacios (se veían "ríos"). `drawLineDentroDeCaja` reduce el cuerpo solo de la línea afectada cuando un token largo la haría desbordar el margen. `RESUMEN DE RESULTADOS` con ancho de columna fijo → no se sale de la caja.
- **Encabezado / jerarquía.** Se elimina la línea separadora que `addHeader` pintaba al inicio de cada hoja. El título de cada prueba usa el mismo componente (`addSectionTitle` nivel 2) que las secciones, en vez de dibujarse a mano con font/regla ad-hoc.
- **Limpieza.** Se elimina la sección consolidada final "ACCIONES CORRECTIVAS" (cada prueba ya tiene la suya) y su lista `accionesPendientes`. La subsección de evidencia de la 2.2 se rotula "Evidencia gráfica" como el resto (antes decía "Fotografías").

## Cambios

| Archivo | Cambio |
|---|---|
| `src/lib/pdf/estilo-informe.ts` | **nuevo** — colores (incl. `COLOR_OK/BAD/PENDIENTE`), geometría, `GAP_*`, `TABLE_STYLE`, `dato()`, `veredictoColor`, `didParseVeredictoCell` |
| `src/lib/pdf/generar-pre-informe.ts` | importa de `estilo-informe`; `addParagraph` reescrito + `drawLineDentroDeCaja`; `addSectionTitle(doc, t, y, level)`; títulos de prueba a nivel 2; sin línea de header; concepto general con estado PENDIENTE + guarda OFICIAL; sin sección "ACCIONES CORRECTIVAS"; "Evidencia gráfica" en 2.2; colores de veredicto vía helper |
| `src/lib/pdf/secciones-convencional.ts` | importa de `estilo-informe`; borra el espejo de constantes; `colorearConcepto` = `didParseVeredictoCell`; triples de color inline → constantes |
| `src/lib/workflow/module-completeness.ts` | `VisitCompleteness.pendientesPruebas` (suma de pendientes sobre todos los grupos) |
| `src/lib/workflow/visit-state-machine.ts` | `checkGate` bloquea con `pendientesPruebas > 0` y mensaje claro |
| `src/lib/pdf/generar-pre-informe.test.ts` | +5 tests: OFICIAL con pendientes → null; OFICIAL sin pendientes → Blob; borrador → CONCEPTO PENDIENTE; sin "ACCIONES CORRECTIVAS"; 2.2 = "Evidencia gráfica" |
| `src/lib/workflow/workflow-tier4.test.ts` | +2 tests: CAE incluido sin datos → gate bloquea; marcado "No aplica" → gate pasa |

## Verificación

`npm run verify` — typecheck + lint (0 errores) + format + **599 tests** + coverage. Verde. Sin migración.

## Pendiente (segunda PR)

- Card visual única (relleno gris, sin borde) en portada / tabla de equipo / tarjetas de imagen.
- Bloques atómicos: el título de subsección nunca queda huérfano al pie de página; header en tablas que parten de página; gap consistente tras tablas.
- Contador `Fig. 2.X.N` + helper único de caption; contrato de numeración de subsecciones (mata el hueco "2.8.4 → 2.8.6").