### PR TITLE
feat(contactos): agregar cargo 'Ingeniero Biomédico'

### DIFF
--- a/src/components/contacto-form-dialog.test.tsx
+++ b/src/components/contacto-form-dialog.test.tsx
@@ -122,10 +122,10 @@ describe("ContactoFormDialog", () => {
     expect(boton.disabled).toBe(true);
   });
 
-  it("CARGO_OPTIONS cubre todos los cargos que la app escribe (incl. responsable_visita)", () => {
+  it("CARGO_OPTIONS cubre todos los cargos que la app escribe (incl. responsable_visita, ingeniero_biomedico)", () => {
     const valores = CARGO_OPTIONS.map((o) => o.value);
     // El union Contacto["cargo"] completo — si crece, este test recuerda
-    // agregarlo acá y al CHECK de contactos (migración 022).
+    // agregarlo acá y al CHECK de contactos (migraciones 022, 029).
     expect(new Set(valores)).toEqual(
       new Set([
         "medico_responsable",
@@ -133,6 +133,7 @@ describe("ContactoFormDialog", () => {
         "opr",
         "representante",
         "responsable_visita",
+        "ingeniero_biomedico",
         "otro",
       ])
     );

--- a/src/components/contacto-form-dialog.tsx
+++ b/src/components/contacto-form-dialog.tsx
@@ -42,13 +42,14 @@ interface ContactoFormDialogProps {
 
 // Debe cubrir todos los valores de `Contacto["cargo"]` — incluido
 // `responsable_visita`, que se crea desde Información General. La tabla
-// `contactos` de Supabase tiene un CHECK sobre esta lista (migración 022).
+// `contactos` de Supabase tiene un CHECK sobre esta lista (migraciones 022, 029).
 export const CARGO_OPTIONS = [
   { value: "medico_responsable", label: "Médico Responsable" },
   { value: "tecnologo", label: "Tecnólogo" },
   { value: "opr", label: "OPR" },
   { value: "representante", label: "Representante" },
   { value: "responsable_visita", label: "Responsable de la Visita" },
+  { value: "ingeniero_biomedico", label: "Ingeniero Biomédico" },
   { value: "otro", label: "Otro" },
 ];
 

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -114,6 +114,7 @@ export interface Contacto extends Partial<SyncFields> {
     | "opr"
     | "representante"
     | "responsable_visita"
+    | "ingeniero_biomedico"
     | "otro";
   cedula?: string;
   telefono?: string;

--- a/supabase/migrations/029_contacto_cargo_ingeniero_biomedico.sql
+++ b/supabase/migrations/029_contacto_cargo_ingeniero_biomedico.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+--  029 — `contactos.cargo` admite 'ingeniero_biomedico'
+--
+--  Necesidad de negocio: el ingeniero biomédico del cliente debe poder
+--  quedar registrado en la lista de contactos de la sede/ubicación, igual
+--  que el médico responsable o el tecnólogo. El CHECK de `contactos.cargo`
+--  (migración 022) no contemplaba este cargo.
+--
+--  El tipo `Contacto["cargo"]` de la app y `CARGO_OPTIONS` del formulario
+--  ya usan `ingeniero_biomedico`; esto alinea la restricción de la base.
+--  Idempotente.
+-- ============================================================
+
+ALTER TABLE public.contactos DROP CONSTRAINT IF EXISTS contactos_cargo_check;
+
+ALTER TABLE public.contactos
+  ADD CONSTRAINT contactos_cargo_check
+  CHECK (
+    cargo IS NULL
+    OR cargo IN (
+      'medico_responsable',
+      'tecnologo',
+      'opr',
+      'representante',
+      'responsable_visita',
+      'ingeniero_biomedico',
+      'otro'
+    )
+  );


### PR DESCRIPTION
## Qué

Se agrega `ingeniero_biomedico` como cargo válido de contacto — necesidad de negocio reportada: registrar al ingeniero biomédico del cliente en la lista de contactos de la sede/ubicación, igual que el médico responsable o el tecnólogo.

| Archivo | Cambio |
|---|---|
| `src/lib/db/types.ts` | `Contacto["cargo"]` — se agrega `"ingeniero_biomedico"` al union |
| `src/components/contacto-form-dialog.tsx` | `CARGO_OPTIONS` — se agrega `{ value: "ingeniero_biomedico", label: "Ingeniero Biomédico" }` |
| `supabase/migrations/029_contacto_cargo_ingeniero_biomedico.sql` | Realinea el CHECK `contactos_cargo_check` con el nuevo valor (mismo patrón que la migración 022) |
| `src/components/contacto-form-dialog.test.tsx` | Actualiza el test canario que verifica que `CARGO_OPTIONS` cubre todo el union `Contacto["cargo"]` |

## Por qué la migración

La tabla `contactos` de Supabase tiene un CHECK constraint sobre los valores de `cargo` (ver migración 022). Sin este cambio, un contacto guardado localmente con `cargo: "ingeniero_biomedico"` pasaría el tipo de TypeScript pero el push a Supabase fallaría con error 23514 (constraint violation) y quedaría atascado en `pending` — el mismo bug que motivó la 022 para `responsable_visita`.

## Verificación

`npx tsc --noEmit` — sin errores.
`npx vitest run src/components/contacto-form-dialog.test.tsx` — 6/6 tests verdes.

Sin cambios de UI adicionales — el nuevo cargo aparece automáticamente en el `<Select>` del diálogo de contactos.